### PR TITLE
Separate out release tags for each package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,9 @@ name: Publish
 on:
   push:
     tags:
-      - "v*"
+      - "binoc-v*"
+      - "binoc-sqlite-v*"
+      - "binoc-sdk-v*"
   workflow_dispatch:
 
 permissions:
@@ -19,6 +21,7 @@ env:
 jobs:
   build-binoc-wheels:
     name: Build binoc wheels (${{ matrix.artifact }})
+    if: startsWith(github.ref_name, 'binoc-v')
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -66,6 +69,7 @@ jobs:
 
   build-binoc-sdist:
     name: Build binoc sdist
+    if: startsWith(github.ref_name, 'binoc-v')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -83,6 +87,7 @@ jobs:
 
   publish-binoc:
     name: Publish binoc to PyPI
+    if: startsWith(github.ref_name, 'binoc-v')
     runs-on: ubuntu-latest
     needs: [build-binoc-wheels, build-binoc-sdist]
     environment:
@@ -103,6 +108,7 @@ jobs:
 
   build-binoc-sqlite-wheels:
     name: Build binoc-sqlite wheels (${{ matrix.artifact }})
+    if: startsWith(github.ref_name, 'binoc-sqlite-v')
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -150,6 +156,7 @@ jobs:
 
   build-binoc-sqlite-sdist:
     name: Build binoc-sqlite sdist
+    if: startsWith(github.ref_name, 'binoc-sqlite-v')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -167,6 +174,7 @@ jobs:
 
   publish-binoc-sqlite:
     name: Publish binoc-sqlite to PyPI
+    if: startsWith(github.ref_name, 'binoc-sqlite-v')
     runs-on: ubuntu-latest
     needs: [build-binoc-sqlite-wheels, build-binoc-sqlite-sdist]
     environment:
@@ -187,6 +195,7 @@ jobs:
 
   publish-binoc-sdk:
     name: Publish binoc-sdk to crates.io
+    if: startsWith(github.ref_name, 'binoc-sdk-v')
     runs-on: ubuntu-latest
     environment:
       name: crates-io-binoc-sdk

--- a/docs/adr/independent_release_tags_and_published_version_policy.md
+++ b/docs/adr/independent_release_tags_and_published_version_policy.md
@@ -1,0 +1,73 @@
+# Independent release tags and published version policy
+
+**Date:** 2026-04-10
+**Status:** Implemented
+
+## Context
+
+Binoc currently publishes three public artifacts from one repository:
+
+- `binoc` on PyPI
+- `binoc-sqlite` on PyPI
+- `binoc-sdk` on crates.io
+
+The first release workflow used a single `vX.Y.Z` tag and required all published manifests to share one version number. That made the release mechanics simple, but it coupled unrelated deploys:
+
+- a failed publish for one package could not be retried by retagging just that package
+- maintainers had to think in terms of one repo-wide release even when only one published artifact changed
+- version numbers implied lockstep across packages with different audiences and compatibility boundaries
+
+This coupling is especially misleading for native plugins. Their compatibility boundary is the Rust SDK protocol version, not the `binoc` Python package minor version.
+
+## Decision
+
+Binoc now uses package-specific release tags:
+
+- `binoc-vX.Y.Z`
+- `binoc-sqlite-vX.Y.Z`
+- `binoc-sdk-vX.Y.Z`
+
+The publish workflow triggers jobs only for the package named by the tag.
+
+The `just` release helpers are package-scoped:
+
+- `just set-version binoc <version>`
+- `just set-version binoc-sqlite <version>`
+- `just set-version binoc-sdk <version>`
+- `just release binoc`
+- `just release binoc-sqlite`
+- `just release binoc-sdk`
+
+`all` remains available as a convenience when maintainers intentionally want a coordinated multi-package release, but it is no longer the default release model.
+
+Versioning policy:
+
+- `binoc` versions the user-facing Python distribution: CLI, Python bindings, host-side packaging, and bundled runtime behavior.
+- `binoc-sqlite` versions the SQLite plugin package.
+- `binoc-sdk` versions the Rust plugin SDK and compatibility floor.
+- These version numbers do not need to match.
+
+Native plugin compatibility policy:
+
+- Rust native plugins should key compatibility to `binoc-sdk`, not to the `binoc` package minor version.
+- A native plugin's `pyproject.toml` should usually declare a minimum `binoc` version floor for host-side loader/runtime features, but should not add a `binoc<next-minor` cap merely to mirror the SDK line.
+- Runtime acceptance remains governed by the plugin `sdk_version` check performed by the host.
+
+Release coordination policy:
+
+- A `binoc-sdk` release often implies a follow-on `binoc` release, because `binoc` ships the native-plugin host runtime that loads plugins and enforces SDK compatibility.
+- A `binoc-sdk` release does not automatically require a `binoc-sqlite` release. Release the plugin when the plugin changed or when a fresh wheel built against the new SDK is needed.
+
+## Alternatives Considered
+
+### Keep one shared `vX.Y.Z` tag
+
+Rejected because a shared tag turns three independent publications into one coupled deploy surface. It makes retries coarse-grained and keeps maintainers thinking in terms of repo-wide releases rather than package-specific releases.
+
+### Keep independent versions but trigger all publish jobs from every tag
+
+Rejected because it preserves the operational problem. The repository would still rebuild and attempt to publish unrelated packages on every release tag, so a failed publish would remain entangled with successful ones.
+
+### Tie native plugin compatibility to `binoc` package minor versions
+
+Rejected because the host package version and the SDK compatibility version are not the same thing. `binoc` may ship CLI or packaging changes without changing the native plugin protocol, and a `binoc<next-minor` cap would block otherwise compatible plugin installs when a plugin author is no longer around to cut a no-op release.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -20,3 +20,4 @@
 * 2026-04-08: [Release surface and automated publishing](release_surface_and_automated_publishing.md)
 * 2026-04-10: [Rust MSRV and dependency update policy](rust_msrv_and_dependency_update_policy.md)
 * 2026-04-10: [Security posture and how to audit Binoc (core and plugins)](security_posture_and_auditing.md)
