### PR TITLE
Parse .tsv with a tab delimiter (#55)

### DIFF
--- a/binoc-stdlib/src/comparators/csv_compare.rs
+++ b/binoc-stdlib/src/comparators/csv_compare.rs
@@ -1,4 +1,5 @@
 use std::io::BufReader;
+use std::path::Path;
 
 use binoc_sdk::*;
 
@@ -10,10 +11,30 @@ use binoc_sdk::*;
 /// source-format-agnostic.
 pub struct CsvComparator;
 
-fn parse_csv(path: &std::path::Path) -> BinocResult<TabularData> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct CsvParseOptions {
+    delimiter: u8,
+}
+
+impl CsvParseOptions {
+    fn for_item(item: &ItemRef) -> Self {
+        // TODO(#48/#51): move comparator parse options into the dataset-config
+        // surface once per-target comparator config lands.
+        let delimiter = match item.extension().as_deref() {
+            Some(".tsv") => b'\t',
+            _ => b',',
+        };
+        Self { delimiter }
+    }
+}
+
+fn parse_csv(path: &Path, options: CsvParseOptions) -> BinocResult<TabularData> {
     let file = std::fs::File::open(path).map_err(BinocError::Io)?;
     let reader = BufReader::new(file);
-    let mut rdr = csv::ReaderBuilder::new().flexible(true).from_reader(reader);
+    let mut rdr = csv::ReaderBuilder::new()
+        .delimiter(options.delimiter)
+        .flexible(true)
+        .from_reader(reader);
 
     let headers: Vec<String> = rdr
         .headers()
@@ -33,7 +54,7 @@ fn parse_csv(path: &std::path::Path) -> BinocResult<TabularData> {
 
 fn parse_csv_via_data(item: &ItemRef, data: &dyn DataAccess) -> BinocResult<TabularData> {
     let path = data.local_path(item)?;
-    parse_csv(&path)
+    parse_csv(&path, CsvParseOptions::for_item(item))
 }
 
 fn publish_tabular(
@@ -96,5 +117,41 @@ impl Comparator for CsvComparator {
     ) -> Option<ExtractResult> {
         let pair = TabularDataPair::from_artifacts(node, data)?;
         tabular_extract(&pair, node, aspect)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn item(logical_path: &str) -> ItemRef {
+        ItemRef {
+            logical_path: logical_path.into(),
+            is_dir: false,
+            content_hash: None,
+            size: None,
+            media_type: None,
+            handle: String::new(),
+        }
+    }
+
+    #[test]
+    fn parse_options_use_tab_for_tsv() {
+        assert_eq!(
+            CsvParseOptions::for_item(&item("table.tsv")),
+            CsvParseOptions { delimiter: b'\t' }
+        );
+    }
+
+    #[test]
+    fn parse_options_default_to_comma() {
+        assert_eq!(
+            CsvParseOptions::for_item(&item("table.csv")),
+            CsvParseOptions { delimiter: b',' }
+        );
+        assert_eq!(
+            CsvParseOptions::for_item(&item("table.unknown")),
+            CsvParseOptions { delimiter: b',' }
+        );
     }
 }

--- a/binoc-stdlib/tests/comparator_tests.rs
+++ b/binoc-stdlib/tests/comparator_tests.rs
@@ -197,6 +197,34 @@ fn csv_different_data_produces_modify_with_artifacts() {
 }
 
 #[test]
+fn tsv_different_data_produces_modify_with_artifacts() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join("a.tsv"), "name\tage\nAlice\t30\n").unwrap();
+    std::fs::write(
+        tmp.path().join("b.tsv"),
+        "name\tage\temail\nAlice\t30\ta@b.com\n",
+    )
+    .unwrap();
+
+    let da = data();
+    let pair = ItemPair::both(
+        da.register_local(&tmp.path().join("a.tsv"), "data.tsv")
+            .unwrap(),
+        da.register_local(&tmp.path().join("b.tsv"), "data.tsv")
+            .unwrap(),
+    );
+    let result = CsvComparator.compare(&pair, &da).unwrap();
+    match result {
+        CompareResult::Leaf(node) => {
+            assert_eq!(node.action, "modify");
+            assert_eq!(node.item_type, "tabular");
+            assert_eq!(node.artifacts.len(), 2);
+        }
+        _ => panic!("Expected Leaf"),
+    }
+}
+
+#[test]
 fn csv_added_file_produces_add_with_artifact() {
     let tmp = tempfile::tempdir().unwrap();
     std::fs::write(tmp.path().join("b.csv"), "name,age\nAlice,30\nBob,25\n").unwrap();

--- a/docs/explanation/test-vectors-gallery.md
+++ b/docs/explanation/test-vectors-gallery.md
@@ -13,7 +13,7 @@ audience: new user, data steward, archivist
 
 These are runnable examples from binoc's test suite. Each example links to its source folder on GitHub, tells you whether it needs any extra setup, gives you the exact command to run, and shows the Markdown changelog binoc is expected to print.
 
-Binoc currently ships **27 shared examples** in this gallery.
+Binoc currently ships **28 shared examples** in this gallery.
 
 ## One-time setup
 
@@ -54,6 +54,7 @@ just materialize
 | [`tree-wide-correlation`](#tree-wide-correlation) | Shows tree-wide move and copy detection across nested zip boundaries, including one-to-many copies and many-to-one moves. | gamma-renamed.txt: Moved from gamma.txt | Default pipeline |
 | [`trivial-identical`](#trivial-identical) | Two identical directories → empty changeset | No changes detected. | Default pipeline |
 | [`trivial-identical-csv`](#trivial-identical-csv) | Two identical CSV files → no changes reported | No changes detected. | Default pipeline |
+| [`tsv-cell-changes`](#tsv-cell-changes) | Tab-delimited file parses into real columns and reports cell changes | data.tsv: 2 cells changed | Default pipeline |
 | [`zip-nested`](#zip-nested) | Nested zip containing CSV | outer.zip/inner.zip/data.csv: 1 row added | Default pipeline |
 | [`zip-simple`](#zip-simple) | Zipped files with changes inside | archive.zip/data.txt: 1 line added, 1 removed | Default pipeline |
 
@@ -667,6 +668,29 @@ Result:
 # Changelog: snapshot-a → snapshot-b
 
 No changes detected.
+```
+
+## tsv-cell-changes
+
+Tab-delimited file parses into real columns and reports cell changes
+
+- **Browse source:** [tsv-cell-changes](https://github.com/harvard-lil/binoc/tree/main/test-vectors/tsv-cell-changes)
+- **Tags:** `tsv`, `cell-change`
+- **Snapshots:** `snapshot-a` has 1 file — `data.tsv`; `snapshot-b` has 1 file — `data.tsv`
+
+Run it:
+```bash
+binoc diff \
+  ./test-vectors-materialized/tsv-cell-changes/snapshot-a \
+  ./test-vectors-materialized/tsv-cell-changes/snapshot-b
+```
+Result:
+```markdown
+# Changelog: snapshot-a → snapshot-b
+
+## Other Changes
+
+- **data.tsv**: 2 cells changed
 ```
 
 ## zip-nested

--- a/test-vectors/tsv-cell-changes/expected-output/abi-log.snap
+++ b/test-vectors/tsv-cell-changes/expected-output/abi-log.snap
@@ -1,0 +1,113 @@
+---
+source: binoc-stdlib/src/test_vectors.rs
+expression: "&abi_log"
+---
+[
+  {
+    "method": "compare",
+    "plugin": "binoc.directory",
+    "data_ops": [
+      {
+        "op": "local_path",
+        "handle": ""
+      },
+      {
+        "op": "local_path",
+        "handle": ""
+      },
+      {
+        "op": "register_local",
+        "logical": "data.tsv"
+      },
+      {
+        "op": "read_bytes",
+        "handle": "data.tsv",
+        "result_size": 41
+      },
+      {
+        "op": "register_local",
+        "logical": "data.tsv"
+      },
+      {
+        "op": "read_bytes",
+        "handle": "data.tsv",
+        "result_size": 44
+      }
+    ]
+  },
+  {
+    "method": "compare",
+    "plugin": "binoc.csv",
+    "data_ops": [
+      {
+        "op": "local_path",
+        "handle": "data.tsv"
+      },
+      {
+        "op": "local_path",
+        "handle": "data.tsv"
+      },
+      {
+        "op": "publish_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "subject": "Left",
+        "producer": "binoc.csv",
+        "size": 85
+      },
+      {
+        "op": "publish_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "subject": "Right",
+        "producer": "binoc.csv",
+        "size": 88
+      }
+    ]
+  },
+  {
+    "method": "transform",
+    "plugin": "binoc.correlation_detector",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
+    "plugin": "binoc.fuzzy_correlation_detector",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
+    "plugin": "binoc.folder_move_detector",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
+    "plugin": "binoc.tabular_analyzer",
+    "data_ops": [
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      },
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      }
+    ]
+  }
+]

--- a/test-vectors/tsv-cell-changes/expected-output/changelog.snap
+++ b/test-vectors/tsv-cell-changes/expected-output/changelog.snap
@@ -1,0 +1,9 @@
+---
+source: binoc-stdlib/src/test_vectors.rs
+expression: "&md"
+---
+# Changelog: snapshot-a → snapshot-b
+
+## Other Changes
+
+- **data.tsv**: 2 cells changed

--- a/test-vectors/tsv-cell-changes/expected-output/changeset.snap
+++ b/test-vectors/tsv-cell-changes/expected-output/changeset.snap
@@ -1,0 +1,50 @@
+---
+source: binoc-stdlib/src/test_vectors.rs
+expression: "&stable_changeset"
+---
+{
+  "from_snapshot": "snapshot-a",
+  "to_snapshot": "snapshot-b",
+  "root": {
+    "action": "modify",
+    "item_type": "directory",
+    "path": "",
+    "children": [
+      {
+        "action": "modify",
+        "item_type": "tabular",
+        "path": "data.tsv",
+        "summary": "2 cells changed",
+        "tags": [
+          "binoc.cell-change"
+        ],
+        "details": {
+          "cells_changed": 2,
+          "columns_added": [],
+          "columns_left": [
+            "name",
+            "age",
+            "city"
+          ],
+          "columns_removed": [],
+          "columns_right": [
+            "name",
+            "age",
+            "city"
+          ],
+          "hash_left": "40846706232f796351507ce4380e8cafda832f555b7aac181579f9d971dd91bb",
+          "hash_right": "c29e4ffe02763e0ba8581e7a44731f58d50f614a30166f78e936aac9e7025914",
+          "rows_added": 0,
+          "rows_left": 2,
+          "rows_removed": 0,
+          "rows_right": 2
+        },
+        "comparator": "binoc.csv",
+        "transformed_by": [
+          "binoc.tabular_analyzer"
+        ]
+      }
+    ],
+    "comparator": "binoc.directory"
+  }
+}

--- a/test-vectors/tsv-cell-changes/manifest.toml
+++ b/test-vectors/tsv-cell-changes/manifest.toml
@@ -1,0 +1,8 @@
+[vector]
+name = "tsv-cell-changes"
+description = "Tab-delimited file parses into real columns and reports cell changes"
+tags = ["tsv", "cell-change"]
+
+[expected]
+root_kind = "modify"
+has_tags = ["binoc.cell-change"]

--- a/test-vectors/tsv-cell-changes/snapshot-a/data.tsv
+++ b/test-vectors/tsv-cell-changes/snapshot-a/data.tsv
@@ -1,0 +1,3 @@
+name	age	city
+Alice	30	NYC
+Bob	25	Boston

--- a/test-vectors/tsv-cell-changes/snapshot-b/data.tsv
+++ b/test-vectors/tsv-cell-changes/snapshot-b/data.tsv
@@ -1,0 +1,3 @@
+name	age	city
+Alice	31	NYC
+Bob	25	Cambridge


### PR DESCRIPTION
Closes #55.

The CSV comparator advertised `.tsv` support but parsed tab-separated files with a comma delimiter, collapsing every row into a single column. It now selects the field delimiter from the file extension (`.tsv` → tab, otherwise comma), so `.tsv` inputs parse into their real columns and the changeset reports per-column / per-cell changes.

- Adds a `tsv-cell-changes` test vector covering tab-delimited parsing.
- The delimiter lives in a local `CsvParseOptions` for now; a `TODO` notes it should migrate into the unified dataset-config surface (#48/#51) once per-target comparator config lands.

## Notes
- The `csv` reader continues to run in **flexible mode** to tolerate basic CSV compatibility issues (rows with varying field counts).

## Follow-on work
- Handle byte-order marks (BOMs) on input.
- Handle Unicode/encoding errors gracefully rather than failing the parse.

(Auto generated pull request)