### PR TITLE
Packaging workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+version: 2
+
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      cargo-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: uv
+    directory: "/binoc-python"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: uv
+    directory: "/model-plugins/binoc-sqlite"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: uv
+    directory: "/model-plugins/binoc-html"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # security or bugfix versions under https://devguide.python.org/versions/
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
 
       - run: just check
 
-  test:
+  rust-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -41,6 +41,28 @@ jobs:
 
       - uses: astral-sh/setup-uv@v5
 
-      - uses: extractions/setup-just@v2
+      - run: cargo test
 
-      - run: just test
+  python-test:
+    name: Python tests (${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - uses: astral-sh/setup-uv@v5
+
+      - run: cd binoc-python && uv run --extra dev pytest
+      - run: cd model-plugins/binoc-sqlite && uv run --extra dev maturin develop && uv run --extra dev python -m pytest
+      - run: cd model-plugins/binoc-html && uv run --extra dev python -m pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,30 +19,30 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: clippy, rustfmt
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
 
-      - uses: extractions/setup-just@v2
+      - uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2
 
       - run: just check
 
   rust-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
 
       - run: cargo test
 
@@ -55,17 +55,17 @@ jobs:
         # security or bugfix versions under https://devguide.python.org/versions/
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
 
       - run: cd binoc-python && uv run --extra dev pytest
       - run: cd model-plugins/binoc-sqlite && uv run --extra dev maturin develop && uv run --extra dev python -m pytest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,9 @@ on:
       - "v*"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,193 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-binoc-wheels:
+    name: Build binoc wheels (${{ matrix.artifact }})
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact: linux-x86_64
+            target: x86_64-unknown-linux-gnu
+            manylinux: auto
+          - os: windows-latest
+            artifact: windows-x86_64
+            target: x86_64-pc-windows-msvc
+            manylinux: off
+          - os: macos-13
+            artifact: macos-x86_64
+            target: x86_64-apple-darwin
+            manylinux: off
+          - os: macos-14
+            artifact: macos-aarch64
+            target: aarch64-apple-darwin
+            manylinux: off
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - uses: PyO3/maturin-action@v1
+        with:
+          command: build
+          working-directory: binoc-python
+          target: ${{ matrix.target }}
+          manylinux: ${{ matrix.manylinux }}
+          args: --release --interpreter python --out dist
+          sccache: "true"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: binoc-dist-${{ matrix.artifact }}
+          path: binoc-python/dist
+
+  build-binoc-sdist:
+    name: Build binoc sdist
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+          working-directory: binoc-python
+          args: --out dist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: binoc-dist-sdist
+          path: binoc-python/dist
+
+  publish-binoc:
+    name: Publish binoc to PyPI
+    runs-on: ubuntu-latest
+    needs: [build-binoc-wheels, build-binoc-sdist]
+    environment:
+      name: pypi-binoc
+      url: https://pypi.org/project/binoc/
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: binoc-dist-*
+          path: dist
+          merge-multiple: true
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist
+
+  build-binoc-sqlite-wheels:
+    name: Build binoc-sqlite wheels (${{ matrix.artifact }})
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact: linux-x86_64
+            target: x86_64-unknown-linux-gnu
+            manylinux: auto
+          - os: windows-latest
+            artifact: windows-x86_64
+            target: x86_64-pc-windows-msvc
+            manylinux: off
+          - os: macos-13
+            artifact: macos-x86_64
+            target: x86_64-apple-darwin
+            manylinux: off
+          - os: macos-14
+            artifact: macos-aarch64
+            target: aarch64-apple-darwin
+            manylinux: off
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - uses: PyO3/maturin-action@v1
+        with:
+          command: build
+          working-directory: model-plugins/binoc-sqlite
+          target: ${{ matrix.target }}
+          manylinux: ${{ matrix.manylinux }}
+          args: --release --interpreter python --out dist
+          sccache: "true"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: binoc-sqlite-dist-${{ matrix.artifact }}
+          path: model-plugins/binoc-sqlite/dist
+
+  build-binoc-sqlite-sdist:
+    name: Build binoc-sqlite sdist
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+          working-directory: model-plugins/binoc-sqlite
+          args: --out dist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: binoc-sqlite-dist-sdist
+          path: model-plugins/binoc-sqlite/dist
+
+  publish-binoc-sqlite:
+    name: Publish binoc-sqlite to PyPI
+    runs-on: ubuntu-latest
+    needs: [build-binoc-sqlite-wheels, build-binoc-sqlite-sdist]
+    environment:
+      name: pypi-binoc-sqlite
+      url: https://pypi.org/project/binoc-sqlite/
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: binoc-sqlite-dist-*
+          path: dist
+          merge-multiple: true
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist
+
+  publish-binoc-sdk:
+    name: Publish binoc-sdk to crates.io
+    runs-on: ubuntu-latest
+    environment:
+      name: crates-io-binoc-sdk
+      url: https://crates.io/crates/binoc-sdk
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+      - run: cargo publish -p binoc-sdk --locked
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,11 +43,11 @@ jobs:
             target: aarch64-apple-darwin
             manylinux: off
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.10"
-      - uses: PyO3/maturin-action@v1
+      - uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           command: build
           working-directory: binoc-python
@@ -55,7 +55,7 @@ jobs:
           manylinux: ${{ matrix.manylinux }}
           args: --release --interpreter python --out dist
           sccache: "true"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: binoc-dist-${{ matrix.artifact }}
           path: binoc-python/dist
@@ -66,13 +66,13 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: PyO3/maturin-action@v1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           command: sdist
           working-directory: binoc-python
           args: --out dist
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: binoc-dist-sdist
           path: binoc-python/dist
@@ -88,12 +88,12 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: binoc-dist-*
           path: dist
           merge-multiple: true
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           packages-dir: dist
 
@@ -123,11 +123,11 @@ jobs:
             target: aarch64-apple-darwin
             manylinux: off
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.10"
-      - uses: PyO3/maturin-action@v1
+      - uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           command: build
           working-directory: model-plugins/binoc-sqlite
@@ -135,7 +135,7 @@ jobs:
           manylinux: ${{ matrix.manylinux }}
           args: --release --interpreter python --out dist
           sccache: "true"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: binoc-sqlite-dist-${{ matrix.artifact }}
           path: model-plugins/binoc-sqlite/dist
@@ -146,13 +146,13 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: PyO3/maturin-action@v1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           command: sdist
           working-directory: model-plugins/binoc-sqlite
           args: --out dist
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: binoc-sqlite-dist-sdist
           path: model-plugins/binoc-sqlite/dist
@@ -168,12 +168,12 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: binoc-sqlite-dist-*
           path: dist
           merge-multiple: true
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           packages-dir: dist
 
@@ -187,9 +187,9 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: rust-lang/crates-io-auth-action@v1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1
         id: auth
       - run: cargo publish -p binoc-sdk --locked
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1108,9 +1108,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
 dependencies = [
  "filetime",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,22 @@ default-members = [
     "model-plugins/binoc-row-reorder",
 ]
 resolver = "2"
+
+[workspace.package]
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+repository = "https://github.com/harvard-lil/binoc"
+homepage = "https://github.com/harvard-lil/binoc"
+documentation = "https://github.com/harvard-lil/binoc/tree/main/docs"
+
+[workspace.dependencies]
+binoc-sdk = { path = "binoc-sdk" }
+binoc-core = { path = "binoc-core" }
+binoc-stdlib = { path = "binoc-stdlib" }
+binoc-cli = { path = "binoc-cli" }
+
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.149"
+tempfile = "3.26.0"
+pyo3 = { version = "0.27", features = ["extension-module", "abi3-py310"] }

--- a/README.md
+++ b/README.md
@@ -141,14 +141,15 @@ uvx binoc --with binoc-sqlite diff snapshots/v1 snapshots/v2
 
 Plugins can be Rust crates (compiled as native shared libraries via the `export_plugin!` macro) or pure Python. See [docs/adr/](docs/adr/) for architecture and [model-plugins/](model-plugins/) for reference implementations.
 
-### Rust-only CLI
+### Rust SDK
 
-A standalone Rust binary with standard library plugins (no Python, no plugin discovery) is also available:
+Rust plugin authors should depend on the published SDK crate:
 
 ```bash
-cargo install binoc-cli
-binoc-cli diff path/to/snapshot-a path/to/snapshot-b
+cargo add binoc-sdk
 ```
+
+The workspace also includes a standalone `binoc-cli` crate for contributors and a future Rust-only distribution path, but the SDK is the only Rust package published on crates.io for now.
 
 ### Development
 

--- a/binoc-cli/Cargo.toml
+++ b/binoc-cli/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "binoc-cli"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
 description = "Standalone Rust CLI for Binoc"
-license = "MIT"
-repository = "https://github.com/harvard-lil/binoc"
-homepage = "https://github.com/harvard-lil/binoc"
-documentation = "https://github.com/harvard-lil/binoc/tree/main/docs"
 publish = false
 
 [lib]
@@ -18,14 +18,14 @@ name = "binoc-cli"
 path = "src/main.rs"
 
 [dependencies]
-binoc-sdk = { path = "../binoc-sdk" }
-binoc-core = { path = "../binoc-core" }
-binoc-stdlib = { path = "../binoc-stdlib" }
+binoc-sdk = { workspace = true }
+binoc-core = { workspace = true }
+binoc-stdlib = { workspace = true }
 clap = { version = "4.5.60", features = ["derive"] }
-serde_json = "1.0.149"
+serde_json = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = "2.1.2"
 predicates = "3.1.4"
-tempfile = "3.26.0"
+tempfile = { workspace = true }
 zip = { version = "7.2.0", default-features = false, features = ["deflate"] }

--- a/binoc-cli/Cargo.toml
+++ b/binoc-cli/Cargo.toml
@@ -2,6 +2,12 @@
 name = "binoc-cli"
 version = "0.1.0"
 edition = "2021"
+description = "Standalone Rust CLI for Binoc"
+license = "MIT"
+repository = "https://github.com/harvard-lil/binoc"
+homepage = "https://github.com/harvard-lil/binoc"
+documentation = "https://github.com/harvard-lil/binoc/tree/main/docs"
+publish = false
 
 [lib]
 name = "binoc_cli"

--- a/binoc-core/Cargo.toml
+++ b/binoc-core/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
 name = "binoc-core"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
 description = "Core controller and host runtime for Binoc"
-license = "MIT"
-repository = "https://github.com/harvard-lil/binoc"
-homepage = "https://github.com/harvard-lil/binoc"
-documentation = "https://github.com/harvard-lil/binoc/tree/main/docs"
 publish = false
 
 [dependencies]
-binoc-sdk = { path = "../binoc-sdk" }
+binoc-sdk = { workspace = true }
 rayon = "1.11.0"
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
+serde = { workspace = true }
+serde_json = { workspace = true }
 serde_yaml = "0.9.34"
-tempfile = "3.26.0"
+tempfile = { workspace = true }
 
 [dev-dependencies]
 insta = "1.46.3"

--- a/binoc-core/Cargo.toml
+++ b/binoc-core/Cargo.toml
@@ -2,6 +2,12 @@
 name = "binoc-core"
 version = "0.1.0"
 edition = "2021"
+description = "Core controller and host runtime for Binoc"
+license = "MIT"
+repository = "https://github.com/harvard-lil/binoc"
+homepage = "https://github.com/harvard-lil/binoc"
+documentation = "https://github.com/harvard-lil/binoc/tree/main/docs"
+publish = false
 
 [dependencies]
 binoc-sdk = { path = "../binoc-sdk" }

--- a/binoc-core/src/controller.rs
+++ b/binoc-core/src/controller.rs
@@ -42,7 +42,10 @@ impl Controller {
 
     /// Diff two snapshots and produce a changeset.
     pub fn diff(&self, from_path: &str, to_path: &str) -> BinocResult<Changeset> {
-        let data = Arc::new(LocalDataAccess::new());
+        let data = Arc::new(LocalDataAccess::new_for_diff(
+            Path::new(from_path),
+            Path::new(to_path),
+        )?);
 
         let left = data.register_local(Path::new(from_path), "")?;
         let right = data.register_local(Path::new(to_path), "")?;
@@ -82,7 +85,10 @@ impl Controller {
         let ancestor_chain = Self::build_ancestor_chain(root, node_path)
             .ok_or_else(|| BinocError::Extract(format!("cannot build path to {node_path}")))?;
 
-        let data = Arc::new(LocalDataAccess::new());
+        let data = Arc::new(LocalDataAccess::new_for_diff(
+            Path::new(snapshot_a),
+            Path::new(snapshot_b),
+        )?);
         let left = data.register_local(Path::new(snapshot_a), "")?;
         let right = data.register_local(Path::new(snapshot_b), "")?;
         let mut current_pair = ItemPair::both(left, right);

--- a/binoc-python/Cargo.toml
+++ b/binoc-python/Cargo.toml
@@ -2,6 +2,12 @@
 name = "binoc-python"
 version = "0.1.0"
 edition = "2021"
+description = "PyO3 bindings and Python CLI host for Binoc"
+license = "MIT"
+repository = "https://github.com/harvard-lil/binoc"
+homepage = "https://github.com/harvard-lil/binoc"
+documentation = "https://github.com/harvard-lil/binoc/tree/main/docs"
+publish = false
 
 [lib]
 name = "_binoc"
@@ -13,5 +19,5 @@ binoc-sdk = { path = "../binoc-sdk" }
 binoc-stdlib = { path = "../binoc-stdlib" }
 binoc-cli = { path = "../binoc-cli" }
 libloading = "0.8"
-pyo3 = { version = "0.27", features = ["extension-module"] }
+pyo3 = { version = "0.27", features = ["extension-module", "abi3-py310"] }
 serde_json = "1.0"

--- a/binoc-python/Cargo.toml
+++ b/binoc-python/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "binoc-python"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
 description = "PyO3 bindings and Python CLI host for Binoc"
-license = "MIT"
-repository = "https://github.com/harvard-lil/binoc"
-homepage = "https://github.com/harvard-lil/binoc"
-documentation = "https://github.com/harvard-lil/binoc/tree/main/docs"
 publish = false
 
 [lib]
@@ -14,10 +14,10 @@ name = "_binoc"
 crate-type = ["cdylib"]
 
 [dependencies]
-binoc-core = { path = "../binoc-core" }
-binoc-sdk = { path = "../binoc-sdk" }
-binoc-stdlib = { path = "../binoc-stdlib" }
-binoc-cli = { path = "../binoc-cli" }
+binoc-core = { workspace = true }
+binoc-sdk = { workspace = true }
+binoc-stdlib = { workspace = true }
+binoc-cli = { workspace = true }
 libloading = "0.8"
-pyo3 = { version = "0.27", features = ["extension-module", "abi3-py310"] }
-serde_json = "1.0"
+pyo3 = { workspace = true }
+serde_json = { workspace = true }

--- a/binoc-python/README.md
+++ b/binoc-python/README.md
@@ -1,0 +1,18 @@
+# binoc
+
+`binoc` is the primary Python distribution for Binoc.
+
+It provides:
+
+- the `binoc` CLI
+- Python bindings over the core diff engine
+- native plugin discovery and loading
+- the standard library comparators, transformers, and Markdown renderer
+
+Install it with:
+
+```bash
+pip install binoc
+```
+
+Optional format-specific plugins, such as `binoc-sqlite`, install separately and are discovered automatically through Python entry points.

--- a/binoc-python/pyproject.toml
+++ b/binoc-python/pyproject.toml
@@ -2,8 +2,31 @@
 name = "binoc"
 version = "0.1.0"
 description = "The missing changelog for datasets"
+readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "MIT" }
+authors = [{ name = "Harvard Library Innovation Lab" }]
+keywords = ["archive", "changelog", "csv", "data-diff", "datasets"]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Science/Research",
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+  "Programming Language :: Rust",
+  "Topic :: Scientific/Engineering :: Information Analysis",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+]
+
+[project.urls]
+Homepage = "https://github.com/harvard-lil/binoc"
+Repository = "https://github.com/harvard-lil/binoc"
+Issues = "https://github.com/harvard-lil/binoc/issues"
+Documentation = "https://github.com/harvard-lil/binoc/tree/main/docs"
 
 [project.scripts]
 binoc = "binoc.__main__:main"
@@ -18,4 +41,3 @@ build-backend = "maturin"
 [tool.maturin]
 python-source = "python"
 module-name = "binoc._binoc"
-features = ["pyo3/extension-module"]

--- a/binoc-sdk/Cargo.toml
+++ b/binoc-sdk/Cargo.toml
@@ -2,6 +2,12 @@
 name = "binoc-sdk"
 version = "0.1.0"
 edition = "2021"
+description = "Plugin SDK and ABI for Binoc dataset-diff plugins"
+license = "MIT"
+readme = "README.md"
+repository = "https://github.com/harvard-lil/binoc"
+homepage = "https://github.com/harvard-lil/binoc"
+documentation = "https://docs.rs/binoc-sdk"
 
 [features]
 default = []

--- a/binoc-sdk/Cargo.toml
+++ b/binoc-sdk/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
 name = "binoc-sdk"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
 description = "Plugin SDK and ABI for Binoc dataset-diff plugins"
-license = "MIT"
 readme = "README.md"
-repository = "https://github.com/harvard-lil/binoc"
-homepage = "https://github.com/harvard-lil/binoc"
-documentation = "https://docs.rs/binoc-sdk"
 
 [features]
 default = []
 test-support = []
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-tempfile = "3.26"
+serde = { workspace = true }
+serde_json = { workspace = true }
+tempfile = { workspace = true }
 thiserror = "2.0"

--- a/binoc-sdk/README.md
+++ b/binoc-sdk/README.md
@@ -1,0 +1,14 @@
+# binoc-sdk
+
+`binoc-sdk` is the stable Rust surface for writing Binoc plugins.
+
+It contains:
+
+- plugin traits
+- IR and result types
+- `DataAccess`
+- artifact descriptors and codec-facing types
+- the native plugin ABI
+- the `export_plugin!` macro
+
+If you are writing a Rust comparator, transformer, or renderer for Binoc, depend on `binoc-sdk`, not `binoc-core`.

--- a/binoc-sdk/src/data_access.rs
+++ b/binoc-sdk/src/data_access.rs
@@ -8,14 +8,15 @@ use crate::{BinocError, BinocResult, DataAccess, ItemRef};
 /// In-process DataAccess backed by the local filesystem, temp directories,
 /// and a filesystem-backed artifact store under `data_root/.artifacts/`.
 ///
-/// Three construction modes:
+/// Construction modes:
 ///
-/// - `new()` — owns a session temp dir as data_root (used by the controller).
-/// - `for_plugin(data_root, workspace)` — shares the host's data_root for
-///   artifact access, plus a pre-allocated workspace for expansion. Used by
-///   the `export_plugin!` macro across the C ABI.
-/// - `with_data_root(data_root)` — shares an existing data_root for artifact
-///   access only (no expansion workspace). Used for extract-only access.
+/// - [`Self::new`] — unrestricted paths (tests, ad-hoc tooling).
+/// - [`Self::new_for_diff`] — paths must stay under the two snapshot trees or
+///   session workspace (used by the controller).
+/// - [`Self::for_plugin`] — shares the host's `data_root` for artifact access,
+///   plus a pre-allocated workspace for expansion (C ABI plugins).
+/// - [`Self::with_data_root`] — shares an existing `data_root` for artifact
+///   reads only (no expansion workspace).
 pub struct LocalDataAccess {
     _session_dir: Option<tempfile::TempDir>,
     data_root: PathBuf,
@@ -23,6 +24,16 @@ pub struct LocalDataAccess {
     workspace_counter: AtomicU32,
     workspaces: Mutex<Vec<tempfile::TempDir>>,
     provide_dir: Mutex<Option<tempfile::TempDir>>,
+    path_policy: PathPolicy,
+}
+
+enum PathPolicy {
+    Unrestricted,
+    Restricted {
+        snapshot_a: PathBuf,
+        snapshot_b: PathBuf,
+        extra_allowed: Mutex<Vec<PathBuf>>,
+    },
 }
 
 fn artifacts_dir(data_root: &Path) -> PathBuf {
@@ -49,6 +60,21 @@ fn subject_dir_name(subject: ArtifactSubject) -> &'static str {
     }
 }
 
+/// True when `path` is `root` or a descendant (component-wise).
+fn path_is_within(path: &Path, root: &Path) -> bool {
+    path.starts_with(root)
+}
+
+fn item_ref_from_physical(physical: &Path, logical: &str) -> ItemRef {
+    ItemRef {
+        logical_path: logical.to_string(),
+        is_dir: physical.is_dir(),
+        content_hash: None,
+        media_type: None,
+        handle: physical.to_string_lossy().to_string(),
+    }
+}
+
 impl LocalDataAccess {
     pub fn new() -> Self {
         let session = tempfile::tempdir().expect("failed to create session temp dir");
@@ -60,7 +86,32 @@ impl LocalDataAccess {
             workspace_counter: AtomicU32::new(0),
             workspaces: Mutex::new(Vec::new()),
             provide_dir: Mutex::new(None),
+            path_policy: PathPolicy::Unrestricted,
         }
+    }
+
+    /// Session-backed access with path confinement: filesystem reads and
+    /// `register_local` targets must lie under the snapshot roots, the session
+    /// `data_root`, or a workspace / provide directory created by this instance.
+    pub fn new_for_diff(snapshot_a: &Path, snapshot_b: &Path) -> BinocResult<Self> {
+        let session = tempfile::tempdir().map_err(BinocError::Io)?;
+        let data_root = session.path().to_path_buf();
+        let snap_a = std::fs::canonicalize(snapshot_a).map_err(BinocError::Io)?;
+        let snap_b = std::fs::canonicalize(snapshot_b).map_err(BinocError::Io)?;
+        let data_root_canon = std::fs::canonicalize(&data_root).map_err(BinocError::Io)?;
+        Ok(Self {
+            _session_dir: Some(session),
+            data_root,
+            external_root: None,
+            workspace_counter: AtomicU32::new(0),
+            workspaces: Mutex::new(Vec::new()),
+            provide_dir: Mutex::new(None),
+            path_policy: PathPolicy::Restricted {
+                snapshot_a: snap_a,
+                snapshot_b: snap_b,
+                extra_allowed: Mutex::new(vec![data_root_canon]),
+            },
+        })
     }
 
     /// Create a LocalDataAccess for a plugin running across the C ABI.
@@ -74,11 +125,12 @@ impl LocalDataAccess {
             workspace_counter: AtomicU32::new(0),
             workspaces: Mutex::new(Vec::new()),
             provide_dir: Mutex::new(None),
+            path_policy: PathPolicy::Unrestricted,
         }
     }
 
     /// Create a LocalDataAccess that can only read from an existing data_root
-    /// cache. No workspace for expansion. Used during extract.
+    /// cache. No workspace for expansion. Used during extract-only access.
     pub fn with_data_root(data_root: PathBuf) -> Self {
         Self {
             _session_dir: None,
@@ -87,28 +139,88 @@ impl LocalDataAccess {
             workspace_counter: AtomicU32::new(0),
             workspaces: Mutex::new(Vec::new()),
             provide_dir: Mutex::new(None),
+            path_policy: PathPolicy::Unrestricted,
         }
     }
 
-    pub fn register_local_impl(physical: &Path, logical: &str) -> BinocResult<ItemRef> {
-        Ok(ItemRef {
-            logical_path: logical.to_string(),
-            is_dir: physical.is_dir(),
-            content_hash: None,
-            media_type: None,
-            handle: physical.to_string_lossy().to_string(),
-        })
+    fn record_allowed_if_restricted(&self, path: &Path) -> BinocResult<()> {
+        if let PathPolicy::Restricted { extra_allowed, .. } = &self.path_policy {
+            let c = std::fs::canonicalize(path).map_err(BinocError::Io)?;
+            extra_allowed.lock().unwrap().push(c);
+        }
+        Ok(())
+    }
+
+    fn enforce_path_policy_resolved(&self, resolved: &Path) -> BinocResult<()> {
+        match &self.path_policy {
+            PathPolicy::Unrestricted => Ok(()),
+            PathPolicy::Restricted {
+                snapshot_a,
+                snapshot_b,
+                extra_allowed,
+            } => {
+                if path_is_within(resolved, snapshot_a) || path_is_within(resolved, snapshot_b) {
+                    return Ok(());
+                }
+                let roots = extra_allowed.lock().unwrap();
+                for root in roots.iter() {
+                    if path_is_within(resolved, root) {
+                        return Ok(());
+                    }
+                }
+                Err(BinocError::PathPolicy(format!(
+                    "path must stay under snapshot directories or session workspace: {}",
+                    resolved.display()
+                )))
+            }
+        }
+    }
+
+    /// Enforce policy for a path that must already exist on disk (e.g. `register_local`).
+    fn enforce_path_policy(&self, physical: &Path) -> BinocResult<()> {
+        let resolved = std::fs::canonicalize(physical).map_err(BinocError::Io)?;
+        self.enforce_path_policy_resolved(&resolved)
+    }
+
+    /// Enforce policy before reading; allows missing leaf paths under an allowed directory.
+    fn enforce_policy_for_read_path(&self, path: &Path) -> BinocResult<()> {
+        match &self.path_policy {
+            PathPolicy::Unrestricted => Ok(()),
+            PathPolicy::Restricted { .. } => {
+                if let Ok(c) = std::fs::canonicalize(path) {
+                    return self.enforce_path_policy_resolved(&c);
+                }
+                let mut probe: Option<&Path> = Some(path);
+                while let Some(p) = probe {
+                    if p.as_os_str().is_empty() {
+                        break;
+                    }
+                    if p.exists() {
+                        let base = std::fs::canonicalize(p).map_err(BinocError::Io)?;
+                        self.enforce_path_policy_resolved(&base)?;
+                        return Ok(());
+                    }
+                    probe = p.parent();
+                }
+                Err(BinocError::PathPolicy(format!(
+                    "cannot resolve path under session: {}",
+                    path.display()
+                )))
+            }
+        }
     }
 
     fn ensure_provide_dir(&self) -> BinocResult<PathBuf> {
         if let Some(root) = &self.external_root {
             let d = root.join("_provide");
             std::fs::create_dir_all(&d).map_err(BinocError::Io)?;
+            self.record_allowed_if_restricted(&d)?;
             return Ok(d);
         }
         let mut guard = self.provide_dir.lock().unwrap();
         if guard.is_none() {
             let dir = tempfile::tempdir().map_err(BinocError::Io)?;
+            self.record_allowed_if_restricted(dir.path())?;
             *guard = Some(dir);
         }
         Ok(guard.as_ref().unwrap().path().to_path_buf())
@@ -123,16 +235,22 @@ impl Default for LocalDataAccess {
 
 impl DataAccess for LocalDataAccess {
     fn read_bytes(&self, item: &ItemRef) -> BinocResult<Vec<u8>> {
-        std::fs::read(&item.handle).map_err(BinocError::Io)
+        let p = Path::new(&item.handle);
+        self.enforce_policy_for_read_path(p)?;
+        std::fs::read(p).map_err(BinocError::Io)
     }
 
     fn open_read(&self, item: &ItemRef) -> BinocResult<Box<dyn std::io::Read + Send>> {
-        let file = std::fs::File::open(&item.handle).map_err(BinocError::Io)?;
+        let p = Path::new(&item.handle);
+        self.enforce_policy_for_read_path(p)?;
+        let file = std::fs::File::open(p).map_err(BinocError::Io)?;
         Ok(Box::new(file))
     }
 
     fn local_path(&self, item: &ItemRef) -> BinocResult<PathBuf> {
-        Ok(PathBuf::from(&item.handle))
+        let p = PathBuf::from(&item.handle);
+        self.enforce_policy_for_read_path(&p)?;
+        Ok(p)
     }
 
     fn provide(&self, logical_path: &str, content: &[u8]) -> BinocResult<ItemRef> {
@@ -140,7 +258,8 @@ impl DataAccess for LocalDataAccess {
         let safe_name = logical_path.replace(['/', '\\'], "_");
         let file_path = dir.join(&safe_name);
         std::fs::write(&file_path, content).map_err(BinocError::Io)?;
-        Self::register_local_impl(&file_path, logical_path)
+        self.enforce_path_policy(&file_path)?;
+        Ok(item_ref_from_physical(&file_path, logical_path))
     }
 
     fn workspace(&self) -> BinocResult<PathBuf> {
@@ -148,16 +267,19 @@ impl DataAccess for LocalDataAccess {
             let n = self.workspace_counter.fetch_add(1, Ordering::Relaxed);
             let subdir = root.join(format!("ws-{n}"));
             std::fs::create_dir_all(&subdir).map_err(BinocError::Io)?;
+            self.record_allowed_if_restricted(&subdir)?;
             return Ok(subdir);
         }
         let dir = tempfile::tempdir().map_err(BinocError::Io)?;
         let path = dir.path().to_path_buf();
+        self.record_allowed_if_restricted(&path)?;
         self.workspaces.lock().unwrap().push(dir);
         Ok(path)
     }
 
     fn register_local(&self, physical: &Path, logical: &str) -> BinocResult<ItemRef> {
-        Self::register_local_impl(physical, logical)
+        self.enforce_path_policy(physical)?;
+        Ok(item_ref_from_physical(physical, logical))
     }
 
     fn publish_artifact(
@@ -185,6 +307,7 @@ impl DataAccess for LocalDataAccess {
 
     fn get_artifact(&self, descriptor: &ArtifactDescriptor) -> BinocResult<Option<Vec<u8>>> {
         let path = PathBuf::from(&descriptor.handle);
+        self.enforce_policy_for_read_path(&path)?;
         match std::fs::read(&path) {
             Ok(data) => Ok(Some(data)),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
@@ -262,5 +385,29 @@ mod tests {
         let da = LocalDataAccess::new();
         let root = da.data_root().unwrap();
         assert!(root.exists());
+    }
+
+    #[test]
+    fn restricted_rejects_register_outside_snapshots() {
+        let tmp_a = tempfile::tempdir().unwrap();
+        let tmp_b = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::write(outside.path().join("x.txt"), b"x").unwrap();
+
+        let da = LocalDataAccess::new_for_diff(tmp_a.path(), tmp_b.path()).unwrap();
+        let p = outside.path().join("x.txt");
+        let err = da.register_local(&p, "x.txt").unwrap_err();
+        assert!(matches!(err, BinocError::PathPolicy(_)));
+    }
+
+    #[test]
+    fn restricted_allows_register_under_snapshot() {
+        let tmp_a = tempfile::tempdir().unwrap();
+        let tmp_b = tempfile::tempdir().unwrap();
+        let f = tmp_a.path().join("f.txt");
+        std::fs::write(&f, b"ok").unwrap();
+
+        let da = LocalDataAccess::new_for_diff(tmp_a.path(), tmp_b.path()).unwrap();
+        da.register_local(&f, "f.txt").unwrap();
     }
 }

--- a/binoc-sdk/src/traits.rs
+++ b/binoc-sdk/src/traits.rs
@@ -25,6 +25,8 @@ pub enum BinocError {
     Tar(String),
     #[error("extract error: {0}")]
     Extract(String),
+    #[error("path policy: {0}")]
+    PathPolicy(String),
     #[error(
         "SDK version mismatch: {plugin} (plugin '{name}') is not compatible with host SDK {host}"
     )]

--- a/binoc-stdlib/Cargo.toml
+++ b/binoc-stdlib/Cargo.toml
@@ -27,7 +27,7 @@ similar = "2.7.0"
 tempfile = { workspace = true }
 walkdir = "2.5.0"
 zip = { version = "7.2.0", default-features = false, features = ["deflate"] }
-tar = "0.4"
+tar = "0.4.45"
 flate2 = "1"
 insta = { version = "1.46.3", features = ["json"], optional = true }
 toml = { version = "1.0.4", optional = true }

--- a/binoc-stdlib/Cargo.toml
+++ b/binoc-stdlib/Cargo.toml
@@ -2,6 +2,12 @@
 name = "binoc-stdlib"
 version = "0.1.0"
 edition = "2021"
+description = "Standard comparators, transformers, and renderers for Binoc"
+license = "MIT"
+repository = "https://github.com/harvard-lil/binoc"
+homepage = "https://github.com/harvard-lil/binoc"
+documentation = "https://github.com/harvard-lil/binoc/tree/main/docs"
+publish = false
 
 [features]
 default = ["test-vectors"]
@@ -26,4 +32,3 @@ flate2 = "1"
 insta = { version = "1.46.3", features = ["json"], optional = true }
 toml = { version = "1.0.4", optional = true }
 rayon = { version = "1", optional = true }
-

--- a/binoc-stdlib/Cargo.toml
+++ b/binoc-stdlib/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "binoc-stdlib"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
 description = "Standard comparators, transformers, and renderers for Binoc"
-license = "MIT"
-repository = "https://github.com/harvard-lil/binoc"
-homepage = "https://github.com/harvard-lil/binoc"
-documentation = "https://github.com/harvard-lil/binoc/tree/main/docs"
 publish = false
 
 [features]
@@ -15,16 +15,16 @@ default = ["test-vectors"]
 test-vectors = ["insta", "toml", "rayon", "binoc-sdk/test-support"]
 
 [dependencies]
-binoc-sdk = { path = "../binoc-sdk" }
-binoc-core = { path = "../binoc-core" }
+binoc-sdk = { workspace = true }
+binoc-core = { workspace = true }
 blake3 = "1.8.3"
 csv = "1.4.0"
 infer = "0.19"
 mime_guess = "2.0.5"
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
+serde = { workspace = true }
+serde_json = { workspace = true }
 similar = "2.7.0"
-tempfile = "3.26.0"
+tempfile = { workspace = true }
 walkdir = "2.5.0"
 zip = { version = "7.2.0", default-features = false, features = ["deflate"] }
 tar = "0.4"

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -17,3 +17,4 @@
 * 2026-03-19: [Published artifacts for cross-plugin composition](published_artifacts_for_cross_plugin_composition.md)
 * 2026-03-20: [Transformer dispatch refinement](transformer_dispatch_refinement.md)
 * 2026-03-20: [Transformer composition and artifact flow](transformer_composition_and_artifact_flow.md)
+* 2026-04-08: [Release surface and automated publishing](release_surface_and_automated_publishing.md)

--- a/docs/adr/release_surface_and_automated_publishing.md
+++ b/docs/adr/release_surface_and_automated_publishing.md
@@ -1,0 +1,55 @@
+# Release Surface And Automated Publishing
+
+**Date:** 2026-04-08
+**Status:** Implemented
+
+## Context
+
+Binoc now has a clearer packaging split than the early workspace had:
+
+- `binoc` is the primary user-facing Python distribution.
+- `binoc-sqlite` is the first public plugin package.
+- `binoc-sdk` is the stable Rust surface for plugin authors.
+- `binoc-core`, `binoc-stdlib`, `binoc-cli`, and the remaining model plugins are useful internally, but publishing all of them immediately would create a larger compatibility surface than the project needs at this stage.
+
+The project also needs a modern release path:
+
+- Python packages should publish wheels, not source-only archives.
+- Registry credentials should not be long-lived repository secrets.
+- Release mechanics should be repeatable and documented.
+
+## Decision
+
+Binoc publishes exactly three artifacts for now:
+
+- PyPI: `binoc`
+- PyPI: `binoc-sqlite`
+- crates.io: `binoc-sdk`
+
+All other Rust crates in the workspace set `publish = false`.
+
+Releases are automated from GitHub Actions on `v*` tags:
+
+- `binoc` and `binoc-sqlite` build abi3 wheels and sdists with maturin.
+- PyPI publishing uses GitHub OIDC trusted publishing.
+- `binoc-sdk` publishing uses crates.io trusted publishing via GitHub OIDC.
+
+The root `just release` task is the canonical release entry point. It runs the test suite, verifies that the published package versions are synchronized, pushes the current branch, creates an annotated tag, and pushes that tag to trigger publishing.
+
+## Alternatives Considered
+
+### Publish every Rust crate now
+
+Rejected because it would commit the project to a broader Rust support surface before there is a concrete need for external consumers of `binoc-core`, `binoc-stdlib`, or `binoc-cli`.
+
+### Publish only PyPI packages and skip crates.io for now
+
+Rejected because `binoc-sdk` is now the documented dependency for Rust plugin authors and should exist where those authors expect to obtain it.
+
+### Use API tokens stored as GitHub secrets
+
+Rejected in favor of trusted publishing. OIDC-based publishing is narrower in scope, avoids long-lived credentials, and matches the current deployment direction used elsewhere in the project ecosystem.
+
+### Keep per-Python-version wheels
+
+Rejected in favor of `abi3-py310`. The Binoc Python packages do not need per-version extension builds, and abi3 substantially reduces the wheel matrix while preserving support for Python 3.10+.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,101 @@
+# Releasing Binoc
+
+Binoc publishes three public artifacts today:
+
+- PyPI: `binoc`
+- PyPI: `binoc-sqlite`
+- crates.io: `binoc-sdk`
+
+Releases are published from GitHub Actions when a `v*` tag is pushed. The publish workflow builds platform wheels for the Python packages and uses trusted publishing for both PyPI and crates.io.
+
+(The single `v*` tag is a short term solution. Under active development, we'll use separate tags for each package, or split out repositories.)
+
+## One-time setup
+
+### PyPI trusted publishing
+
+Configure trusted publishers for both PyPI projects:
+
+1. On PyPI, open `binoc` and add a GitHub trusted publisher for:
+   - Repository: `harvard-lil/binoc`
+   - Workflow: `publish.yml`
+   - Environment: `pypi-binoc`
+2. Repeat for `binoc-sqlite` with environment `pypi-binoc-sqlite`.
+
+If the projects do not exist on PyPI yet, create the trusted-publisher setup there before the first automated release.
+
+### crates.io trusted publishing
+
+`binoc-sdk` must be published manually once before trusted publishing can be enabled on crates.io.
+
+1. Publish the first `binoc-sdk` release manually from a maintainer machine.
+2. On crates.io, configure trusted publishing for:
+   - Repository: `harvard-lil/binoc`
+   - Workflow: `publish.yml`
+   - Environment: `crates-io-binoc-sdk`
+
+The workflow uses `rust-lang/crates-io-auth-action` to exchange GitHub OIDC credentials for a short-lived crates.io token.
+
+### GitHub environments
+
+Create these GitHub environments:
+
+- `pypi-binoc`
+- `pypi-binoc-sqlite`
+- `crates-io-binoc-sdk`
+
+If you restrict deployment refs, allow tag pattern `v*` for each environment.
+
+## Versioning
+
+The release tag version must match all published package versions:
+
+- `binoc-python/pyproject.toml`
+- `binoc-python/Cargo.toml`
+- `model-plugins/binoc-sqlite/pyproject.toml`
+- `model-plugins/binoc-sqlite/Cargo.toml`
+- `binoc-sdk/Cargo.toml`
+
+`just release` verifies that these stay in lockstep before it pushes a tag.
+
+## Cutting a release
+
+1. Update the versions in the published manifests.
+2. Commit the release changes and make sure the working tree is clean.
+3. Run:
+
+```bash
+just release
+```
+
+This runs the full test suite, verifies the published versions match, pushes the current branch, creates an annotated `vX.Y.Z` tag, and pushes the tag.
+
+The publish workflow then:
+
+- builds abi3 wheels plus sdists for `binoc`
+- builds abi3 wheels plus sdists for `binoc-sqlite`
+- publishes both Python packages to PyPI via trusted publishing
+- publishes `binoc-sdk` to crates.io via trusted publishing
+
+## Manual fallbacks
+
+### PyPI
+
+Build locally:
+
+```bash
+cd binoc-python && uv build
+cd model-plugins/binoc-sqlite && uv build
+```
+
+Upload with an explicit token only if trusted publishing is unavailable.
+
+### crates.io
+
+Publish locally:
+
+```bash
+cargo publish -p binoc-sdk
+```
+
+Use this for the initial crates.io release before trusted publishing is configured.

--- a/justfile
+++ b/justfile
@@ -52,3 +52,70 @@ snapshot-review:
 # Regenerate all expected-output snapshots (run after intentional IR/output changes).
 snapshot-update:
     INSTA_UPDATE=always cargo test -p binoc-stdlib --test test_vectors
+
+# Tag v{version} from published package metadata, push branch + tag (triggers release workflow).
+release:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    just test
+
+    version_from() {
+      sed -n 's/^version = "\(.*\)"/\1/p' "$1" | head -n 1
+    }
+
+    BINOC_PY_VERSION="$(version_from binoc-python/pyproject.toml)"
+    BINOC_CARGO_VERSION="$(version_from binoc-python/Cargo.toml)"
+    SQLITE_PY_VERSION="$(version_from model-plugins/binoc-sqlite/pyproject.toml)"
+    SQLITE_CARGO_VERSION="$(version_from model-plugins/binoc-sqlite/Cargo.toml)"
+    SDK_VERSION="$(version_from binoc-sdk/Cargo.toml)"
+
+    if [ -z "$BINOC_PY_VERSION" ] || [ -z "$BINOC_CARGO_VERSION" ] || [ -z "$SQLITE_PY_VERSION" ] || [ -z "$SQLITE_CARGO_VERSION" ] || [ -z "$SDK_VERSION" ]; then
+      echo "Failed to read one or more package versions." >&2
+      exit 1
+    fi
+
+    if [ "$BINOC_PY_VERSION" != "$BINOC_CARGO_VERSION" ]; then
+      echo "binoc Python/Cargo versions differ: $BINOC_PY_VERSION vs $BINOC_CARGO_VERSION" >&2
+      exit 1
+    fi
+    if [ "$SQLITE_PY_VERSION" != "$SQLITE_CARGO_VERSION" ]; then
+      echo "binoc-sqlite Python/Cargo versions differ: $SQLITE_PY_VERSION vs $SQLITE_CARGO_VERSION" >&2
+      exit 1
+    fi
+    if [ "$BINOC_PY_VERSION" != "$SQLITE_PY_VERSION" ] || [ "$BINOC_PY_VERSION" != "$SDK_VERSION" ]; then
+      echo "Published package versions must match:" >&2
+      echo "  binoc=$BINOC_PY_VERSION" >&2
+      echo "  binoc-sqlite=$SQLITE_PY_VERSION" >&2
+      echo "  binoc-sdk=$SDK_VERSION" >&2
+      exit 1
+    fi
+
+    VERSION="$BINOC_PY_VERSION"
+    TAG="v${VERSION}"
+
+    if ! git rev-parse --git-dir >/dev/null 2>&1; then
+      echo "Not a git repository." >&2
+      exit 1
+    fi
+    if ! git remote get-url origin >/dev/null 2>&1; then
+      echo "No git remote named 'origin'. Add it before releasing." >&2
+      exit 1
+    fi
+    if git show-ref --verify --quiet "refs/tags/${TAG}"; then
+      echo "Tag ${TAG} already exists locally." >&2
+      exit 1
+    fi
+    if git ls-remote origin "refs/tags/${TAG}" 2>/dev/null | grep -q .; then
+      echo "Tag ${TAG} already exists on origin." >&2
+      exit 1
+    fi
+    if [ -n "$(git status --porcelain)" ]; then
+      echo "Working tree is not clean. Commit or stash before releasing." >&2
+      exit 1
+    fi
+
+    echo "Pushing current branch, then tagging ${TAG} (version ${VERSION})..."
+    git push
+    git tag -a "${TAG}" -m "Release ${VERSION}"
+    git push origin "${TAG}"
+    echo "Pushed ${TAG}. GitHub Actions should publish binoc, binoc-sqlite, and binoc-sdk."

--- a/model-plugins/binoc-row-reorder/Cargo.toml
+++ b/model-plugins/binoc-row-reorder/Cargo.toml
@@ -2,6 +2,12 @@
 name = "binoc-row-reorder"
 version = "0.1.0"
 edition = "2021"
+description = "Row reorder transformer plugin for Binoc"
+license = "MIT"
+repository = "https://github.com/harvard-lil/binoc"
+homepage = "https://github.com/harvard-lil/binoc"
+documentation = "https://github.com/harvard-lil/binoc/tree/main/model-plugins/binoc-row-reorder"
+publish = false
 
 [lib]
 name = "binoc_row_reorder"
@@ -14,7 +20,7 @@ python = ["dep:pyo3"]
 [dependencies]
 binoc-sdk = { path = "../../binoc-sdk" }
 serde_json = "1.0"
-pyo3 = { version = "0.27", features = ["extension-module"], optional = true }
+pyo3 = { version = "0.27", features = ["extension-module", "abi3-py310"], optional = true }
 
 [dev-dependencies]
 binoc-core = { path = "../../binoc-core" }

--- a/model-plugins/binoc-row-reorder/Cargo.toml
+++ b/model-plugins/binoc-row-reorder/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "binoc-row-reorder"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
 description = "Row reorder transformer plugin for Binoc"
-license = "MIT"
-repository = "https://github.com/harvard-lil/binoc"
-homepage = "https://github.com/harvard-lil/binoc"
-documentation = "https://github.com/harvard-lil/binoc/tree/main/model-plugins/binoc-row-reorder"
 publish = false
 
 [lib]
@@ -18,12 +18,12 @@ default = []
 python = ["dep:pyo3"]
 
 [dependencies]
-binoc-sdk = { path = "../../binoc-sdk" }
-serde_json = "1.0"
-pyo3 = { version = "0.27", features = ["extension-module", "abi3-py310"], optional = true }
+binoc-sdk = { workspace = true }
+serde_json = { workspace = true }
+pyo3 = { workspace = true, optional = true }
 
 [dev-dependencies]
-binoc-core = { path = "../../binoc-core" }
-binoc-sdk = { path = "../../binoc-sdk", features = ["test-support"] }
-binoc-stdlib = { path = "../../binoc-stdlib", features = ["test-vectors"] }
+binoc-core = { workspace = true }
+binoc-sdk = { workspace = true, features = ["test-support"] }
+binoc-stdlib = { workspace = true, features = ["test-vectors"] }
 tempfile = "3"

--- a/model-plugins/binoc-sqlite/Cargo.toml
+++ b/model-plugins/binoc-sqlite/Cargo.toml
@@ -2,6 +2,12 @@
 name = "binoc-sqlite"
 version = "0.1.0"
 edition = "2021"
+description = "SQLite comparator plugin for Binoc"
+license = "MIT"
+repository = "https://github.com/harvard-lil/binoc"
+homepage = "https://github.com/harvard-lil/binoc"
+documentation = "https://github.com/harvard-lil/binoc/tree/main/model-plugins/binoc-sqlite"
+publish = false
 
 [lib]
 name = "binoc_sqlite"
@@ -16,7 +22,7 @@ binoc-sdk = { path = "../../binoc-sdk" }
 rusqlite = { version = "0.35", features = ["bundled"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-pyo3 = { version = "0.27", features = ["extension-module"], optional = true }
+pyo3 = { version = "0.27", features = ["extension-module", "abi3-py310"], optional = true }
 
 [dev-dependencies]
 binoc-core = { path = "../../binoc-core" }

--- a/model-plugins/binoc-sqlite/Cargo.toml
+++ b/model-plugins/binoc-sqlite/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "binoc-sqlite"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
 description = "SQLite comparator plugin for Binoc"
-license = "MIT"
-repository = "https://github.com/harvard-lil/binoc"
-homepage = "https://github.com/harvard-lil/binoc"
-documentation = "https://github.com/harvard-lil/binoc/tree/main/model-plugins/binoc-sqlite"
 publish = false
 
 [lib]
@@ -18,14 +18,14 @@ default = []
 python = ["dep:pyo3"]
 
 [dependencies]
-binoc-sdk = { path = "../../binoc-sdk" }
+binoc-sdk = { workspace = true }
 rusqlite = { version = "0.35", features = ["bundled"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-pyo3 = { version = "0.27", features = ["extension-module", "abi3-py310"], optional = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+pyo3 = { workspace = true, optional = true }
 
 [dev-dependencies]
-binoc-core = { path = "../../binoc-core" }
-binoc-sdk = { path = "../../binoc-sdk", features = ["test-support"] }
-binoc-stdlib = { path = "../../binoc-stdlib", features = ["test-vectors"] }
+binoc-core = { workspace = true }
+binoc-sdk = { workspace = true, features = ["test-support"] }
+binoc-stdlib = { workspace = true, features = ["test-vectors"] }
 tempfile = "3"

--- a/model-plugins/binoc-sqlite/pyproject.toml
+++ b/model-plugins/binoc-sqlite/pyproject.toml
@@ -2,8 +2,31 @@
 name = "binoc-sqlite"
 version = "0.1.0"
 description = "SQLite comparator plugin for binoc"
+readme = "README.md"
 requires-python = ">=3.10"
 dependencies = ["binoc"]
+authors = [{ name = "Harvard Library Innovation Lab" }]
+keywords = ["binoc", "datasets", "sqlite"]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Science/Research",
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+  "Programming Language :: Rust",
+  "Topic :: Database",
+  "Topic :: Scientific/Engineering :: Information Analysis",
+]
+
+[project.urls]
+Homepage = "https://github.com/harvard-lil/binoc"
+Repository = "https://github.com/harvard-lil/binoc"
+Issues = "https://github.com/harvard-lil/binoc/issues"
+Documentation = "https://github.com/harvard-lil/binoc/tree/main/model-plugins/binoc-sqlite"
 
 [project.entry-points."binoc.plugins"]
 binoc-sqlite = "binoc_sqlite"


### PR DESCRIPTION
See docs/adr/release_surface_and_automated_publishing.md. This sets us up for automated publishing of three packages: `binoc` and `binoc-sqlite` (our example plugin) on PyPI, and `binoc-sdk` on cargo for writing rust plugins. Currently all three are published with a single version tag. Under more active development we might want things like a binoc github org, packages in separate repos, and/or package-specific tags in the monorepo.