+* 2026-04-10: [Independent release tags and published version policy](independent_release_tags_and_published_version_policy.md)

--- a/docs/release.md
+++ b/docs/release.md
@@ -6,9 +6,7 @@ Binoc publishes three public artifacts today:
 - PyPI: `binoc-sqlite`
 - crates.io: `binoc-sdk`
 
-Releases are published from GitHub Actions when a `v*` tag is pushed. The publish workflow builds platform wheels for the Python packages and uses trusted publishing for both PyPI and crates.io.
-
-(The single `v*` tag is a short term solution. Under active development, we'll use separate tags for each package, or split out repositories.)
+Releases are published from GitHub Actions when a package-specific tag is pushed. The publish workflow builds platform wheels for the Python packages and uses trusted publishing for both PyPI and crates.io.
 
 ## One-time setup
 
@@ -44,43 +42,69 @@ Create these GitHub environments:
 - `pypi-binoc-sqlite`
 - `crates-io-binoc-sdk`
 
-If you restrict deployment refs, allow tag pattern `v*` for each environment.
+If you restrict deployment refs, allow these tag patterns:
+
+- `binoc-v*`
+- `binoc-sqlite-v*`
+- `binoc-sdk-v*`
 
 ## Versioning
 
-The release tag version must match:
+Each published artifact has its own version and its own tag namespace:
 
-- the workspace Cargo version in `Cargo.toml`
-- `binoc-python/pyproject.toml`
-- `model-plugins/binoc-sqlite/pyproject.toml`
+- `binoc-vX.Y.Z` publishes the version in `binoc-python/pyproject.toml`
+- `binoc-sqlite-vX.Y.Z` publishes the version in `model-plugins/binoc-sqlite/pyproject.toml`
+- `binoc-sdk-vX.Y.Z` publishes the workspace version in `Cargo.toml`
 
-`just release` verifies that these stay in lockstep on `origin/main` before it pushes a tag.
+These versions no longer need to stay in lockstep.
+
+Versioning rules:
+
+- Bump `binoc` when the user-facing Python package changes.
+- Bump `binoc-sqlite` when the SQLite plugin package changes.
+- Bump `binoc-sdk` when the Rust plugin SDK or compatibility floor changes.
+- A `binoc-sdk` release often implies a follow-on `binoc` release, because `binoc` is the host package that embeds the runtime loader and compatibility checks for native plugins.
+- A `binoc-sdk` release only implies a `binoc-sqlite` release when the plugin itself changed or needs rebuilding against the new SDK for a fresh published wheel.
 
 ## Cutting a release
 
-1. Update the versions in the published manifests:
+1. Update the version for the package you are releasing:
 
 ```bash
-just set-version 0.1.1
+just set-version binoc 0.1.1
 ```
 
-This updates the manifests plus the tracked lockfiles that the test suite would otherwise rewrite.
+Examples:
+
+```bash
+just set-version binoc-sqlite 0.1.1
+just set-version binoc-sdk 0.2.0
+just set-version all 0.3.0
+```
+
+`just set-version` updates only the selected published manifest(s) plus any tracked lockfiles that would otherwise be rewritten by the test suite.
 
 2. Open a PR, let CI pass, and merge the version bump to `main`.
 3. Run:
 
 ```bash
-just release
+just release binoc
 ```
 
-This fetches `origin/main`, verifies the published versions on `origin/main` match, creates an annotated `vX.Y.Z` tag pointing at the current `origin/main` commit, and pushes only the tag.
+Examples:
+
+```bash
+just release binoc-sqlite
+just release binoc-sdk
+just release all
+```
+
+This fetches `origin/main`, reads the selected package version(s) from `origin/main`, creates annotated package-specific tag(s) pointing at the current `origin/main` commit, and pushes only those tag(s).
 
 The publish workflow then:
 
-- builds abi3 wheels plus sdists for `binoc`
-- builds abi3 wheels plus sdists for `binoc-sqlite`
-- publishes both Python packages to PyPI via trusted publishing
-- publishes `binoc-sdk` to crates.io via trusted publishing
+- builds and publishes only the package(s) named by the tag(s) you pushed
+- leaves unrelated packages untouched
 
 ## Manual fallbacks
 

--- a/docs/writing_plugins.md
+++ b/docs/writing_plugins.md
@@ -143,7 +143,7 @@ To make a plugin available via `uv pip install` (or `pip install`), declare an e
 [project]
 name = "biobinoc"
 version = "0.1.0"
-dependencies = ["binoc"]
+dependencies = ["binoc>=0.1"]
 
 [project.entry-points."binoc.plugins"]
 biobinoc = "biobinoc:register"
@@ -175,6 +175,11 @@ transformers:
   - biobinoc.sequence_normalizer
   - binoc.move_detector
 ```
+
+Versioning note:
+
+- For Python plugins, `binoc` is a real Python API dependency. Set a minimum host version for the Python APIs you use.
+- Do not add an upper bound unless you know your plugin depends on a host-side Python API or behavior that may break across Binoc releases.
 
 ## Rust Plugins
 
@@ -303,7 +308,7 @@ binoc_sdk::export_plugin! {
 [project]
 name = "biobinoc"
 version = "0.1.0"
-dependencies = ["binoc"]
+dependencies = ["binoc>=0.1"]
 
 [project.entry-points."binoc.plugins"]
 biobinoc = "biobinoc"
@@ -317,6 +322,13 @@ features = ["python"]
 ```
 
 Note the entry point value is just the module name (`"biobinoc"`), not a `module:function` callable. The discovery code detects that it's a native module and loads it via the C ABI automatically.
+
+Versioning note:
+
+- The Rust compatibility boundary is `binoc-sdk`, not the `binoc` package version.
+- Depend on the `binoc-sdk` minor line you build against in `Cargo.toml`.
+- In `pyproject.toml`, use `binoc` as a host-package dependency with a minimum version floor for the loader/runtime features you need.
+- Do not add a `binoc<next-minor` cap just to mirror the SDK minor. Native plugin compatibility is checked at runtime through the plugin `sdk_version`.
 
 ### Runtime flow
 

--- a/justfile
+++ b/justfile
@@ -54,10 +54,11 @@ snapshot-update:
     INSTA_UPDATE=always cargo test -p binoc-stdlib --test test_vectors
 
 # Set the shared published package version across Cargo + Python manifests.
-set-version version:
+set-version package version:
     #!/usr/bin/env bash
     set -euo pipefail
 
+    PACKAGE="{{package}}"
     VERSION="{{version}}"
 
     if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
@@ -65,22 +66,57 @@ set-version version:
       exit 1
     fi
 
-    perl -0pi -e 's/^version = "[^"]*"/version = "'"$VERSION"'"/m' Cargo.toml
-    perl -0pi -e 's/^version = "[^"]*"/version = "'"$VERSION"'"/m' binoc-python/pyproject.toml
-    perl -0pi -e 's/^version = "[^"]*"/version = "'"$VERSION"'"/m' model-plugins/binoc-sqlite/pyproject.toml
+    set_manifest_version() {
+      local path="$1"
+      perl -0pi -e 's/^version = "[^"]*"/version = "'"$VERSION"'"/m' "$path"
+    }
 
-    # update the lock files
-    cargo update -w
-    cd binoc-python && uv lock
-    cd ../model-plugins/binoc-sqlite && uv lock
-    cd ../binoc-html && uv lock
+    relock_uv() {
+      local path="$1"
+      (
+        cd "$path"
+        uv lock
+      )
+    }
 
-    echo "Set published package version to ${VERSION}."
+    case "$PACKAGE" in
+      binoc)
+        set_manifest_version binoc-python/pyproject.toml
+        relock_uv binoc-python
+        relock_uv model-plugins/binoc-sqlite
+        relock_uv model-plugins/binoc-html
+        ;;
+      binoc-sqlite)
+        set_manifest_version model-plugins/binoc-sqlite/pyproject.toml
+        relock_uv model-plugins/binoc-sqlite
+        ;;
+      binoc-sdk)
+        set_manifest_version Cargo.toml
+        cargo update -w
+        ;;
+      all)
+        set_manifest_version Cargo.toml
+        set_manifest_version binoc-python/pyproject.toml
+        set_manifest_version model-plugins/binoc-sqlite/pyproject.toml
+        cargo update -w
+        relock_uv binoc-python
+        relock_uv model-plugins/binoc-sqlite
+        relock_uv model-plugins/binoc-html
+        ;;
+      *)
+        echo "Usage: just set-version [binoc|binoc-sqlite|binoc-sdk|all] <version>" >&2
+        exit 1
+        ;;
+    esac
 
