### PR TITLE
Qualify move source paths in summaries (#57)

### DIFF
--- a/binoc-stdlib/src/transformers/correlation.rs
+++ b/binoc-stdlib/src/transformers/correlation.rs
@@ -124,6 +124,36 @@ pub(crate) fn file_name_of(path: &str) -> &str {
     path.rsplit_once('/').map(|(_, n)| n).unwrap_or(path)
 }
 
+/// Return a source-path label concise for leaf renames, but qualified
+/// enough to make parent-container moves obvious.
+pub(crate) fn source_label_for_move(source_path: &str, dest_path: &str) -> String {
+    if parent_path_of(source_path) == parent_path_of(dest_path) {
+        return file_name_of(source_path).to_string();
+    }
+
+    let source_segments: Vec<&str> = source_path.split('/').collect();
+    let dest_segments: Vec<&str> = dest_path.split('/').collect();
+
+    let mut common_prefix = 0;
+    while common_prefix < source_segments.len()
+        && common_prefix < dest_segments.len()
+        && source_segments[common_prefix] == dest_segments[common_prefix]
+    {
+        common_prefix += 1;
+    }
+
+    if common_prefix >= source_segments.len() {
+        return file_name_of(source_path).to_string();
+    }
+
+    let mut start = common_prefix;
+    if source_segments.len() - start == 1 && source_segments.len() > 1 {
+        start = start.saturating_sub(1);
+    }
+
+    source_segments[start..].join("/")
+}
+
 /// Plan for rewriting a tree in a single pass: set of leaf paths to
 /// delete, plus new nodes to insert under each parent container.
 #[derive(Default, Debug)]
@@ -256,6 +286,41 @@ mod tests {
     fn file_name() {
         assert_eq!(file_name_of("a/b/c.txt"), "c.txt");
         assert_eq!(file_name_of("c.txt"), "c.txt");
+    }
+
+    #[test]
+    fn move_label_keeps_leaf_rename_concise() {
+        assert_eq!(
+            source_label_for_move("docs/old-name.txt", "docs/new-name.txt"),
+            "old-name.txt"
+        );
+    }
+
+    #[test]
+    fn move_label_includes_changed_parent_segment() {
+        assert_eq!(
+            source_label_for_move(
+                "FoodData_Central_csv_2026-04-29/branded_food.csv",
+                "FoodData_Central_csv_2026-04-30/branded_food.csv"
+            ),
+            "FoodData_Central_csv_2026-04-29/branded_food.csv"
+        );
+    }
+
+    #[test]
+    fn move_label_includes_parent_when_destination_gains_container() {
+        assert_eq!(
+            source_label_for_move("outer.zip/beta.txt", "outer.zip/inner.zip/beta-renamed.txt"),
+            "outer.zip/beta.txt"
+        );
+    }
+
+    #[test]
+    fn move_label_falls_back_to_full_path_when_roots_diverge() {
+        assert_eq!(
+            source_label_for_move("outer.zip/inner.zip/gamma.txt", "gamma-renamed.txt"),
+            "outer.zip/inner.zip/gamma.txt"
+        );
     }
 
     #[test]

--- a/binoc-stdlib/src/transformers/correlation_detector.rs
+++ b/binoc-stdlib/src/transformers/correlation_detector.rs
@@ -22,7 +22,7 @@ use binoc_sdk::*;
 
 use super::correlation::{
     apply_rewrite, collect_and_hydrate, english_list, file_name_of, group_by_hash, parent_path_of,
-    HashGroup, LeafEntry, RewritePlan,
+    source_label_for_move, HashGroup, LeafEntry, RewritePlan,
 };
 
 pub struct CorrelationDetector;
@@ -171,7 +171,10 @@ fn emit_move(group: &HashGroup, aggregate: bool, plan: &mut RewritePlan) {
         let add = sorted_adds[i];
         let rm = sorted_removes[i];
         let node = DiffNode::new("move", &add.item_type, &add.path)
-            .with_summary(format!("Moved from {}", file_name_of(&rm.path)))
+            .with_summary(format!(
+                "Moved from {}",
+                source_label_for_move(&rm.path, &add.path)
+            ))
             .with_source_path(&rm.path)
             .with_tag("binoc.move");
         plan.schedule_remove(&add.path);

--- a/binoc-stdlib/src/transformers/fuzzy_correlation_detector.rs
+++ b/binoc-stdlib/src/transformers/fuzzy_correlation_detector.rs
@@ -47,7 +47,7 @@ use std::collections::{BTreeSet, HashSet};
 
 use binoc_sdk::*;
 
-use super::correlation::{apply_rewrite, parent_path_of, RewritePlan};
+use super::correlation::{apply_rewrite, parent_path_of, source_label_for_move, RewritePlan};
 
 const DEFAULT_THRESHOLD: f64 = 0.5;
 const DEFAULT_RENAME_LIMIT: usize = 400;
@@ -297,7 +297,7 @@ fn greedy_assign(mut pairs: Vec<ScoredPair>, threshold: f64) -> Vec<(usize, usiz
 }
 
 fn build_move_node(rm: &FuzzyLeaf, add: &FuzzyLeaf) -> DiffNode {
-    let source_name = file_basename(&rm.path);
+    let source_name = source_label_for_move(&rm.path, &add.path);
     let mut node = DiffNode::new("move", &add.item_type, &add.path)
         .with_summary(format!("Moved from {source_name} (modified)"))
         .with_source_path(&rm.path)
@@ -305,10 +305,6 @@ fn build_move_node(rm: &FuzzyLeaf, add: &FuzzyLeaf) -> DiffNode {
         .with_tag("binoc.move.modified");
     node.pending_recompare = Some(ItemPair::both(rm.item.clone(), add.item.clone()));
     node
-}
-
-fn file_basename(path: &str) -> &str {
-    path.rsplit_once('/').map(|(_, n)| n).unwrap_or(path)
 }
 
 /// Both files must share the same (lowercased) extension. If neither has

--- a/docs/explanation/test-vectors-gallery.md
+++ b/docs/explanation/test-vectors-gallery.md
@@ -51,7 +51,7 @@ just materialize
 | [`tar-nested`](#tar-nested) | Nested tar.gz containing CSV | outer.tar.gz/inner.tar.gz/data.csv: 1 row added | Default pipeline |
 | [`tar-simple`](#tar-simple) | Tar.gz archive with changes inside | archive.tar.gz/data.csv: 1 row added | Default pipeline |
 | [`text-rename-modify`](#text-rename-modify) | Text file renamed and lines added: detected as a single move with content diff via fuzzy correlation | meeting-notes-v2.txt: Moved from notes.txt (modified) | Default pipeline |
-| [`tree-wide-correlation`](#tree-wide-correlation) | Shows tree-wide move and copy detection across nested zip boundaries, including one-to-many copies and many-to-one moves. | gamma-renamed.txt: Moved from gamma.txt | Default pipeline |
+| [`tree-wide-correlation`](#tree-wide-correlation) | Shows tree-wide move and copy detection across nested zip boundaries, including one-to-many copies and many-to-one moves. | gamma-renamed.txt: Moved from outer.zip/inner.zip/gamma.txt | Default pipeline |
 | [`trivial-identical`](#trivial-identical) | Two identical directories → empty changeset | No changes detected. | Default pipeline |
 | [`trivial-identical-csv`](#trivial-identical-csv) | Two identical CSV files → no changes reported | No changes detected. | Default pipeline |
 | [`zip-nested`](#zip-nested) | Nested zip containing CSV | outer.zip/inner.zip/data.csv: 1 row added | Default pipeline |
@@ -620,11 +620,11 @@ Result:
 
 ## Other Changes
 
-- **gamma-renamed.txt**: Moved from gamma.txt
+- **gamma-renamed.txt**: Moved from outer.zip/inner.zip/gamma.txt
 - **kept-copy.txt**: Copied from kept.txt to kept-copy.txt and outer.zip/kept-copy.txt
 - **merged.bin**: Moved from dup.bin and dup-b.bin
 - **outer.zip/alpha-renamed.txt**: Moved from alpha.txt
-- **outer.zip/inner.zip/beta-renamed.txt**: Moved from beta.txt
+- **outer.zip/inner.zip/beta-renamed.txt**: Moved from outer.zip/beta.txt
 ```
 
 ## trivial-identical

--- a/test-vectors/tree-wide-correlation/expected-output/changelog.snap
+++ b/test-vectors/tree-wide-correlation/expected-output/changelog.snap
@@ -6,8 +6,8 @@ expression: "&md"
 
 ## Other Changes
 
-- **gamma-renamed.txt**: Moved from gamma.txt
+- **gamma-renamed.txt**: Moved from outer.zip/inner.zip/gamma.txt
 - **kept-copy.txt**: Copied from kept.txt to kept-copy.txt and outer.zip/kept-copy.txt
 - **merged.bin**: Moved from dup.bin and dup-b.bin
 - **outer.zip/alpha-renamed.txt**: Moved from alpha.txt
-- **outer.zip/inner.zip/beta-renamed.txt**: Moved from beta.txt
+- **outer.zip/inner.zip/beta-renamed.txt**: Moved from outer.zip/beta.txt

--- a/test-vectors/tree-wide-correlation/expected-output/changeset.snap
+++ b/test-vectors/tree-wide-correlation/expected-output/changeset.snap
@@ -15,7 +15,7 @@ expression: "&stable_changeset"
         "item_type": "text",
         "path": "gamma-renamed.txt",
         "source_path": "outer.zip/inner.zip/gamma.txt",
-        "summary": "Moved from gamma.txt",
+        "summary": "Moved from outer.zip/inner.zip/gamma.txt",
         "tags": [
           "binoc.move"
         ]
@@ -87,7 +87,7 @@ expression: "&stable_changeset"
                         "item_type": "text",
                         "path": "outer.zip/inner.zip/beta-renamed.txt",
                         "source_path": "outer.zip/beta.txt",
-                        "summary": "Moved from beta.txt",
+                        "summary": "Moved from outer.zip/beta.txt",
                         "tags": [
                           "binoc.move"
                         ]


### PR DESCRIPTION
Closes #57.

When an enclosing folder was renamed/moved between snapshots, move summaries labeled the change with only the leaf filename, implying the file itself was renamed. Move source paths are now qualified enough to disambiguate a parent-directory move from a leaf rename.

Before:
```
gamma-renamed.txt: Moved from gamma.txt
```
After:
```
gamma-renamed.txt: Moved from outer.zip/inner.zip/gamma.txt
```

- Change is in the correlation transformers (`correlation.rs`, `correlation_detector.rs`, `fuzzy_correlation_detector.rs`); pure rename detection logic is unchanged.
- `tree-wide-correlation` test-vector snapshots updated.

(Auto generated pull request)