### PR TITLE
Accept an arbitrary number of snapshots (#59)

### DIFF
--- a/binoc-cli/src/lib.rs
+++ b/binoc-cli/src/lib.rs
@@ -13,8 +13,8 @@ use binoc_sdk::{BinocError, Changeset, ExtractResult, Renderer};
     name = "binoc",
     about = "The missing changelog for datasets",
     long_about = "Binoc produces the missing changelog for datasets. It \
-                  detects, classifies, and renders changes between two \
-                  snapshots. The CLI is porcelain over the embeddable \
+                  detects, classifies, and renders changes across ordered \
+                  dataset snapshots. The CLI is porcelain over the embeddable \
                   library; see the Python API and Rust SDK reference pages \
                   for programmatic use."
 )]
@@ -25,17 +25,17 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Diff two snapshots and produce a changelog.
+    /// Diff an ordered sequence of snapshots and produce a changelog.
     ///
-    /// Runs the comparator chain over snapshot_a and snapshot_b and emits the
-    /// resulting changeset. Defaults to human-readable Markdown on stdout;
-    /// use --format json or -o for machine-readable or multi-output rendering.
+    /// Runs pairwise comparisons over each consecutive snapshot pair and emits
+    /// the resulting changeset sequence. Defaults to human-readable Markdown
+    /// on stdout; use --format json or -o for machine-readable or multi-output
+    /// rendering.
     Diff {
-        /// Path to the "before" snapshot (file, directory, or archive, depending
-        /// on which comparators are registered).
-        snapshot_a: PathBuf,
-        /// Path to the "after" snapshot.
-        snapshot_b: PathBuf,
+        /// Ordered snapshot paths. For N inputs, binoc emits N-1 pairwise
+        /// diffs (A→B, B→C, ...). Must provide at least two snapshots.
+        #[arg(required = true, num_args = 2..)]
+        snapshots: Vec<PathBuf>,
         /// Path to a dataset config YAML file. If omitted, the registry's
         /// default config is used.
         #[arg(long)]
@@ -196,6 +196,18 @@ fn render(
     }
 }
 