-# Tag the current origin/main commit using published package metadata from origin/main.
-release:
+    echo "Set ${PACKAGE} version to ${VERSION}."
+
+# Tag the current origin/main commit for one published package, or `all`.
+release package:
     #!/usr/bin/env bash
     set -euo pipefail
+
+    PACKAGE="{{package}}"
 
     toml_string_from_origin_main() {
       local path="$1"
@@ -92,41 +128,82 @@ release:
       printf '%s\n' "$contents" | sed -n 's/^version = "\(.*\)"/\1/p' | head -n 1
     }
 
+    package_version_from_origin_main() {
+      local package="$1"
+      case "$package" in
+        binoc)
+          toml_string_from_origin_main binoc-python/pyproject.toml
+          ;;
+        binoc-sqlite)
+          toml_string_from_origin_main model-plugins/binoc-sqlite/pyproject.toml
+          ;;
+        binoc-sdk)
+          toml_string_from_origin_main Cargo.toml
+          ;;
+        *)
+          echo "Unknown package: ${package}" >&2
+          exit 1
+          ;;
+      esac
+    }
+
+    package_tag() {
+      local package="$1"
+      local version="$2"
+      echo "${package}-v${version}"
+    }
+
     git fetch origin main --tags
     REMOTE_MAIN="$(git rev-parse origin/main)"
 
