### PR TITLE
Remove default Markdown significance buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 Binoc generates changelogs for datasets that don't have them. Given a
 series of snapshots of a dataset downloaded at different times, it
 detects what changed, expresses those changes as a minimal structured
-diff, and produces human-readable summaries that distinguish
-substantive policy changes from clerical housekeeping. The primary
+diff, and produces human-readable summaries from the resulting
+changeset. The primary
 audience is archivists, data scientists, and stewards tracking
 undocumented changes to published datasets.
 

--- a/binoc-cli/tests/cli.rs
+++ b/binoc-cli/tests/cli.rs
@@ -125,7 +125,7 @@ fn diff_output_md_file() {
 
     let md = std::fs::read_to_string(&md_path).unwrap();
     assert!(md.contains("# Changelog:"));
-    assert!(md.contains("Substantive Changes"));
+    assert!(!md.contains("## "));
 }
 
 #[test]

--- a/binoc-stdlib/src/renderers/markdown.rs
+++ b/binoc-stdlib/src/renderers/markdown.rs
@@ -5,9 +5,15 @@ use serde::{Deserialize, Serialize};
 use binoc_sdk::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MarkdownGroup {
+    pub heading: String,
+    pub tags: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MarkdownRendererConfig {
     #[serde(default)]
-    pub significance: BTreeMap<String, Vec<String>>,
+    pub groups: Vec<MarkdownGroup>,
     #[serde(default = "default_max_diagnostics")]
     pub max_diagnostics: usize,
 }
@@ -15,7 +21,7 @@ pub struct MarkdownRendererConfig {
 impl Default for MarkdownRendererConfig {
     fn default() -> Self {
         Self {
-            significance: BTreeMap::new(),
+            groups: Vec::new(),
             max_diagnostics: default_max_diagnostics(),
         }
     }
@@ -49,25 +55,19 @@ pub fn render_markdown(changesets: &[Changeset], config: &MarkdownRendererConfig
         ));
 
         if let Some(root) = &changeset.root {
-            let tag_to_significance = build_tag_map(&config.significance);
-            let mut by_significance: BTreeMap<String, Vec<&DiffNode>> = BTreeMap::new();
+            let tag_to_group = build_tag_map(&config.groups);
+            let mut by_group: Vec<Vec<&DiffNode>> = vec![Vec::new(); config.groups.len()];
             let mut uncategorized: Vec<&DiffNode> = Vec::new();
-            collect_reportable_nodes(
-                root,
-                &tag_to_significance,
-                &mut by_significance,
-                &mut uncategorized,
-            );
+            collect_reportable_nodes(root, &tag_to_group, &mut by_group, &mut uncategorized);
 
-            if tag_to_significance.is_empty() {
+            if config.groups.is_empty() {
                 for node in &uncategorized {
                     format_node(&mut out, node);
                 }
                 out.push('\n');
             } else {
-                for (category, nodes) in &by_significance {
-                    let title = capitalize(category);
-                    out.push_str(&format!("## {title} Changes\n\n"));
+                for (group, nodes) in config.groups.iter().zip(by_group.iter()) {
+                    out.push_str(&format!("## {}\n\n", group.heading));
                     for node in nodes {
                         format_node(&mut out, node);
                     }
@@ -146,20 +146,36 @@ fn format_diagnostics_section(
     out.push('\n');
 }
 
-fn build_tag_map(significance: &BTreeMap<String, Vec<String>>) -> BTreeMap<String, String> {
+fn build_tag_map(groups: &[MarkdownGroup]) -> BTreeMap<String, usize> {
     let mut map = BTreeMap::new();
-    for (category, tags) in significance {
-        for tag in tags {
-            map.insert(tag.clone(), category.clone());
+    for (index, group) in groups.iter().enumerate() {
+        for tag in &group.tags {
+            map.entry(tag.clone()).or_insert(index);
         }
     }
     map
 }
 
+fn classify_tags(
+    tags: impl IntoIterator<Item = impl AsRef<str>>,
+    tag_map: &BTreeMap<String, usize>,
+) -> Option<usize> {
+    let mut best: Option<usize> = None;
+    for tag in tags {
+        if let Some(index) = tag_map.get(tag.as_ref()) {
+            best = Some(match best {
+                Some(current) => current.min(*index),
+                None => *index,
+            });
+        }
+    }
+    best
+}
+
 fn collect_reportable_nodes<'a>(
     node: &'a DiffNode,
-    tag_map: &BTreeMap<String, String>,
-    by_significance: &mut BTreeMap<String, Vec<&'a DiffNode>>,
+    tag_map: &BTreeMap<String, usize>,
+    by_group: &mut [Vec<&'a DiffNode>],
     uncategorized: &mut Vec<&'a DiffNode>,
 ) {
     let is_reportable = node.summary.is_some()
@@ -172,24 +188,22 @@ fn collect_reportable_nodes<'a>(
     // `annotations.tabular_summary` (TabularAnalyzer), or in
     // `annotations.content_summary` (comparator leaf summary captured
     // during inflate). Without this grouping, the move and its content
-    // detail would land in different significance sections, hiding the
+    // detail would land in different sections, hiding the
     // relationship.
     let group_as_move = should_group_move_children(node);
 
     if is_reportable {
-        let category = if group_as_move {
-            // Promote to the highest-significance category among the move
-            // node's own tags and any descendant tags.
-            node.all_tags()
-                .iter()
-                .find_map(|tag| tag_map.get(tag))
-                .cloned()
+        let group_index = if group_as_move {
+            // Promote to the highest-priority group among the move
+            // node's own tags and any descendant tags. Priority is the
+            // first matching configured group.
+            classify_tags(node.all_tags().iter(), tag_map)
         } else {
-            node.tags.iter().find_map(|tag| tag_map.get(tag)).cloned()
+            classify_tags(node.tags.iter(), tag_map)
         };
 
-        match category {
-            Some(cat) => by_significance.entry(cat).or_default().push(node),
+        match group_index {
+            Some(index) => by_group[index].push(node),
             None => uncategorized.push(node),
         }
     }
@@ -201,7 +215,7 @@ fn collect_reportable_nodes<'a>(
     }
 
     for child in &node.children {
-        collect_reportable_nodes(child, tag_map, by_significance, uncategorized);
+        collect_reportable_nodes(child, tag_map, by_group, uncategorized);
     }
 }
 
@@ -361,7 +375,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn to_markdown_includes_significance_sections() {
+    fn to_markdown_default_is_flat_list() {
         let changeset = Changeset::new(
             "v1",
             "v2",
@@ -374,9 +388,76 @@ mod tests {
         let config = MarkdownRendererConfig::default();
         let md = render_markdown(&[changeset], &config);
         assert!(md.contains("# Changelog: v1 → v2"));
-        assert!(md.contains("## Substantive Changes"));
+        assert!(!md.contains("## "));
         assert!(md.contains("**data.csv**"));
         assert!(md.contains("Column added: 'email'"));
+    }
+
+    #[test]
+    fn to_markdown_respects_explicit_group_sections() {
+        let changeset = Changeset::new(
+            "v1",
+            "v2",
+            Some(
+                DiffNode::new("modify", "csv", "data.csv")
+                    .with_summary("Column added: 'email'")
+                    .with_tag("binoc.column-addition"),
+            ),
+        );
+        let config = MarkdownRendererConfig {
+            groups: vec![MarkdownGroup {
+                heading: "Substantive changes".into(),
+                tags: vec!["binoc.column-addition".into()],
+            }],
+            ..Default::default()
+        };
+        let md = render_markdown(&[changeset], &config);
+        assert!(md.contains("## Substantive changes"));
+    }
+
+    #[test]
+    fn to_markdown_uses_declared_group_order_and_first_match_priority() {
+        let changeset = Changeset::new(
+            "v1",
+            "v2",
+            Some(
+                DiffNode::new("modify", "csv", "data.csv")
+                    .with_summary("Column added: 'email'")
+                    .with_tag("binoc.column-addition")
+                    .with_tag("binoc.content-changed"),
+            ),
+        );
+        let config = MarkdownRendererConfig {
+            groups: vec![
+                MarkdownGroup {
+                    heading: "Critical".into(),
+                    tags: vec!["binoc.content-changed".into()],
+                },
+                MarkdownGroup {
+                    heading: "Substantive".into(),
+                    tags: vec!["binoc.column-addition".into()],
+                },
+            ],
+            ..Default::default()
+        };
+        let md = render_markdown(&[changeset], &config);
+        let critical = md.find("## Critical").expect("missing Critical heading");
+        let substantive = md
+            .find("## Substantive")
+            .expect("missing Substantive heading");
+        assert!(
+            critical < substantive,
+            "group headings should keep declaration order; got:\n{md}"
+        );
+        let substantive_section = md
+            .split("## Substantive")
+            .nth(1)
+            .expect("expected substantive section");
+        assert!(md.contains("## Critical\n\n- **data.csv**: Column added: 'email'"));
+        assert!(
+            !substantive_section.contains("**data.csv**"),
+            "node should land in first matching group; got:\n{md}"
+        );
     }
 
     #[test]
@@ -455,11 +536,17 @@ mod tests {
 
         let md = render_markdown(
             &[Changeset::new("v1", "v2", Some(root))],
-            &MarkdownRendererConfig::default(),
+            &MarkdownRendererConfig {
+                groups: vec![MarkdownGroup {
+                    heading: "Substantive changes".into(),
+                    tags: vec!["binoc.column-addition".into()],
+                }],
+                ..Default::default()
+            },
         );
 
         assert!(
-            md.contains("## Substantive Changes"),
+            md.contains("## Substantive changes"),
             "should land in substantive section (promoted from child tag)"
         );
         assert!(md.contains("- **data_v2.csv**: Moved from data.csv (modified)\n"));
@@ -488,10 +575,16 @@ mod tests {
 
         let md = render_markdown(
             &[Changeset::new("v1", "v2", Some(root))],
-            &MarkdownRendererConfig::default(),
+            &MarkdownRendererConfig {
+                groups: vec![MarkdownGroup {
+                    heading: "Substantive changes".into(),
+                    tags: vec!["binoc.column-addition".into(), "binoc.schema-change".into()],
+                }],
+                ..Default::default()
+            },
         );
 
-        assert!(md.contains("## Substantive Changes"));
+        assert!(md.contains("## Substantive changes"));
         assert!(
             md.contains("- **data_v2.csv**: Moved from data.csv (modified)\n"),
             "move headline bullet missing; got:\n{md}"

--- a/binoc-stdlib/src/renderers/markdown.rs
+++ b/binoc-stdlib/src/renderers/markdown.rs
@@ -6,7 +6,7 @@ use binoc_sdk::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MarkdownRendererConfig {
-    #[serde(default = "default_significance")]
+    #[serde(default)]
     pub significance: BTreeMap<String, Vec<String>>,
     #[serde(default = "default_max_diagnostics")]
     pub max_diagnostics: usize,
@@ -15,7 +15,7 @@ pub struct MarkdownRendererConfig {
 impl Default for MarkdownRendererConfig {
     fn default() -> Self {
         Self {
-            significance: default_significance(),
+            significance: BTreeMap::new(),
             max_diagnostics: default_max_diagnostics(),
         }
     }
@@ -23,31 +23,6 @@ impl Default for MarkdownRendererConfig {
 
 fn default_max_diagnostics() -> usize {
     8
-}
-
-fn default_significance() -> BTreeMap<String, Vec<String>> {
-    let mut map = BTreeMap::new();
-    map.insert(
-        "clerical".into(),
-        vec![
-            "binoc.column-reorder".into(),
-            "binoc.whitespace-change".into(),
-            "binoc.folder-rename".into(),
-            "binoc.encoding-change".into(),
-        ],
-    );
-    map.insert(
-        "substantive".into(),
-        vec![
-            "binoc.column-addition".into(),
-            "binoc.column-removal".into(),
-            "binoc.schema-change".into(),
-            "binoc.row-addition".into(),
-            "binoc.row-removal".into(),
-            "binoc.content-changed".into(),
-        ],
-    );
-    map
 }
 
 pub struct MarkdownRenderer;
@@ -84,21 +59,28 @@ pub fn render_markdown(changesets: &[Changeset], config: &MarkdownRendererConfig
                 &mut uncategorized,
             );
 
-            for (category, nodes) in &by_significance {
-                let title = capitalize(category);
-                out.push_str(&format!("## {title} Changes\n\n"));
-                for node in nodes {
-                    format_node(&mut out, node);
-                }
-                out.push('\n');
-            }
-
-            if !uncategorized.is_empty() {
-                out.push_str("## Other Changes\n\n");
+            if tag_to_significance.is_empty() {
                 for node in &uncategorized {
                     format_node(&mut out, node);
                 }
                 out.push('\n');
+            } else {
+                for (category, nodes) in &by_significance {
+                    let title = capitalize(category);
+                    out.push_str(&format!("## {title} Changes\n\n"));
+                    for node in nodes {
+                        format_node(&mut out, node);
+                    }
+                    out.push('\n');
+                }
+
+                if !uncategorized.is_empty() {
+                    out.push_str("## Other Changes\n\n");
+                    for node in &uncategorized {
+                        format_node(&mut out, node);
+                    }
+                    out.push('\n');
+                }
             }
         } else {
             out.push_str("No changes detected.\n\n");

--- a/binoc-stdlib/src/test_vectors.rs
+++ b/binoc-stdlib/src/test_vectors.rs
@@ -879,10 +879,14 @@ fn check_assertions(
         let md_val = config.output.get_for_renderer("binoc.markdown");
         let md_config: markdown::MarkdownRendererConfig =
             serde_json::from_value(md_val).unwrap_or_default();
-        let sig_tags = md_config.significance.get(significance.as_str());
+        let sig_tags = md_config
+            .groups
+            .iter()
+            .find(|group| group.heading == *significance)
+            .map(|group| &group.tags);
         assert!(
             sig_tags.is_some(),
-            "[{name}] Significance category '{significance}' not in markdown renderer config"
+            "[{name}] Significance group '{significance}' not in markdown renderer config"
         );
         let sig_tags = sig_tags.unwrap();
         let has_sig_tag = all_tags.iter().any(|t| sig_tags.contains(t));

--- a/docs/adr/2026-03-09-renderer_config.md
+++ b/docs/adr/2026-03-09-renderer_config.md
@@ -3,6 +3,8 @@
 **Date:** 2026-03-09
 **Status:** Decided (implemented)
 
+Superseded in part by [2026-06-02-renderer_groups.md](2026-06-02-renderer_groups.md) for the Markdown renderer's `groups` naming and ordered-list semantics.
+
 ## Problem
 
 The original design placed significance classification config in a flat `output.significance` section of the dataset config:

--- a/docs/adr/2026-03-18-terminology.md
+++ b/docs/adr/2026-03-18-terminology.md
@@ -50,12 +50,14 @@ Binoc introduces a number of domain-specific terms. This ADR catalogs the delibe
 
 ### Significance Classification
 
+Superseded in part by [2026-06-02-renderer_groups.md](2026-06-02-renderer_groups.md) for the current Markdown grouping model and the removal of shipped default headings.
+
 | Chosen term | Meaning |
 |---|---|---|---|
 | **Clerical** | Changes that are mechanically necessary but semantically unimportant: column reordering, whitespace normalization, encoding changes. Chosen over *ministerial* (precise in records management but unfamiliar to most developers), *minor*/*trivial* (judgmental), *cosmetic* (implies visual concerns). |
 | **Substantive** | Changes that alter the information content: added columns, removed rows, schema changes. |
 
-Note: these are the *default* category names in the Markdown renderer. They are not baked into the IR. Any renderer or dataset config can define its own categories (e.g. `critical`, `informational`, `review-required`). 
+Note: these were the original category names used in the Markdown renderer design. They are not baked into the IR. Current renderer config uses explicit ordered groups with literal headings. 
 
 ### Testing
 

--- a/docs/adr/2026-06-02-renderer_groups.md
+++ b/docs/adr/2026-06-02-renderer_groups.md
@@ -1,0 +1,66 @@
+# Markdown Renderer Groups Replace Significance-Map Grouping
+
+**Date:** 2026-06-02
+**Status:** Implemented
+
+## Context
+
+The Markdown renderer originally grouped changes with a map-like
+`output.markdown.significance` config keyed by category name. That design had
+three practical problems:
+
+- It did not preserve section order naturally. A map shape suggests that keys
+  are unordered, while changelog sections need predictable top-to-bottom
+  priority.
+- It encouraged derived headings from category names, which made the output
+  feel more schema-driven than author-driven.
+- It described multi-tag behavior as "significance" priority even though the
+  real rule was simply "first configured match wins."
+
+Separately, Binoc had already removed the shipped clerical/substantive default
+mapping. The default Markdown output is now a flat list with no group
+headings unless the user configures them.
+
+## Decision
+
+The Markdown renderer uses `output.markdown.groups`, an ordered list of group
+objects:
+
+```yaml
+output:
+  markdown:
+    groups:
+      - heading: "Critical review"
+        tags: [bio.cross-contamination]
+      - heading: "Substantive changes"
+        tags: [binoc.column-addition, binoc.content-changed]
+```
+
+The semantics are:
+
+- `groups` is optional. If omitted or empty, Markdown renders a flat list with
+  no headings.
+- Each group has a literal `heading` string and a `tags` list.
+- Sections render in declared order.
+- If a node matches multiple groups, it goes to the first matching group.
+- If any groups are configured, unmatched nodes render under a trailing
+  `## Other Changes` section.
+
+This supersedes the Markdown-specific naming and semantics described in
+[2026-03-09-renderer_config.md](2026-03-09-renderer_config.md), while keeping
+that ADR's broader decision intact: renderer-side grouping remains a renderer
+concern, not an IR concern.
+
+## Alternatives Considered
+
+Keep `significance` as a map and document an ordering convention.
+
+Rejected because it leaves the structure at odds with the renderer's actual
+behavior. Ordered groups are simpler to read, serialize, and reason about than
+an implicitly ordered map.
+
+Keep `significance` but change only the value type.
+
+Rejected because the old name suggests built-in levels or severity classes.
+`groups` better describes what the Markdown renderer actually does: place
+reportable nodes into ordered, author-defined sections.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -6,6 +6,7 @@ Newer entries appear first. Each entry shows its date and current status. Create
 
 | Date | Title | Status |
 |---|---|---|
+| 2026-06-02 | [Markdown Renderer Groups Replace Significance-Map Grouping](2026-06-02-renderer_groups.md) | Implemented |
 | 2026-06-01 | [Diagnostics Channel for Non-Fatal Warnings and Suggestions](2026-06-01-diagnostics_channel.md) | Implemented |
 | 2026-05-13 | [Rename-and-modify detection: fuzzy correlation + transformer-initiated re-dispatch](rename_modify_detection.md) | Implemented |
 | 2026-04-17 | [Documentation Platform and Information Design](2026-04-17-documentation_platform_and_info_design.md) | Proposed |

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -34,7 +34,7 @@ Five moving parts:
 | **Controller** | Dispatches item pairs through a work queue, assembles the diff tree, drives transformers. | No |
 | **Comparators** | Parsers. Take raw data and emit IR (a leaf node, or an expansion into child item pairs). | Yes |
 | **Transformers** | Optimization passes over the IR. Detect cross-cutting patterns (moves, reorders) without touching raw data. | Yes (about *patterns* in IR) |
-| **Renderers** | Serialize the IR for a presentation surface (Markdown, JSON, HTML…). Optionally apply significance classification. | Yes (about *output*) |
+| **Renderers** | Serialize the IR for a presentation surface (Markdown, JSON, HTML…). Optionally apply renderer-side grouping. | Yes (about *output*) |
 | **Config** | Decides which plugins run and in what order. | n/a |
 
 For the conceptual model behind each part, see
@@ -67,7 +67,7 @@ The three plugin axes correspond to three phases of work:
   by default — they consume *artifacts* published by comparators. See
   [Artifacts and composition](artifacts-and-composition.md).
 - **Renderers** decide what the IR *means* for a given output surface.
-  Optional significance classification is a renderer concern. See
+  Optional grouping is a renderer concern. See
   [Significance classification](significance-classification.md).
 
 This split is not just hygiene; it is what enables cross-plugin composition.

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -34,7 +34,7 @@ Five moving parts:
 | **Controller** | Dispatches item pairs through a work queue, assembles the diff tree, drives transformers. | No |
 | **Comparators** | Parsers. Take raw data and emit IR (a leaf node, or an expansion into child item pairs). | Yes |
 | **Transformers** | Optimization passes over the IR. Detect cross-cutting patterns (moves, reorders) without touching raw data. | Yes (about *patterns* in IR) |
-| **Renderers** | Serialize the IR for a presentation surface (Markdown, JSON, HTML…). Apply significance classification. | Yes (about *output*) |
+| **Renderers** | Serialize the IR for a presentation surface (Markdown, JSON, HTML…). Optionally apply significance classification. | Yes (about *output*) |
 | **Config** | Decides which plugins run and in what order. | n/a |
 
 For the conceptual model behind each part, see
@@ -67,8 +67,8 @@ The three plugin axes correspond to three phases of work:
   by default — they consume *artifacts* published by comparators. See
   [Artifacts and composition](artifacts-and-composition.md).
 - **Renderers** decide what the IR *means* for a given output surface.
-  Significance classification — clerical vs. substantive — is a renderer
-  concern. See [Significance classification](significance-classification.md).
+  Optional significance classification is a renderer concern. See
+  [Significance classification](significance-classification.md).
 
 This split is not just hygiene; it is what enables cross-plugin composition.
 A new comparator that publishes `tabular_v1` artifacts inherits all the

--- a/docs/explanation/ir-and-changesets.md
+++ b/docs/explanation/ir-and-changesets.md
@@ -70,9 +70,10 @@ care about precise dispatch can do so safely. See
 ### Tags are facts, not judgments
 
 Every tag in the IR is a *factual observation*: `binoc.column-reorder`
-means "the columns were reordered" — not "this is unimportant." Whether a
-column reorder counts as clerical or substantive is a *renderer* concern,
-mapped from tags via configuration. See
+means "the columns were reordered" — not "this belongs under a particular
+heading." Whether a column reorder is grouped as clerical, substantive, or
+something custom is a *renderer* concern, mapped from tags via
+configuration. See
 [Significance classification](significance-classification.md).
 
 This split is the reason a single dataset's binoc output can be read
@@ -122,7 +123,7 @@ produces a flat factual list:
 ```
 
 With explicit renderer config, the same tree can instead be grouped under
-custom headings such as `clerical` and `substantive`.
+literal headings in a declared order.
 
 Pipeline integrators consume the JSON directly. The
 [changeset JSON schema](../reference/changeset-schema.md) is the canonical

--- a/docs/explanation/ir-and-changesets.md
+++ b/docs/explanation/ir-and-changesets.md
@@ -77,8 +77,8 @@ mapped from tags via configuration. See
 
 This split is the reason a single dataset's binoc output can be read
 differently by different audiences without re-running the diff: the same
-changeset JSON, fed through two renderer configs, can produce two
-changelogs that disagree about what mattered.
+changeset JSON can be rendered as a flat factual list or grouped output
+depending on renderer config.
 
 ### The tree is structural, not just additive
 
@@ -110,21 +110,19 @@ flowchart LR
 ## What a changeset looks like on disk
 
 A changeset on disk is JSON. The root node is the top-level object;
-children nest naturally. The default Markdown renderer reads the tree,
-applies significance classification, and produces grouped output:
+children nest naturally. The default Markdown renderer reads the tree and
+produces a flat factual list:
 
 ```
 # Changelog: snapshot-a → snapshot-b
 
-## Substantive Changes
-
 - **data/records.csv**: 1 row added
 - **data/extra.csv**: New table (2 columns, 1 row)
-
-## Clerical Changes
-
 - **summary.csv**: Columns reordered (content unchanged)
 ```
+
+With explicit renderer config, the same tree can instead be grouped under
+custom headings such as `clerical` and `substantive`.
 
 Pipeline integrators consume the JSON directly. The
 [changeset JSON schema](../reference/changeset-schema.md) is the canonical

--- a/docs/explanation/plugin-model.md
+++ b/docs/explanation/plugin-model.md
@@ -79,8 +79,8 @@ Typical transformer jobs:
 A renderer takes a finished changeset and produces a presentation-format
 output: Markdown changelog, JSON, HTML, RSS, anything. Renderers are also
 where **significance classification** lives when a presentation wants it —
-the mapping from semantic tags (facts) to categories like "clerical" or
-"substantive" (judgments).
+the mapping from semantic tags (facts) to grouped changelog sections
+(judgments).
 This is a deliberate placement: see
 [Significance classification](significance-classification.md).
 

--- a/docs/explanation/plugin-model.md
+++ b/docs/explanation/plugin-model.md
@@ -78,8 +78,9 @@ Typical transformer jobs:
 
 A renderer takes a finished changeset and produces a presentation-format
 output: Markdown changelog, JSON, HTML, RSS, anything. Renderers are also
-where **significance classification** lives — the mapping from semantic
-tags (facts) to categories like "clerical" or "substantive" (judgments).
+where **significance classification** lives when a presentation wants it —
+the mapping from semantic tags (facts) to categories like "clerical" or
+"substantive" (judgments).
 This is a deliberate placement: see
 [Significance classification](significance-classification.md).
 

--- a/docs/explanation/significance-classification.md
+++ b/docs/explanation/significance-classification.md
@@ -12,64 +12,65 @@ Binoc separates the two:
 - **The IR records facts.** Tags like `binoc.column-reorder`,
   `binoc.row-addition`, and `binoc.content-changed` are factual
   observations attached to nodes by comparators and transformers.
-- **The renderer applies judgments.** A renderer's config maps tags to
-  significance categories (`clerical`, `substantive`, `critical`,
-  `informational`, …). The same IR can be rendered through different
-  configs to produce different changelogs.
+- **The renderer applies judgments.** A renderer's config maps tags into
+  changelog groups with ordered headings. The same IR can be rendered
+  through different configs to produce different changelogs.
 
 This split is documented in the
 [per-renderer config ADR](../adr/2026-03-09-renderer_config.md) and the
-[terminology ADR](../adr/2026-03-18-terminology.md).
+[terminology ADR](../adr/2026-03-18-terminology.md). "Significance
+classification" is the historical name for this renderer-side grouping
+feature.
 
-## The default mapping
+## The default behavior
 
-The default Markdown renderer uses two categories:
+If you omit `output.markdown.groups`, the Markdown renderer emits a flat list
+with no group headings at all.
 
-| Category | Default tags |
-|---|---|
-| **Clerical** | `binoc.column-reorder`, `binoc.whitespace-change`, `binoc.folder-rename`, `binoc.encoding-change` |
-| **Substantive** | `binoc.column-addition`, `binoc.column-removal`, `binoc.schema-change`, `binoc.row-addition`, `binoc.row-removal`, `binoc.content-changed` |
+Grouping is opt-in. Once `groups` is configured, the renderer emits sections
+in declared order and puts any unmatched nodes in a trailing
+`## Other Changes` section.
 
-Anything that doesn't match is grouped under "Other Changes."
+## Configuring groups
 
-Why "clerical" and "substantive"? They are domain-neutral and capture the
-basic split most data audiences care about. *Clerical* over alternatives
-like *minor*, *cosmetic*, or *ministerial* — see the
-[terminology ADR](../adr/2026-03-18-terminology.md) for the rejected alternatives.
-
-## Overriding the mapping
-
-A dataset config YAML can replace or extend the defaults under
-`output.markdown.significance`:
+A dataset config YAML can define ordered groups under
+`output.markdown.groups`:
 
 ```yaml
 output:
   markdown:
-    significance:
-      clerical:
-        - binoc.column-reorder
-        - binoc.whitespace-change
-        - bio.header-change
-      substantive:
-        - binoc.column-addition
-        - binoc.content-changed
-        - bio.sequence-change
-      critical:
-        - bio.cross-contamination
+    groups:
+      - heading: "Critical review"
+        tags:
+          - bio.cross-contamination
+      - heading: "Substantive changes"
+        tags:
+          - binoc.column-addition
+          - binoc.content-changed
+          - bio.sequence-change
+      - heading: "Clerical changes"
+        tags:
+          - binoc.column-reorder
+          - binoc.whitespace-change
+          - bio.header-change
 ```
 
-A plugin pack can ship a recommended significance config that users opt into.
+A plugin pack can ship a recommended grouping config that users opt into.
 A team can ship a stricter or looser version of the same config without
 changing any plugin code.
 
-## How a node is classified when it has multiple tags
+## Group order is priority
 
-When a node carries tags from more than one category, the renderer picks
-the *highest-priority* match. The priority is the order in which categories
-are declared in the renderer config. If a node has both
-`binoc.column-reorder` (clerical) and `binoc.column-addition`
-(substantive), and the config lists `substantive` before `clerical`, the
-node is classified as substantive.
+Groups are an ordered list, not a map. The renderer preserves the declared
+order when it writes sections, and the same order defines priority when a
+node matches more than one group.
+
+If a node has both `binoc.column-reorder` and `binoc.column-addition`, and
+the config lists "Substantive changes" before "Clerical changes", the node
+goes into "Substantive changes". First matching group wins.
+
+Headings are literal strings. The renderer does not auto-capitalize them or
+append `" Changes"`.
 
 This is consistent with the principle that *the IR records facts* — both
 tags genuinely apply — and *the renderer decides what to do about it*.
@@ -89,18 +90,19 @@ A naive design would put `significance: "substantive"` directly in
   re-classified by re-rendering.
 - **Plugin packs that don't know about a tag shouldn't have to.** A plugin
   emitting `bio.sequence-change` doesn't know whether a downstream user
-  considers it clerical or substantive. The user does.
+  considers it a critical review item, a routine content change, or
+  something else. The user does.
 
 ## Classification is one renderer's job
 
 Different renderers can apply different classification logic — or none.
 The JSON renderer doesn't classify at all; it just serializes the tree.
-The Markdown renderer is where the default mapping lives. A custom HTML
+The Markdown renderer can emit either a flat list or configured groups. A custom HTML
 renderer (see the [`binoc-html` model plugin](https://github.com/harvard-lil/binoc/tree/main/model-plugins/binoc-html))
 applies its own grouping with hooks for review workflows.
 
-This is why significance config is *per-renderer* (`output.markdown.significance`,
-`output.html.significance`) rather than a global setting on the changeset.
+This is why grouping config is *per-renderer* (`output.markdown.groups`,
+`output.html.groups`) rather than a global setting on the changeset.
 
 ## Where to go next
 

--- a/docs/explanation/test-vectors-gallery.md
+++ b/docs/explanation/test-vectors-gallery.md
@@ -42,8 +42,8 @@ just materialize
 | [`directory-nested`](#directory-nested) | Subdirectories with mixed changes | data/extra.csv: New table (2 columns, 1 rows) | Default pipeline |
 | [`directory-nested-with-tar`](#directory-nested-with-tar) | Shows binoc diffing a tar archive and a plain directory that contain overlapping internal paths. | data/records.csv: 1 row added | Default pipeline |
 | [`folder-move-nested`](#folder-move-nested) | Detects a whole-folder rename and rolls many file moves up into one folder-move entry. | documentation: Folder moved from docs | Default pipeline |
-| [`folder-move-partial`](#folder-move-partial) | Detects a mostly-moved folder rename and preserves only the added/removed/modified remainder entries beneath it. | FoodData_Central_csv_2026-04-30/data/new-table.csv: New table (2 columns, 1 rows) | Custom config |
-| [`kitchen-sink`](#kitchen-sink) | Runs text, CSV, archive, move, and copy detection together in one end-to-end example. | metrics.csv: Columns reordered (content unchanged) | Default pipeline |
+| [`folder-move-partial`](#folder-move-partial) | Detects a mostly-moved folder rename and preserves only the added/removed/modified remainder entries beneath it. | FoodData_Central_csv_2026-04-30: Folder moved from FoodData_Central_csv_2,025-12-18 | Custom config |
+| [`kitchen-sink`](#kitchen-sink) | Runs text, CSV, archive, move, and copy detection together in one end-to-end example. | archive.tar.gz/inventory.csv: 1 row added | Default pipeline |
 | [`single-file-add`](#single-file-add) | File present in B but not A | new_file.txt: New file (1 line) | Default pipeline |
 | [`single-file-modify-binary`](#single-file-modify-binary) | Binary file, different hash | data.bin: Content changed (4 bytes → 4 bytes) | Default pipeline |
 | [`single-file-modify-csv`](#single-file-modify-csv) | CSV file compared directly (file-to-file, not via directory) | data.csv: 1 row added | Default pipeline |
@@ -78,8 +78,6 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-## Substantive Changes
-
 - **data.parquet**: Content changed (7 bytes → 7 bytes)
 
 ## Suggestions
@@ -105,8 +103,6 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-## Other Changes
-
 - **data.csv**: 2 cells changed
 ```
 
@@ -128,8 +124,6 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-## Substantive Changes
-
 - **data.csv**: Column added: 'email'
 ```
 
@@ -150,8 +144,6 @@ binoc diff \
 Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
-
-## Substantive Changes
 
 - **data.csv**: Column removed: 'city'
 ```
@@ -187,8 +179,6 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-## Clerical Changes
-
 - **data.csv**: Columns reordered (content unchanged)
 ```
 
@@ -210,8 +200,6 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-## Substantive Changes
-
 - **data.csv**: Column added: 'email'; columns reordered; 1 row added
 ```
 
@@ -232,8 +220,6 @@ binoc diff \
 Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
-
-## Substantive Changes
 
 - **data_v2.csv**: Moved from data.csv (modified)
 - **data_v2.csv**: Column added: 'email'
@@ -257,8 +243,6 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-## Substantive Changes
-
 - **data.csv**: 2 rows added
 ```
 
@@ -279,8 +263,6 @@ binoc diff \
 Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
-
-## Substantive Changes
 
 - **data.csv**: 2 rows removed
 ```
@@ -303,8 +285,6 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-## Other Changes
-
 - **duplicate.txt**: Copied from original.txt
 ```
 
@@ -325,8 +305,6 @@ binoc diff \
 Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
-
-## Substantive Changes
 
 - **data/extra.csv**: New table (2 columns, 1 rows)
 - **data/records.csv**: 1 row added
@@ -351,12 +329,7 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-## Substantive Changes
-
 - **data/records.csv**: 1 row added
-
-## Other Changes
-
 - **data.tar.gz/records.csv**: 1 cell changed
 ```
 
@@ -377,8 +350,6 @@ binoc diff \
 Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
-
-## Other Changes
 
 - **documentation**: Folder moved from docs
 ```
@@ -411,15 +382,10 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-## Substantive Changes
-
+- **FoodData_Central_csv_2026-04-30**: Folder moved from FoodData_Central_csv_2,025-12-18
 - **FoodData_Central_csv_2026-04-30/data/new-table.csv**: New table (2 columns, 1 rows)
 - **FoodData_Central_csv_2026-04-30/docs/modified.txt**: Text modified
 - **FoodData_Central_csv_2026-04-30/docs/old-table.txt**: File removed (1 line)
-
-## Other Changes
-
-- **FoodData_Central_csv_2026-04-30**: Folder moved from FoodData_Central_csv_2,025-12-18
 ```
 
 ## kitchen-sink
@@ -440,23 +406,15 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-## Clerical Changes
-
-- **metrics.csv**: Columns reordered (content unchanged)
-
-## Substantive Changes
-
 - **archive.tar.gz/inventory.csv**: 1 row added
 - **bundle.zip/notes.txt**: 2 lines added, 1 removed
+- **data.csv**: 2 cells changed
 - **docs/new-file.txt**: New file (1 line)
 - **docs/old-notes.txt**: File removed (1 line)
 - **docs/readme.txt**: 2 lines added, 2 removed
 - **icon.bin**: Content changed (19 bytes → 19 bytes)
-
-## Other Changes
-
-- **data.csv**: 2 cells changed
 - **license-copy.txt**: Copied from license.txt
+- **metrics.csv**: Columns reordered (content unchanged)
 - **summary.txt**: Moved from report.txt
 
 ## Suggestions
@@ -482,8 +440,6 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-## Substantive Changes
-
 - **new_file.txt**: New file (1 line)
 ```
 
@@ -504,8 +460,6 @@ binoc diff \
 Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
-
-## Substantive Changes
 
 - **data.bin**: Content changed (4 bytes → 4 bytes)
 
@@ -532,8 +486,6 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-## Substantive Changes
-
 - **data.csv**: 1 row added
 ```
 
@@ -554,8 +506,6 @@ binoc diff \
 Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
-
-## Substantive Changes
 
 - **story.txt**: 2 lines added, 1 removed
 ```
@@ -578,8 +528,6 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-## Substantive Changes
-
 - **story.txt**: 2 lines added, 1 removed
 ```
 
@@ -600,8 +548,6 @@ binoc diff \
 Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
-
-## Substantive Changes
 
 - **removed_file.txt**: File removed (1 line)
 ```
@@ -624,8 +570,6 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-## Substantive Changes
-
 - **outer.tar.gz/inner.tar.gz/data.csv**: 1 row added
 ```
 
@@ -646,8 +590,6 @@ binoc diff \
 Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
-
-## Substantive Changes
 
 - **archive.tar.gz/data.csv**: 1 row added
 - **archive.tar.gz/hello.txt**: 1 line added
@@ -671,8 +613,6 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-## Substantive Changes
-
 - **meeting-notes-v2.txt**: Moved from notes.txt (modified)
 - **meeting-notes-v2.txt**: 2 lines added
 ```
@@ -694,8 +634,6 @@ binoc diff \
 Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
-
-## Other Changes
 
 - **gamma-renamed.txt**: Moved from outer.zip/inner.zip/gamma.txt
 - **kept-copy.txt**: Copied from kept.txt to kept-copy.txt and outer.zip/kept-copy.txt
@@ -764,8 +702,6 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-## Other Changes
-
 - **data.tsv**: 2 cells changed
 ```
 
@@ -787,8 +723,6 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-## Substantive Changes
-
 - **outer.zip/inner.zip/data.csv**: 1 row added
 ```
 
@@ -809,8 +743,6 @@ binoc diff \
 Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
-
-## Substantive Changes
 
 - **archive.zip/data.txt**: 1 line added, 1 removed
 - **archive.zip/extra.txt**: New file (1 line)

--- a/docs/explanation/vocabulary.md
+++ b/docs/explanation/vocabulary.md
@@ -22,7 +22,7 @@ flowchart LR
     Dispatch[Dispatch descriptors] --> Comparator
     Dispatch --> Transformer
     Fields["action / item_type / tags / details / annotations / summary"] --> IR
-    IR --> Significance[Significance categories]
+    IR --> Significance[Renderer grouping]
 ```
 
 ## Core objects
@@ -71,12 +71,11 @@ See [IR and changesets](ir-and-changesets.md) for the full picture.
 
 | Term | Meaning |
 |---|---|
-| **Clerical** | Changes that are mechanically necessary but semantically unimportant: column reordering, whitespace normalization, encoding changes. |
-| **Substantive** | Changes that alter the information content: added columns, removed rows, schema changes. |
+| **Significance classification** | The historical name for renderer-side grouping: mapping factual tags into user-facing sections in a changelog. |
+| **Clerical / substantive** | Common heading names some teams may choose for grouped Markdown output. They are not built into the IR or shipped as defaults. |
 
-These are the *default* category names in the Markdown renderer; they are not
-baked into the IR. Any renderer or dataset config can define its own
-categories. See [Significance classification](significance-classification.md).
+Any renderer or dataset config can define its own headings and order. See
+[Significance classification](significance-classification.md).
 
 ## Plugin distribution
 

--- a/docs/howto/contribute-to-binoc.md
+++ b/docs/howto/contribute-to-binoc.md
@@ -85,7 +85,7 @@ For focused iteration: `cargo build` or `cargo test -p binoc-core`
 | Fix the controller / dispatch logic | `binoc-core/src/controller.rs`. See [Dispatch model](../explanation/dispatch-model.md). |
 | Fix the CLI | `binoc-cli/src/lib.rs` (the library); `binoc-cli/src/main.rs` is a thin wrapper around `binoc_cli::run()`. |
 | Add a Python API surface | `binoc-python/src/lib.rs` (PyO3) and `binoc-python/python/binoc/__init__.py`. |
-| Change Markdown grouping behavior | `binoc-stdlib/src/renderers/markdown.rs` — `MarkdownRendererConfig` and `render_markdown`. See [Significance classification](../explanation/significance-classification.md). |
+| Change Markdown grouping behavior | `binoc-stdlib/src/renderers/markdown.rs` — `MarkdownRendererConfig`, `MarkdownGroup`, and `render_markdown`. See [Significance classification](../explanation/significance-classification.md). |
 
 ## Test vectors are the cheap contribution
 

--- a/docs/howto/contribute-to-binoc.md
+++ b/docs/howto/contribute-to-binoc.md
@@ -85,7 +85,7 @@ For focused iteration: `cargo build` or `cargo test -p binoc-core`
 | Fix the controller / dispatch logic | `binoc-core/src/controller.rs`. See [Dispatch model](../explanation/dispatch-model.md). |
 | Fix the CLI | `binoc-cli/src/lib.rs` (the library); `binoc-cli/src/main.rs` is a thin wrapper around `binoc_cli::run()`. |
 | Add a Python API surface | `binoc-python/src/lib.rs` (PyO3) and `binoc-python/python/binoc/__init__.py`. |
-| Tune default significance | `binoc-stdlib/src/renderers/markdown.rs` — `default_significance`. See [Significance classification](../explanation/significance-classification.md). |
+| Change Markdown grouping behavior | `binoc-stdlib/src/renderers/markdown.rs` — `MarkdownRendererConfig` and `render_markdown`. See [Significance classification](../explanation/significance-classification.md). |
 
 ## Test vectors are the cheap contribution
 

--- a/docs/howto/diff-two-snapshots.md
+++ b/docs/howto/diff-two-snapshots.md
@@ -35,19 +35,13 @@ For a dataset that ships as a zip of CSVs alongside a SQLite database:
 ```text
 # Changelog: release-q3/ → release-q4/
 
-## Clerical Changes
-
 - **data.zip/agencies.csv**: Columns reordered (content unchanged)
-
-## Substantive Changes
-
 - **summary.sqlite**: Content changed (12.0 KB → 12.0 KB)
 ```
 
-Binoc looked inside the zip and compared the CSV column by column — the
-reorder is flagged as a clerical change (housekeeping), not a real data
-change. The `.sqlite` file is opaque to the standard library, so you
-only learn the bytes differ. To get semantic SQLite diffing, see
+Binoc looked inside the zip and compared the CSV column by column. The
+`.sqlite` file is opaque to the standard library, so you only learn the bytes
+differ. To get semantic SQLite diffing, see
 [Install and use plugins](install-and-use-plugins.md).
 
 ## Choose an output format

--- a/docs/howto/save-and-render-changesets.md
+++ b/docs/howto/save-and-render-changesets.md
@@ -18,7 +18,7 @@ Binoc has two distinct output concepts:
 - **The changeset JSON** is the raw "IR" (intermediate representation) — the structured diff tree.
   It's what `extract`, `changelog`, and downstream pipelines consume.
 - **Rendered outputs** (Markdown today; HTML or others via plugins)
-  are *views* of the changeset. They apply significance classification
+  are *views* of the changeset. They can apply renderer-side grouping
   and format the tree for humans.
 
 `json` is a reserved format name handled by the CLI directly. Every
@@ -133,4 +133,4 @@ and suggests the `format:path` syntax.
 - [Changeset JSON schema](../reference/changeset-schema.md) — the
   contract for anyone consuming the JSON.
 - [Dataset config](../reference/dataset-config.md) — per-renderer
-  config, including significance classification.
+  config, including Markdown grouping.

--- a/docs/howto/write-a-python-comparator.md
+++ b/docs/howto/write-a-python-comparator.md
@@ -101,18 +101,19 @@ distribute, see [Publish a plugin](publish-a-plugin.md).
 ## Classify your tags
 
 Out of the box your custom tags (for example `biobinoc.sequence-changed`)
-fall under "Other Changes" in the Markdown renderer. Teach the
-renderer your classification via
+render in the default flat Markdown list. Teach the renderer your grouping via
 [dataset config](../reference/dataset-config.md):
 
 ```yaml
 output:
   markdown:
-    significance:
-      clerical:
-        - biobinoc.header-change
-      substantive:
-        - biobinoc.sequence-changed
+    groups:
+      - heading: "Substantive changes"
+        tags:
+          - biobinoc.sequence-changed
+      - heading: "Clerical changes"
+        tags:
+          - biobinoc.header-change
 ```
 
 ```python

--- a/docs/howto/write-a-python-renderer.md
+++ b/docs/howto/write-a-python-renderer.md
@@ -120,11 +120,11 @@ def render(self, changesets, config):
 Renderers deserialize their own config — no coordination with core
 required for new knobs.
 
-## Apply significance classification
+## Apply renderer-side grouping
 
-If your renderer wants to group changes by clerical vs. substantive,
-read the significance map from config and look up each node's tags
-against it. The Markdown renderer is the reference; see its source
+If your renderer wants grouped sections, read an ordered `groups` list from
+config and match each node's tags against it. Preserve declared order and let
+the first matching group win. The Markdown renderer is the reference; see its source
 and [Significance classification](../explanation/significance-classification.md)
 for the pattern.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,8 +9,7 @@ audience: anyone
 Binoc generates changelogs for datasets that don't have them. Given a series of
 snapshots of a dataset downloaded at different times, binoc detects what
 changed, expresses those changes as a minimal structured diff, and produces
-human-readable summaries that distinguish substantive policy changes from
-clerical housekeeping.
+human-readable summaries from the resulting changeset.
 
 The core workflow: an archivist, data scientist, or steward has five copies of
 a government dataset containing CSVs, downloaded over two years. Some are
@@ -30,18 +29,13 @@ binoc diff release-q3/ release-q4/
 ```
 # Changelog: release-q3/ → release-q4/
 
-## Clerical Changes
-
 - **data.zip/agencies.csv**: Columns reordered (content unchanged)
-
-## Substantive Changes
-
 - **summary.sqlite**: Content changed (12.0 KB → 12.0 KB)
 ```
 
-Binoc looked inside the zip and compared the CSV column-by-column — the reorder
-is flagged as clerical housekeeping, not a real data change. But `.sqlite` is
-opaque to the standard library, so you only learn that the bytes differ.
+Binoc looked inside the zip and compared the CSV column-by-column. But
+`.sqlite` is opaque to the standard library, so you only learn that the bytes
+differ.
 
 ```bash
 pip install binoc-sqlite
@@ -51,12 +45,7 @@ binoc diff release-q3/ release-q4/
 ```
 # Changelog: release-q3/ → release-q4/
 
-## Clerical Changes
-
 - **data.zip/agencies.csv**: Columns reordered (content unchanged)
-
-## Substantive Changes
-
 - **summary.sqlite/allocations**: 3 rows added (84 → 87 rows)
 ```
 

--- a/docs/reference/changeset-schema.md
+++ b/docs/reference/changeset-schema.md
@@ -22,8 +22,8 @@ from the Rust IR types. The tables below are a rendering of that schema.
 
 ## What is *not* in the changeset
 
-- **Significance classification.** Clerical vs. substantive is a renderer
-  concern, applied at render time from a tag-to-category mapping in config.
+- **Significance classification.** Changelog grouping is a renderer
+  concern, applied at render time from configured headings and tag lists.
   The IR is judgment-free. See
   [Significance classification](../explanation/significance-classification.md).
 - **Transient session data.** `source_items` and `artifacts` are wire-visible

--- a/docs/reference/dataset-config.md
+++ b/docs/reference/dataset-config.md
@@ -5,8 +5,8 @@ audience: anyone authoring a dataset config
 # Dataset config
 
 A *dataset config* is an optional YAML file that tells binoc which
-plugins to run, in what order, and how the renderer should classify
-the resulting tags if you want grouped output. You do not need a config to run `binoc diff` —
+plugins to run, in what order, and how a renderer should present
+the resulting changes if you want grouped output. You do not need a config to run `binoc diff` —
 the defaults handle the built-in comparators. A config becomes
 useful when you want to:
 
@@ -41,15 +41,17 @@ transformers:
 
 output:
   markdown:
-    significance:
-      clerical:
-        - binoc.column-reorder
-        - binoc.whitespace-change
-      substantive:
-        - binoc.column-addition
-        - binoc.column-removal
-        - binoc.row-addition
-        - binoc.content-changed
+    groups:
+      - heading: "Substantive changes"
+        tags:
+          - binoc.column-addition
+          - binoc.column-removal
+          - binoc.row-addition
+          - binoc.content-changed
+      - heading: "Clerical changes"
+        tags:
+          - binoc.column-reorder
+          - binoc.whitespace-change
 ```
 
 Passing this file via `binoc diff A B --config dataset.yaml` (or
@@ -115,32 +117,38 @@ section receives an empty object and applies its own defaults.
 
 The Markdown renderer is the most interesting case today.
 
-### `output.markdown.significance`
+### `output.markdown.groups`
 
-A map from category names (`clerical`, `substantive`, `review-first`, …)
-to lists of tag names. The renderer looks up each tagged node in this map and
-buckets the change under the corresponding heading in the changelog.
+An ordered list of group definitions. Each group has a literal `heading`
+string and a `tags` list. The renderer looks up each tagged node against this
+list and places the change under the first matching heading.
 
 ```yaml
 output:
   markdown:
-    significance:
-      clerical:
-        - binoc.column-reorder
-        - binoc.whitespace-change
-        - bio.header-change        # custom tag from a plugin
-      substantive:
-        - binoc.column-addition
-        - binoc.row-addition
-        - bio.sequence-change      # custom tag from a plugin
+    groups:
+      - heading: "Review first"
+        tags:
+          - bio.cross-contamination
+      - heading: "Substantive changes"
+        tags:
+          - binoc.column-addition
+          - binoc.row-addition
+          - bio.sequence-change      # custom tag from a plugin
+      - heading: "Clerical changes"
+        tags:
+          - binoc.column-reorder
+          - binoc.whitespace-change
+          - bio.header-change        # custom tag from a plugin
 ```
 
-A node with multiple tags is classified by the highest-priority
-match; anything unmapped falls under `Other Changes`. If this map is
-omitted or empty, the default Markdown output is a flat factual list with no
-category headings. This is
+A node with multiple tags goes to the first matching group; declared order is
+both display order and priority order. Anything unmapped falls under
+`Other Changes`, but only when at least one group is configured. If `groups`
+is omitted or empty, the default Markdown output is a flat factual list with
+no section headings. This is
 intentionally a renderer concern, not an IR concern — a single
-changeset can be rendered with different significance mappings for
+changeset can be rendered with different grouping policies for
 different audiences. See
 [Significance classification](../explanation/significance-classification.md)
 and

--- a/docs/reference/dataset-config.md
+++ b/docs/reference/dataset-config.md
@@ -6,13 +6,13 @@ audience: anyone authoring a dataset config
 
 A *dataset config* is an optional YAML file that tells binoc which
 plugins to run, in what order, and how the renderer should classify
-the resulting tags. You do not need a config to run `binoc diff` —
+the resulting tags if you want grouped output. You do not need a config to run `binoc diff` —
 the defaults handle the built-in comparators. A config becomes
 useful when you want to:
 
 - Restrict or reorder the comparator / transformer pipeline.
-- Teach the Markdown renderer that a plugin-specific tag is clerical
-  or substantive for your domain.
+- Teach the Markdown renderer how to group plugin-specific tags for
+  your domain.
 - Configure a renderer's behavior (HTML theme, CI failure rules, …)
   without changing code.
 
@@ -117,8 +117,8 @@ The Markdown renderer is the most interesting case today.
 
 ### `output.markdown.significance`
 
-A map from category names (`clerical`, `substantive`, …) to lists of
-tag names. The renderer looks up each tagged node in this map and
+A map from category names (`clerical`, `substantive`, `review-first`, …)
+to lists of tag names. The renderer looks up each tagged node in this map and
 buckets the change under the corresponding heading in the changelog.
 
 ```yaml
@@ -136,7 +136,9 @@ output:
 ```
 
 A node with multiple tags is classified by the highest-priority
-match; anything unmapped falls under `Other Changes`. This is
+match; anything unmapped falls under `Other Changes`. If this map is
+omitted or empty, the default Markdown output is a flat factual list with no
+category headings. This is
 intentionally a renderer concern, not an IR concern — a single
 changeset can be rendered with different significance mappings for
 different audiences. See

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -32,7 +32,8 @@ You care about contracts, automation, and stable machine-readable output.
   output routing and [Extract changed data](howto/extract-changed-data.md)
   for extracting the underlying changed records.
 - Read [Significance classification](explanation/significance-classification.md)
-  if you need to understand how semantic tags become user-facing severity.
+  if you need to understand how semantic tags become user-facing changelog
+  sections.
 
 ## Plugin developers
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -91,8 +91,6 @@ binoc diff ./test-vectors-materialized/single-file-modify-text/snapshot-a ./test
 ```output
 # Changelog: ./test-vectors-materialized/single-file-modify-text/snapshot-a → ./test-vectors-materialized/single-file-modify-text/snapshot-b
 
-## Substantive Changes
-
 - **story.txt**: 2 lines added, 1 removed
 
 ```
@@ -130,8 +128,6 @@ binoc diff ./test-vectors-materialized/csv-column-reorder/snapshot-a ./test-vect
 ```output
 # Changelog: ./test-vectors-materialized/csv-column-reorder/snapshot-a → ./test-vectors-materialized/csv-column-reorder/snapshot-b
 
-## Clerical Changes
-
 - **data.csv**: Columns reordered (content unchanged)
 
 ```
@@ -150,8 +146,6 @@ binoc diff ./test-vectors-materialized/csv-mixed-changes/snapshot-a ./test-vecto
 ```output
 # Changelog: ./test-vectors-materialized/csv-mixed-changes/snapshot-a → ./test-vectors-materialized/csv-mixed-changes/snapshot-b
 
-## Substantive Changes
-
 - **data.csv**: Column added: 'email'; columns reordered; 1 row added
 
 ```
@@ -169,8 +163,6 @@ binoc diff ./test-vectors-materialized/zip-simple/snapshot-a ./test-vectors-mate
 
 ```output
 # Changelog: ./test-vectors-materialized/zip-simple/snapshot-a → ./test-vectors-materialized/zip-simple/snapshot-b
-
-## Substantive Changes
 
 - **archive.zip/data.txt**: 1 line added, 1 removed
 - **archive.zip/extra.txt**: New file (1 line)
@@ -191,8 +183,6 @@ binoc diff ./docs/examples/fasta-demo/snapshot-a/sequences.fasta ./docs/examples
 
 ```output
 # Changelog: ./docs/examples/fasta-demo/snapshot-a/sequences.fasta → ./docs/examples/fasta-demo/snapshot-b/sequences.fasta
-
-## Substantive Changes
 
 - **sequences.fasta**: Content changed (92 bytes → 102 bytes)
 
@@ -280,8 +270,6 @@ PY
 
 ```output
 # Changelog: ./docs/examples/fasta-demo/snapshot-a/sequences.fasta → ./docs/examples/fasta-demo/snapshot-b/sequences.fasta
-
-## Other Changes
 
 - **sequences.fasta**: Headers updated (2 records); sequences unchanged
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -161,6 +161,7 @@ nav:
       - Architectural decisions:
           # BEGIN-ADR-NAV
           - adr/README.md
+          - 'Markdown Renderer Groups Replace Significance-Map Grouping': adr/2026-06-02-renderer_groups.md
           - 'Diagnostics Channel for Non-Fatal Warnings and Suggestions': adr/2026-06-01-diagnostics_channel.md
           - 'Rename-and-modify detection: fuzzy correlation + transformer-initiated re-dispatch': adr/rename_modify_detection.md
           - 'Documentation Platform and Information Design': adr/2026-04-17-documentation_platform_and_info_design.md

--- a/model-plugins/binoc-row-reorder/test-vectors/csv-row-reorder/expected-output/changelog.snap
+++ b/model-plugins/binoc-row-reorder/test-vectors/csv-row-reorder/expected-output/changelog.snap
@@ -4,6 +4,4 @@ expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
 
-## Other Changes
-
 - **data.csv**: Rows reordered (same data, different sort order)

--- a/model-plugins/binoc-sqlite/test-vectors/sqlite-row-addition/expected-output/changelog.snap
+++ b/model-plugins/binoc-sqlite/test-vectors/sqlite-row-addition/expected-output/changelog.snap
@@ -4,6 +4,4 @@ expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
 
-## Substantive Changes
-
 - **data.sqlite/users**: 1 row added (1 → 2 rows)

--- a/model-plugins/binoc-sqlite/test-vectors/sqlite-row-addition/manifest.toml
+++ b/model-plugins/binoc-sqlite/test-vectors/sqlite-row-addition/manifest.toml
@@ -6,4 +6,3 @@ tags = ["sqlite", "row-addition"]
 [expected]
 root_kind = "modify"
 has_tags = ["binoc-sqlite.row-addition", "binoc.row-addition"]
-significance = "substantive"

--- a/model-plugins/binoc-sqlite/test-vectors/sqlite-table-addition/expected-output/changelog.snap
+++ b/model-plugins/binoc-sqlite/test-vectors/sqlite-table-addition/expected-output/changelog.snap
@@ -4,6 +4,4 @@ expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
 
-## Substantive Changes
-
 - **data.sqlite/posts**: Table added (3 columns, 1 row)

--- a/model-plugins/binoc-sqlite/test-vectors/sqlite-table-addition/manifest.toml
+++ b/model-plugins/binoc-sqlite/test-vectors/sqlite-table-addition/manifest.toml
@@ -6,4 +6,3 @@ tags = ["sqlite", "table-addition"]
 [expected]
 root_kind = "modify"
 has_tags = ["binoc-sqlite.table-addition", "binoc.schema-change"]
-significance = "substantive"

--- a/model-plugins/binoc-sqlite/test-vectors/without-plugin/expected-output/changelog.snap
+++ b/model-plugins/binoc-sqlite/test-vectors/without-plugin/expected-output/changelog.snap
@@ -4,8 +4,6 @@ expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
 
-## Substantive Changes
-
 - **data.sqlite**: Content changed (8.0 KB → 8.0 KB)
 
 ## Suggestions

--- a/scripts/build_changeset_schema_page.py
+++ b/scripts/build_changeset_schema_page.py
@@ -64,8 +64,8 @@ from the Rust IR types. The tables below are a rendering of that schema.
 
 ## What is *not* in the changeset
 
-- **Significance classification.** Clerical vs. substantive is a renderer
-  concern, applied at render time from a tag-to-category mapping in config.
+- **Significance classification.** Changelog grouping is a renderer
+  concern, applied at render time from configured headings and tag lists.
   The IR is judgment-free. See
   [Significance classification](../explanation/significance-classification.md).
 - **Transient session data.** `source_items` and `artifacts` are wire-visible

--- a/test-vectors/binary-fallback-diagnostic/expected-output/changelog.snap
+++ b/test-vectors/binary-fallback-diagnostic/expected-output/changelog.snap
@@ -4,8 +4,6 @@ expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
 
-## Substantive Changes
-
 - **data.parquet**: Content changed (7 bytes → 7 bytes)
 
 ## Suggestions

--- a/test-vectors/csv-cell-changes/expected-output/changelog.snap
+++ b/test-vectors/csv-cell-changes/expected-output/changelog.snap
@@ -1,9 +1,7 @@
 ---
-source: binoc-stdlib/tests/test_vectors.rs
+source: binoc-stdlib/src/test_vectors.rs
 expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
-
-## Other Changes
 
 - **data.csv**: 2 cells changed

--- a/test-vectors/csv-column-addition/expected-output/changelog.snap
+++ b/test-vectors/csv-column-addition/expected-output/changelog.snap
@@ -1,9 +1,7 @@
 ---
-source: binoc-stdlib/tests/test_vectors.rs
+source: binoc-stdlib/src/test_vectors.rs
 expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
-
-## Substantive Changes
 
 - **data.csv**: Column added: 'email'

--- a/test-vectors/csv-column-removal/expected-output/changelog.snap
+++ b/test-vectors/csv-column-removal/expected-output/changelog.snap
@@ -1,9 +1,7 @@
 ---
-source: binoc-stdlib/tests/test_vectors.rs
+source: binoc-stdlib/src/test_vectors.rs
 expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
-
-## Substantive Changes
 
 - **data.csv**: Column removed: 'city'

--- a/test-vectors/csv-column-reorder/expected-output/changelog.snap
+++ b/test-vectors/csv-column-reorder/expected-output/changelog.snap
@@ -1,9 +1,7 @@
 ---
-source: binoc-stdlib/tests/test_vectors.rs
+source: binoc-stdlib/src/test_vectors.rs
 expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
-
-## Clerical Changes
 
 - **data.csv**: Columns reordered (content unchanged)

--- a/test-vectors/csv-column-reorder/manifest.toml
+++ b/test-vectors/csv-column-reorder/manifest.toml
@@ -11,4 +11,3 @@ transformers = ["binoc.tabular_analyzer", "binoc.column_reorder_detector"]
 root_kind = "modify"
 child_count = 1
 has_tags = ["binoc.column-reorder"]
-significance = "clerical"

--- a/test-vectors/csv-mixed-changes/expected-output/changelog.snap
+++ b/test-vectors/csv-mixed-changes/expected-output/changelog.snap
@@ -1,9 +1,7 @@
 ---
-source: binoc-stdlib/tests/test_vectors.rs
+source: binoc-stdlib/src/test_vectors.rs
 expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
-
-## Substantive Changes
 
 - **data.csv**: Column added: 'email'; columns reordered; 1 row added

--- a/test-vectors/csv-rename-modify/expected-output/changelog.snap
+++ b/test-vectors/csv-rename-modify/expected-output/changelog.snap
@@ -1,11 +1,8 @@
 ---
 source: binoc-stdlib/src/test_vectors.rs
-assertion_line: 478
 expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
-
-## Substantive Changes
 
 - **data_v2.csv**: Moved from data.csv (modified)
 - **data_v2.csv**: Column added: 'email'

--- a/test-vectors/csv-row-addition/expected-output/changelog.snap
+++ b/test-vectors/csv-row-addition/expected-output/changelog.snap
@@ -1,9 +1,7 @@
 ---
-source: binoc-stdlib/tests/test_vectors.rs
+source: binoc-stdlib/src/test_vectors.rs
 expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
-
-## Substantive Changes
 
 - **data.csv**: 2 rows added

--- a/test-vectors/csv-row-removal/expected-output/changelog.snap
+++ b/test-vectors/csv-row-removal/expected-output/changelog.snap
@@ -4,6 +4,4 @@ expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
 
-## Substantive Changes
-
 - **data.csv**: 2 rows removed

--- a/test-vectors/directory-file-copy/expected-output/changelog.snap
+++ b/test-vectors/directory-file-copy/expected-output/changelog.snap
@@ -1,9 +1,7 @@
 ---
-source: binoc-stdlib/tests/test_vectors.rs
+source: binoc-stdlib/src/test_vectors.rs
 expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
-
-## Other Changes
 
 - **duplicate.txt**: Copied from original.txt

--- a/test-vectors/directory-nested-with-tar/expected-output/changelog.snap
+++ b/test-vectors/directory-nested-with-tar/expected-output/changelog.snap
@@ -4,10 +4,5 @@ expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
 
-## Substantive Changes
-
 - **data/records.csv**: 1 row added
-
-## Other Changes
-
 - **data.tar.gz/records.csv**: 1 cell changed

--- a/test-vectors/directory-nested/expected-output/changelog.snap
+++ b/test-vectors/directory-nested/expected-output/changelog.snap
@@ -4,8 +4,6 @@ expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
 
-## Substantive Changes
-
 - **data/extra.csv**: New table (2 columns, 1 rows)
 - **data/records.csv**: 1 row added
 - **docs/readme.txt**: 2 lines added, 1 removed

--- a/test-vectors/folder-move-nested/expected-output/changelog.snap
+++ b/test-vectors/folder-move-nested/expected-output/changelog.snap
@@ -4,6 +4,4 @@ expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
 
-## Other Changes
-
 - **documentation**: Folder moved from docs

--- a/test-vectors/folder-move-partial/expected-output/changelog.snap
+++ b/test-vectors/folder-move-partial/expected-output/changelog.snap
@@ -4,12 +4,7 @@ expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
 
-## Substantive Changes
-
+- **FoodData_Central_csv_2026-04-30**: Folder moved from FoodData_Central_csv_2,025-12-18
 - **FoodData_Central_csv_2026-04-30/data/new-table.csv**: New table (2 columns, 1 rows)
 - **FoodData_Central_csv_2026-04-30/docs/modified.txt**: Text modified
 - **FoodData_Central_csv_2026-04-30/docs/old-table.txt**: File removed (1 line)
-
-## Other Changes
-
-- **FoodData_Central_csv_2026-04-30**: Folder moved from FoodData_Central_csv_2,025-12-18

--- a/test-vectors/kitchen-sink/expected-output/changelog.snap
+++ b/test-vectors/kitchen-sink/expected-output/changelog.snap
@@ -1,27 +1,18 @@
 ---
 source: binoc-stdlib/src/test_vectors.rs
-assertion_line: 472
 expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
 
-## Clerical Changes
-
-- **metrics.csv**: Columns reordered (content unchanged)
-
-## Substantive Changes
-
 - **archive.tar.gz/inventory.csv**: 1 row added
 - **bundle.zip/notes.txt**: 2 lines added, 1 removed
+- **data.csv**: 2 cells changed
 - **docs/new-file.txt**: New file (1 line)
 - **docs/old-notes.txt**: File removed (1 line)
 - **docs/readme.txt**: 2 lines added, 2 removed
 - **icon.bin**: Content changed (19 bytes → 19 bytes)
-
-## Other Changes
-
-- **data.csv**: 2 cells changed
 - **license-copy.txt**: Copied from license.txt
+- **metrics.csv**: Columns reordered (content unchanged)
 - **summary.txt**: Moved from report.txt
 
 ## Suggestions

--- a/test-vectors/single-file-add/expected-output/changelog.snap
+++ b/test-vectors/single-file-add/expected-output/changelog.snap
@@ -1,9 +1,7 @@
 ---
-source: binoc-stdlib/tests/test_vectors.rs
+source: binoc-stdlib/src/test_vectors.rs
 expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
-
-## Substantive Changes
 
 - **new_file.txt**: New file (1 line)

--- a/test-vectors/single-file-modify-binary/expected-output/changelog.snap
+++ b/test-vectors/single-file-modify-binary/expected-output/changelog.snap
@@ -1,11 +1,8 @@
 ---
 source: binoc-stdlib/src/test_vectors.rs
-assertion_line: 472
 expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
-
-## Substantive Changes
 
 - **data.bin**: Content changed (4 bytes → 4 bytes)
 

--- a/test-vectors/single-file-modify-csv/expected-output/changelog.snap
+++ b/test-vectors/single-file-modify-csv/expected-output/changelog.snap
@@ -4,6 +4,4 @@ expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
 
-## Substantive Changes
-
 - **data.csv**: 1 row added

--- a/test-vectors/single-file-modify-text-root/expected-output/changelog.snap
+++ b/test-vectors/single-file-modify-text-root/expected-output/changelog.snap
@@ -4,6 +4,4 @@ expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
 
-## Substantive Changes
-
 - **story.txt**: 2 lines added, 1 removed

--- a/test-vectors/single-file-modify-text/expected-output/changelog.snap
+++ b/test-vectors/single-file-modify-text/expected-output/changelog.snap
@@ -1,9 +1,7 @@
 ---
-source: binoc-stdlib/tests/test_vectors.rs
+source: binoc-stdlib/src/test_vectors.rs
 expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
-
-## Substantive Changes
 
 - **story.txt**: 2 lines added, 1 removed

--- a/test-vectors/single-file-remove/expected-output/changelog.snap
+++ b/test-vectors/single-file-remove/expected-output/changelog.snap
@@ -1,9 +1,7 @@
 ---
-source: binoc-stdlib/tests/test_vectors.rs
+source: binoc-stdlib/src/test_vectors.rs
 expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
-
-## Substantive Changes
 
 - **removed_file.txt**: File removed (1 line)

--- a/test-vectors/tar-nested/expected-output/changelog.snap
+++ b/test-vectors/tar-nested/expected-output/changelog.snap
@@ -4,6 +4,4 @@ expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
 
-## Substantive Changes
-
 - **outer.tar.gz/inner.tar.gz/data.csv**: 1 row added

--- a/test-vectors/tar-simple/expected-output/changelog.snap
+++ b/test-vectors/tar-simple/expected-output/changelog.snap
@@ -4,7 +4,5 @@ expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
 
-## Substantive Changes
-
 - **archive.tar.gz/data.csv**: 1 row added
 - **archive.tar.gz/hello.txt**: 1 line added

--- a/test-vectors/text-rename-modify/expected-output/changelog.snap
+++ b/test-vectors/text-rename-modify/expected-output/changelog.snap
@@ -1,11 +1,8 @@
 ---
 source: binoc-stdlib/src/test_vectors.rs
-assertion_line: 478
 expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
-
-## Substantive Changes
 
 - **meeting-notes-v2.txt**: Moved from notes.txt (modified)
 - **meeting-notes-v2.txt**: 2 lines added

--- a/test-vectors/tree-wide-correlation/expected-output/changelog.snap
+++ b/test-vectors/tree-wide-correlation/expected-output/changelog.snap
@@ -4,8 +4,6 @@ expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
 
-## Other Changes
-
 - **gamma-renamed.txt**: Moved from outer.zip/inner.zip/gamma.txt
 - **kept-copy.txt**: Copied from kept.txt to kept-copy.txt and outer.zip/kept-copy.txt
 - **merged.bin**: Moved from dup.bin and dup-b.bin

--- a/test-vectors/tsv-cell-changes/expected-output/changelog.snap
+++ b/test-vectors/tsv-cell-changes/expected-output/changelog.snap
@@ -4,6 +4,4 @@ expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
 
-## Other Changes
-
 - **data.tsv**: 2 cells changed

--- a/test-vectors/zip-nested/expected-output/changelog.snap
+++ b/test-vectors/zip-nested/expected-output/changelog.snap
@@ -1,9 +1,7 @@
 ---
-source: binoc-stdlib/tests/test_vectors.rs
+source: binoc-stdlib/src/test_vectors.rs
 expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
-
-## Substantive Changes
 
 - **outer.zip/inner.zip/data.csv**: 1 row added

--- a/test-vectors/zip-simple/expected-output/changelog.snap
+++ b/test-vectors/zip-simple/expected-output/changelog.snap
@@ -1,10 +1,8 @@
 ---
-source: binoc-stdlib/tests/test_vectors.rs
+source: binoc-stdlib/src/test_vectors.rs
 expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
-
-## Substantive Changes
 
 - **archive.zip/data.txt**: 1 line added, 1 removed
 - **archive.zip/extra.txt**: New file (1 line)


### PR DESCRIPTION
- remove built-in clerical/substantive grouping from the default Markdown renderer
- replace the Markdown significance map with ordered, opt-in groups using literal headings
- update docs, ADRs, and default-output snapshots for flat Markdown output

Follow ons will need to add a test vector (in addition to existing unit tests) and root out the word "significance" in some remaining places.

Closes #53