+fn parse_changesets_json(data: &str) -> Result<Vec<Changeset>, BinocError> {
+    match serde_json::from_str::<Changeset>(data) {
+        Ok(changeset) => Ok(vec![changeset]),
+        Err(single_err) => match serde_json::from_str::<Vec<Changeset>>(data) {
+            Ok(changesets) => Ok(changesets),
+            Err(seq_err) => Err(BinocError::Other(format!(
+                "failed to parse changeset JSON as object ({single_err}) or array ({seq_err})"
+            ))),
+        },
+    }
+}
+
 fn write_outputs(
     output_specs: &[String],
     stdout_format: &str,
@@ -250,8 +262,7 @@ pub fn run(
 
     match cli.command {
         Commands::Diff {
-            snapshot_a,
-            snapshot_b,
+            snapshots,
             config,
             output,
             format,
@@ -267,11 +278,11 @@ pub fn run(
                 Controller::new(resolved.comparators.clone(), resolved.transformers.clone())
                     .with_transformer_configs(dataset_config.transformer_config.as_map());
 
-            let snap_a = snapshot_a.to_string_lossy().to_string();
-            let snap_b = snapshot_b.to_string_lossy().to_string();
-
-            let changeset = controller.diff(&snap_a, &snap_b)?;
-            let changesets = [changeset];
+            let snapshots: Vec<String> = snapshots
+                .iter()
+                .map(|path| path.to_string_lossy().to_string())
+                .collect();
+            let changesets = controller.diff_many(&snapshots)?;
 
             write_outputs(
                 &output,
@@ -299,8 +310,7 @@ pub fn run(
             let mut changesets: Vec<Changeset> = Vec::new();
             for path in &changeset_paths {
                 let data = std::fs::read_to_string(path)?;
-                let m: Changeset = serde_json::from_str(&data)?;
-                changesets.push(m);
+                changesets.extend(parse_changesets_json(&data)?);
             }
 
             write_outputs(

--- a/binoc-cli/tests/cli.rs
+++ b/binoc-cli/tests/cli.rs
@@ -53,6 +53,32 @@ fn diff_format_json_outputs_raw_changeset() {
 }
 
 #[test]
+fn diff_three_snapshots_outputs_pairwise_sequence() {
+    let tmp = tempfile::tempdir().unwrap();
+    let snap_a = tmp.path().join("snapshot-a");
+    let snap_b = tmp.path().join("snapshot-b");
+    let snap_c = tmp.path().join("snapshot-c");
+    std::fs::create_dir(&snap_a).unwrap();
+    std::fs::create_dir(&snap_b).unwrap();
+    std::fs::create_dir(&snap_c).unwrap();
+    std::fs::write(snap_a.join("story.txt"), "alpha\n").unwrap();
+    std::fs::write(snap_b.join("story.txt"), "alpha\nbeta\n").unwrap();
+    std::fs::write(snap_c.join("story.txt"), "alpha\nbeta\ngamma\n").unwrap();
+
+    binoc()
+        .arg("diff")
+        .arg(&snap_a)
+        .arg(&snap_b)
+        .arg(&snap_c)
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("# Changelog:"))
+        .stdout(predicates::str::contains("snapshot-a"))
+        .stdout(predicates::str::contains("snapshot-b"))
+        .stdout(predicates::str::contains("snapshot-c"));
+}
+
+#[test]
 fn diff_csv_column_addition_markdown() {
     let dir = vectors_dir().join("csv-column-addition");
     binoc()
@@ -124,6 +150,20 @@ fn diff_multiple_outputs() {
 
     let md = std::fs::read_to_string(&md_path).unwrap();
     assert!(md.contains("# Changelog:"));
+}
+
+#[test]
+fn diff_two_snapshots_json_stdout_remains_single_object() {
+    let dir = vectors_dir().join("single-file-modify-text");
+    binoc()
+        .arg("diff")
+        .arg(dir.join("snapshot-a"))
+        .arg(dir.join("snapshot-b"))
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .success()
+        .stdout(predicates::str::starts_with("{"));
 }
 
 #[test]
@@ -296,6 +336,47 @@ fn changelog_output_to_file() {
     let md = std::fs::read_to_string(&changelog_path).unwrap();
     assert!(md.contains("Changelog:"));
     assert!(md.contains("data.csv"));
+}
+
+#[test]
+fn changelog_accepts_multi_snapshot_changeset_file() {
+    let tmp = tempfile::tempdir().unwrap();
+    let changeset_path = tmp.path().join("changesets.json");
+    let changelog_path = tmp.path().join("CHANGELOG.md");
+    let snap_a = tmp.path().join("snapshot-a");
+    let snap_b = tmp.path().join("snapshot-b");
+    let snap_c = tmp.path().join("snapshot-c");
+    std::fs::create_dir(&snap_a).unwrap();
+    std::fs::create_dir(&snap_b).unwrap();
+    std::fs::create_dir(&snap_c).unwrap();
+    std::fs::write(snap_a.join("story.txt"), "alpha\n").unwrap();
+    std::fs::write(snap_b.join("story.txt"), "alpha\nbeta\n").unwrap();
+    std::fs::write(snap_c.join("story.txt"), "alpha\nbeta\ngamma\n").unwrap();
+
+    binoc()
+        .arg("diff")
+        .arg(&snap_a)
+        .arg(&snap_b)
+        .arg(&snap_c)
+        .arg("-o")
+        .arg(&changeset_path)
+        .arg("-q")
+        .assert()
+        .success();
+
+    binoc()
+        .arg("changelog")
+        .arg(&changeset_path)
+        .arg("-o")
+        .arg(&changelog_path)
+        .arg("-q")
+        .assert()
+        .success();
+
+    let md = std::fs::read_to_string(&changelog_path).unwrap();
+    assert!(md.contains("snapshot-a"));
+    assert!(md.contains("snapshot-b"));
+    assert!(md.contains("snapshot-c"));
 }
 
 // ── help and version ───────────────────────────────────────────────

--- a/binoc-core/src/controller.rs
+++ b/binoc-core/src/controller.rs
@@ -88,6 +88,24 @@ impl Controller {
         Ok(changeset)
     }
 
+    /// Diff an ordered snapshot sequence and produce one changeset per
+    /// consecutive pair.
+    pub fn diff_many<S>(&self, snapshots: &[S]) -> BinocResult<Vec<Changeset>>
+    where
+        S: AsRef<str>,
+    {
+        if snapshots.len() < 2 {
+            return Err(BinocError::Config(
+                "diff_many requires at least two snapshots".into(),
+            ));
+        }
+
+        snapshots
+            .windows(2)
+            .map(|pair| self.diff(pair[0].as_ref(), pair[1].as_ref()))
+            .collect()
+    }
+
     /// Build the root `ItemPair` for a diff.
     ///
     /// Directories get `logical_path = ""` (their children build relative
@@ -736,6 +754,39 @@ mod tests {
         let root = changeset.root.as_ref().unwrap();
         assert_eq!(root.action, "modify");
         assert_eq!(root.item_type, "file");
+    }
+
+    #[test]
+    fn controller_diff_many_emits_consecutive_pairwise_changesets() {
+        let dir = tempfile::tempdir().unwrap();
+        let snap_a = dir.path().join("snapshot-a");
+        let snap_b = dir.path().join("snapshot-b");
+        let snap_c = dir.path().join("snapshot-c");
+        std::fs::create_dir(&snap_a).unwrap();
+        std::fs::create_dir(&snap_b).unwrap();
+        std::fs::create_dir(&snap_c).unwrap();
+
+        let snapshots = vec![
+            snap_a.to_string_lossy().to_string(),
+            snap_b.to_string_lossy().to_string(),
+            snap_c.to_string_lossy().to_string(),
+        ];
+
+        let controller = Controller::new(vec![leaf_comparator()], vec![]);
+        let changesets = controller.diff_many(&snapshots).unwrap();
+
+        assert_eq!(changesets.len(), 2);
+        assert_eq!(changesets[0].from_snapshot, snapshots[0]);
+        assert_eq!(changesets[0].to_snapshot, snapshots[1]);
+        assert_eq!(changesets[1].from_snapshot, snapshots[1]);
+        assert_eq!(changesets[1].to_snapshot, snapshots[2]);
+    }
+
+    #[test]
+    fn controller_diff_many_rejects_short_sequences() {
+        let controller = Controller::new(vec![leaf_comparator()], vec![]);
+        let err = controller.diff_many::<String>(&[]).unwrap_err();
+        assert!(err.to_string().contains("at least two snapshots"));
     }
 
     #[test]

--- a/docs/howto/diff-two-snapshots.md
+++ b/docs/howto/diff-two-snapshots.md
@@ -5,7 +5,7 @@ audience: data steward, archivist, pipeline integrator
 # Diff two snapshots
 
 **Goal.** Produce a human-readable changelog that describes what
-changed between two snapshots of a dataset.
+changed across an ordered sequence of dataset snapshots.
 
 **Prerequisites.** `binoc` installed (`pip install binoc` or
 `uvx binoc …`). Nothing else.
@@ -18,6 +18,15 @@ binoc diff path/to/snapshot-a path/to/snapshot-b
 
 By default this prints a Markdown changelog to stdout. That's usually
 what you want at a terminal.
+
+To diff a release sequence in one run, pass more snapshots:
+
+```bash
+binoc diff release-q1/ release-q2/ release-q3/
+```
+
+Binoc will emit two pairwise sections: `release-q1/ → release-q2/` and
+`release-q2/ → release-q3/`.
 
 ## What the output looks like
 
@@ -48,7 +57,8 @@ are `markdown` (the default) and `json` (raw changeset IR):
 
 ```bash
 binoc diff A B                    # Markdown to stdout (default)
-binoc diff A B --format json      # raw changeset JSON to stdout
+binoc diff A B --format json      # raw changeset JSON object to stdout
+binoc diff A B C --format json    # JSON array of pairwise changesets
 ```
 
 A third-party plugin may register additional renderers (for example

--- a/docs/howto/save-and-render-changesets.md
+++ b/docs/howto/save-and-render-changesets.md
@@ -73,9 +73,14 @@ a plain path, not "format `/tmp/file`, path `json`".
 
 ## Combine many changesets into one changelog
 
-Running `binoc diff` produces a changeset for **one** snapshot pair.
-When you are tracking a dataset across many releases, you end up with
-a sequence of changesets:
+Running `binoc diff A B` produces a changeset for one snapshot pair.
+Running `binoc diff A B C ...` produces an ordered JSON array of
+pairwise changesets. You can also keep multiple earlier changeset files
+and combine them later. In both cases, `binoc changelog` flattens the
+sequence into one rendered changelog.
+
+When you are tracking a dataset across many releases, you may end up
+with a sequence like:
 
 ```
 changesets/
@@ -90,6 +95,8 @@ combined changelog:
 ```bash
 binoc changelog changesets/*.json -o CHANGELOG.md
 ```
+
+It also accepts the JSON array emitted by `binoc diff A B C -o changesets.json`.
 
 It shares the same `-o` / `--format` / `-q` flags as `diff`.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -7,7 +7,7 @@ audience: anyone using the CLI
 Binoc ships a single entry point — the `binoc` console script — with three
 subcommands:
 
-- `binoc diff A B` diffs two snapshots and prints a changelog.
+- `binoc diff A B [C ...]` diffs an ordered snapshot sequence and prints pairwise changelog sections.
 - `binoc changelog changesets/*.json` combines one or more saved changesets.
 - `binoc extract changeset.json PATH ASPECT` reopens both snapshots through
   the comparator chain and prints the actual changed data for a given node.
@@ -34,13 +34,13 @@ and `binoc <subcommand> --help` print the same information at the terminal.
 
 ## `binoc`
 
-Binoc produces the missing changelog for datasets. It detects, classifies, and renders changes between two snapshots. The CLI is porcelain over the embeddable library; see the Python API and Rust SDK reference pages for programmatic use.
+Binoc produces the missing changelog for datasets. It detects, classifies, and renders changes across ordered dataset snapshots. The CLI is porcelain over the embeddable library; see the Python API and Rust SDK reference pages for programmatic use.
 
 **Usage:** `binoc <COMMAND>`
 
 ###### **Subcommands:**
 
-* `diff` — Diff two snapshots and produce a changelog
+* `diff` — Diff an ordered sequence of snapshots and produce a changelog
 * `changelog` — Generate a human-readable changelog from one or more saved changesets
 * `extract` — Extract actual changed data from a changeset node
 
@@ -48,16 +48,15 @@ Binoc produces the missing changelog for datasets. It detects, classifies, and r
 
 ## `binoc diff`
 
-Diff two snapshots and produce a changelog.
+Diff an ordered sequence of snapshots and produce a changelog.
 
-Runs the comparator chain over snapshot_a and snapshot_b and emits the resulting changeset. Defaults to human-readable Markdown on stdout; use --format json or -o for machine-readable or multi-output rendering.
+Runs pairwise comparisons over each consecutive snapshot pair and emits the resulting changeset sequence. Defaults to human-readable Markdown on stdout; use --format json or -o for machine-readable or multi-output rendering.
 
-**Usage:** `binoc diff [OPTIONS] <SNAPSHOT_A> <SNAPSHOT_B>`
+**Usage:** `binoc diff [OPTIONS] <SNAPSHOTS> <SNAPSHOTS>...`
 
 ###### **Arguments:**
 
-* `<SNAPSHOT_A>` — Path to the "before" snapshot (file, directory, or archive, depending on which comparators are registered)
-* `<SNAPSHOT_B>` — Path to the "after" snapshot
+* `<SNAPSHOTS>` — Ordered snapshot paths. For N inputs, binoc emits N-1 pairwise diffs (A→B, B→C, ...). Must provide at least two snapshots
 
 ###### **Options:**
 


### PR DESCRIPTION
Closes #59.

The CLI and library API accepted only two snapshots at a time. They now accept an arbitrary-length ordered sequence (N ≥ 2) and emit pairwise diffs across consecutive pairs (A→B, B→C, …) in a single run, so a multi-release changelog no longer has to be stitched together by hand.

- Comparison stays strictly pairwise; each pair is independent (no cross-pair correlation).
- Each section is labeled with its from→to snapshot identity.
- The two-snapshot case (`binoc diff a b`) is unchanged.
- Adds CLI tests covering a 3+ snapshot sequence; docs updated (`diff-two-snapshots`, `save-and-render-changesets`, `cli` reference).

(Auto generated pull request)