-    WORKSPACE_VERSION="$(toml_string_from_origin_main Cargo.toml)"
-    BINOC_PY_VERSION="$(toml_string_from_origin_main binoc-python/pyproject.toml)"
-    SQLITE_PY_VERSION="$(toml_string_from_origin_main model-plugins/binoc-sqlite/pyproject.toml)"
+    case "$PACKAGE" in
+      binoc|binoc-sqlite|binoc-sdk)
+        packages=("$PACKAGE")
+        ;;
+      all)
+        packages=("binoc" "binoc-sqlite" "binoc-sdk")
+        ;;
+      *)
+        echo "Usage: just release [binoc|binoc-sqlite|binoc-sdk|all]" >&2
+        exit 1
+        ;;
+    esac
 
-    if [ -z "$WORKSPACE_VERSION" ] || [ -z "$BINOC_PY_VERSION" ] || [ -z "$SQLITE_PY_VERSION" ]; then
-      echo "Failed to read one or more package versions from origin/main." >&2
-      exit 1
-    fi
+    tags=()
+    versions=()
 
-    if [ "$BINOC_PY_VERSION" != "$SQLITE_PY_VERSION" ] || [ "$BINOC_PY_VERSION" != "$WORKSPACE_VERSION" ]; then
-      echo "Published package versions on origin/main must match:" >&2
-      echo "  workspace=$WORKSPACE_VERSION" >&2
-      echo "  binoc=$BINOC_PY_VERSION" >&2
-      echo "  binoc-sqlite=$SQLITE_PY_VERSION" >&2
-      echo "Merge a version-bump commit before releasing." >&2
-      exit 1
-    fi
+    for package in "${packages[@]}"; do
+      version="$(package_version_from_origin_main "$package")"
+      if [ -z "$version" ]; then
+        echo "Failed to read ${package} version from origin/main." >&2
+        exit 1
+      fi
 
-    TAG="v${WORKSPACE_VERSION}"
+      tag="$(package_tag "$package" "$version")"
 
-    if git show-ref --verify --quiet "refs/tags/${TAG}"; then
-      echo "Tag ${TAG} already exists." >&2
-      exit 1
-    fi
-    if git ls-remote origin "refs/tags/${TAG}" 2>/dev/null | grep -q .; then
-      echo "Tag ${TAG} already exists on origin." >&2
-      exit 1
-    fi
+      if git show-ref --verify --quiet "refs/tags/${tag}"; then
+        echo "Tag ${tag} already exists." >&2
+        exit 1
+      fi
+      if git ls-remote origin "refs/tags/${tag}" 2>/dev/null | grep -q .; then
+        echo "Tag ${tag} already exists on origin." >&2
+        exit 1
+      fi
 
-    # push the tag
-    echo "Tagging origin/main at ${REMOTE_MAIN} as ${TAG} ..."
-    git tag -a "${TAG}" "${REMOTE_MAIN}" -m "Release ${WORKSPACE_VERSION}"
-    git push origin "refs/tags/${TAG}"
-    echo "Pushed ${TAG}. GitHub Actions should publish binoc, binoc-sqlite, and binoc-sdk."
+      versions+=("$version")
+      tags+=("$tag")
+    done
+
+    for i in "${!packages[@]}"; do
+      echo "Tagging origin/main at ${REMOTE_MAIN} as ${tags[$i]} ..."
+      git tag -a "${tags[$i]}" "${REMOTE_MAIN}" -m "Release ${packages[$i]} ${versions[$i]}"
+    done
+
+    push_refs=()
+    for tag in "${tags[@]}"; do
+      push_refs+=("refs/tags/${tag}")
+    done
+
+    git push origin "${push_refs[@]}"
+    echo "Pushed ${tags[*]}. GitHub Actions should publish the selected package(s)."
     echo "Visit https://github.com/harvard-lil/binoc/actions/workflows/publish.yml to monitor the release."

--- a/model-plugins/binoc-html/pyproject.toml
+++ b/model-plugins/binoc-html/pyproject.toml
@@ -3,7 +3,7 @@ name = "binoc-html"
 version = "0.1.0"
 description = "HTML renderer plugin for binoc"
 requires-python = ">=3.10"
-dependencies = ["binoc"]
+dependencies = ["binoc>=0.1"]
 
 [project.entry-points."binoc.plugins"]
 binoc-html = "binoc_html:register"

--- a/model-plugins/binoc-sqlite/pyproject.toml
+++ b/model-plugins/binoc-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.1"
 description = "SQLite comparator plugin for binoc"
 readme = "README.md"
 requires-python = ">=3.10"
-dependencies = ["binoc"]
+dependencies = ["binoc>=0.1"]
 authors = [{ name = "Harvard Library Innovation Lab" }]
 keywords = ["binoc", "datasets", "sqlite"]
 classifiers = [


### PR DESCRIPTION
We often won't want to bump all three packages at the same time, and also it's inconvenient if one release build succeeds and one build fails. Instead of one `v0.1.1` tag to trigger a release, use separate ones for each package.