### PR TITLE
Add examples to markdown for tabular cell changes, with controllable verbosity

### DIFF
--- a/binoc-sdk/src/ir.rs
+++ b/binoc-sdk/src/ir.rs
@@ -96,6 +96,12 @@ pub struct DiffNode {
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub details: BTreeMap<String, serde_json::Value>,
 
+    /// Renderer-visible, structured evidence blocks. Comparators and
+    /// transformers populate these with bounded examples while they still have
+    /// domain knowledge; renderers decide how much to display.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub detail_blocks: Vec<DetailBlock>,
+
     /// Transformer-added metadata.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub annotations: BTreeMap<String, serde_json::Value>,
@@ -160,6 +166,7 @@ impl DiffNode {
             tags: BTreeSet::new(),
             children: Vec::new(),
             details: BTreeMap::new(),
+            detail_blocks: Vec::new(),
             annotations: BTreeMap::new(),
             comparator: None,
             transformed_by: Vec::new(),
@@ -187,6 +194,11 @@ impl DiffNode {
 
     pub fn with_children(mut self, children: Vec<DiffNode>) -> Self {
         self.children = children;
+        self
+    }
+
+    pub fn with_detail_block(mut self, block: DetailBlock) -> Self {
+        self.detail_blocks.push(block);
         self
     }
 
@@ -254,6 +266,135 @@ impl DiffNode {
         for child in &mut self.children {
             child.strip_transient();
         }
+    }
+}
+
+/// Renderer-visible, bounded evidence attached to a diff node.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct DetailBlock {
+    /// Stable within this node, for anchors and extract selection.
+    pub id: String,
+    /// Open, namespaced kind such as `binoc.tabular.cell_changes.v1`.
+    pub kind: String,
+    /// Short renderer-facing label.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    /// Total matching items if known, including omitted examples.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub total_count: Option<u64>,
+    /// Captured examples for inline rendering.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub examples: Vec<DetailExample>,
+    /// Named extract aspects for exhaustive retrieval.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub extract: Vec<ExtractHint>,
+    /// Whether the producer truncated capture before exhausting candidates.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub truncated: bool,
+}
+
+impl DetailBlock {
+    pub fn new(id: impl Into<String>, kind: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            kind: kind.into(),
+            label: None,
+            total_count: None,
+            examples: Vec::new(),
+            extract: Vec::new(),
+            truncated: false,
+        }
+    }
+
+    pub fn with_label(mut self, label: impl Into<String>) -> Self {
+        self.label = Some(label.into());
+        self
+    }
+
+    pub fn with_total_count(mut self, total_count: u64) -> Self {
+        self.total_count = Some(total_count);
+        self
+    }
+
+    pub fn with_example(mut self, example: DetailExample) -> Self {
+        self.examples.push(example);
+        self
+    }
+
+    pub fn with_extract_hint(mut self, hint: ExtractHint) -> Self {
+        self.extract.push(hint);
+        self
+    }
+}
+
+/// One bounded example inside a detail block.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct DetailExample {
+    /// Structured locator such as row/column, line range, or key path.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub locator: BTreeMap<String, serde_json::Value>,
+    /// Value before the change, if present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub before: Option<ValuePreview>,
+    /// Value after the change, if present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub after: Option<ValuePreview>,
+    /// Domain-specific structured context.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub fields: BTreeMap<String, serde_json::Value>,
+}
+
+impl DetailExample {
+    pub fn new() -> Self {
+        Self {
+            locator: BTreeMap::new(),
+            before: None,
+            after: None,
+            fields: BTreeMap::new(),
+        }
+    }
+}
+
+impl Default for DetailExample {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A bounded preview of one value in a detail example.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct ValuePreview {
+    pub value: serde_json::Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub media_type: Option<String>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub truncated: bool,
+}
+
+/// Pointer to an extract aspect that can return exhaustive content.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct ExtractHint {
+    /// Aspect name accepted by `binoc extract`.
+    pub aspect: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+}
+
+impl ExtractHint {
+    pub fn new(aspect: impl Into<String>) -> Self {
+        Self {
+            aspect: aspect.into(),
+            label: None,
+        }
+    }
+
+    pub fn with_label(mut self, label: impl Into<String>) -> Self {
+        self.label = Some(label.into());
+        self
     }
 }
 
@@ -335,6 +476,7 @@ mod tests {
         assert!(node.tags.is_empty());
         assert!(node.children.is_empty());
         assert!(node.details.is_empty());
+        assert!(node.detail_blocks.is_empty());
         assert!(node.annotations.is_empty());
     }
 
@@ -355,6 +497,7 @@ mod tests {
             node.details.get("lines_changed"),
             Some(&serde_json::json!(42))
         );
+        assert!(node.detail_blocks.is_empty());
         assert_eq!(node.children.len(), 1);
         assert_eq!(node.children[0].path, "child.txt");
         assert_eq!(node.source_path.as_deref(), Some("old/dir"));
@@ -402,6 +545,31 @@ mod tests {
         let node = DiffNode::new("move", "file", "new/path.csv")
             .with_tag("binoc.move")
             .with_detail("distance", serde_json::json!(10))
+            .with_detail_block(
+                DetailBlock::new("changed_cells", "binoc.tabular.cell_changes.v1")
+                    .with_label("Changed cells")
+                    .with_total_count(1)
+                    .with_example(DetailExample {
+                        locator: BTreeMap::from([
+                            ("row".into(), serde_json::json!(1)),
+                            ("column".into(), serde_json::json!("status")),
+                        ]),
+                        before: Some(ValuePreview {
+                            value: serde_json::json!("draft"),
+                            media_type: Some("text/plain".into()),
+                            truncated: false,
+                        }),
+                        after: Some(ValuePreview {
+                            value: serde_json::json!("published"),
+                            media_type: Some("text/plain".into()),
+                            truncated: false,
+                        }),
+                        fields: BTreeMap::new(),
+                    })
+                    .with_extract_hint(
+                        ExtractHint::new("cells_changed").with_label("All changed cells"),
+                    ),
+            )
             .with_source_path("old/path.csv");
         let json = serde_json::to_string(&node).unwrap();
         let restored: DiffNode = serde_json::from_str(&json).unwrap();
@@ -411,6 +579,8 @@ mod tests {
         assert_eq!(node.source_path, restored.source_path);
         assert_eq!(node.tags, restored.tags);
         assert_eq!(node.details, restored.details);
+        assert_eq!(restored.detail_blocks.len(), 1);
+        assert_eq!(restored.detail_blocks[0].examples.len(), 1);
     }
 
     #[test]

--- a/binoc-sdk/src/lib.rs
+++ b/binoc-sdk/src/lib.rs
@@ -8,7 +8,10 @@ pub mod types;
 pub mod test_support;
 
 pub use data_access::LocalDataAccess;
-pub use ir::{Changeset, Diagnostic, DiagnosticSeverity, DiffNode};
+pub use ir::{
+    Changeset, DetailBlock, DetailExample, Diagnostic, DiagnosticSeverity, DiffNode, ExtractHint,
+    ValuePreview,
+};
 pub use traits::*;
 pub use types::*;
 

--- a/binoc-stdlib/src/renderers/markdown.rs
+++ b/binoc-stdlib/src/renderers/markdown.rs
@@ -10,10 +10,29 @@ pub struct MarkdownGroup {
     pub tags: Vec<String>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum Verbosity {
+    Summary,
+    #[default]
+    Examples,
+    Full,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MarkdownRendererConfig {
     #[serde(default)]
     pub groups: Vec<MarkdownGroup>,
+    #[serde(default)]
+    pub verbosity: Verbosity,
+    #[serde(default = "default_max_examples_per_block")]
+    pub max_examples_per_block: usize,
+    #[serde(default = "default_max_detail_blocks_per_node")]
+    pub max_detail_blocks_per_node: usize,
+    #[serde(default = "default_max_value_chars")]
+    pub max_value_chars: usize,
+    #[serde(default = "default_max_rendered_detail_bytes")]
+    pub max_rendered_detail_bytes: usize,
     #[serde(default = "default_max_diagnostics")]
     pub max_diagnostics: usize,
 }
@@ -22,9 +41,30 @@ impl Default for MarkdownRendererConfig {
     fn default() -> Self {
         Self {
             groups: Vec::new(),
+            verbosity: Verbosity::Examples,
+            max_examples_per_block: default_max_examples_per_block(),
+            max_detail_blocks_per_node: default_max_detail_blocks_per_node(),
+            max_value_chars: default_max_value_chars(),
+            max_rendered_detail_bytes: default_max_rendered_detail_bytes(),
             max_diagnostics: default_max_diagnostics(),
         }
     }
+}
+
+fn default_max_examples_per_block() -> usize {
+    3
+}
+
+fn default_max_detail_blocks_per_node() -> usize {
+    4
+}
+
+fn default_max_value_chars() -> usize {
+    160
+}
+
+fn default_max_rendered_detail_bytes() -> usize {
+    200_000
 }
 
 fn default_max_diagnostics() -> usize {
@@ -47,6 +87,7 @@ impl Renderer for MarkdownRenderer {
 
 pub fn render_markdown(changesets: &[Changeset], config: &MarkdownRendererConfig) -> String {
     let mut out = String::new();
+    let mut detail_budget = DetailBudget::new(config.max_rendered_detail_bytes);
 
     for changeset in changesets {
         out.push_str(&format!(
@@ -62,14 +103,14 @@ pub fn render_markdown(changesets: &[Changeset], config: &MarkdownRendererConfig
 
             if config.groups.is_empty() {
                 for node in &uncategorized {
-                    format_node(&mut out, node);
+                    format_node(&mut out, node, config, &mut detail_budget);
                 }
                 out.push('\n');
             } else {
                 for (group, nodes) in config.groups.iter().zip(by_group.iter()) {
                     out.push_str(&format!("## {}\n\n", group.heading));
                     for node in nodes {
-                        format_node(&mut out, node);
+                        format_node(&mut out, node, config, &mut detail_budget);
                     }
                     out.push('\n');
                 }
@@ -77,7 +118,7 @@ pub fn render_markdown(changesets: &[Changeset], config: &MarkdownRendererConfig
                 if !uncategorized.is_empty() {
                     out.push_str("## Other Changes\n\n");
                     for node in &uncategorized {
-                        format_node(&mut out, node);
+                        format_node(&mut out, node, config, &mut detail_budget);
                     }
                     out.push('\n');
                 }
@@ -219,7 +260,12 @@ fn collect_reportable_nodes<'a>(
     }
 }
 
-fn format_node(out: &mut String, node: &DiffNode) {
+fn format_node(
+    out: &mut String,
+    node: &DiffNode,
+    config: &MarkdownRendererConfig,
+    detail_budget: &mut DetailBudget,
+) {
     let path = if node.path.is_empty() {
         "(root)"
     } else {
@@ -245,6 +291,8 @@ fn format_node(out: &mut String, node: &DiffNode) {
             out.push_str(&format!("- **{path}**: {}\n", humanize_numbers(&detail)));
         }
     }
+
+    render_detail_blocks(out, node, path, config, detail_budget);
 }
 
 fn should_group_move_children(node: &DiffNode) -> bool {
@@ -317,6 +365,205 @@ fn fallback_description(node: &DiffNode) -> String {
         }
         "reorder" => format!("{} reordered", capitalize(item_type)),
         _ => format!("{action} ({item_type})"),
+    }
+}
+
+fn render_detail_blocks(
+    out: &mut String,
+    node: &DiffNode,
+    path: &str,
+    config: &MarkdownRendererConfig,
+    detail_budget: &mut DetailBudget,
+) {
+    if config.verbosity == Verbosity::Summary || node.detail_blocks.is_empty() {
+        return;
+    }
+
+    let block_limit = if config.verbosity == Verbosity::Full {
+        node.detail_blocks.len()
+    } else {
+        node.detail_blocks
+            .len()
+            .min(config.max_detail_blocks_per_node)
+    };
+    for block in node.detail_blocks.iter().take(block_limit) {
+        let example_limit = if config.verbosity == Verbosity::Full {
+            block.examples.len()
+        } else {
+            block.examples.len().min(config.max_examples_per_block)
+        };
+        if example_limit == 0 && block.examples.is_empty() && block.extract.is_empty() {
+            continue;
+        }
+
+        let shown = example_limit as u64;
+        let total = block.total_count.unwrap_or(block.examples.len() as u64);
+        let omitted_by_renderer = shown < block.examples.len() as u64
+            || (config.verbosity != Verbosity::Full
+                && node.detail_blocks.len() > config.max_detail_blocks_per_node);
+        let truncated = block.truncated || omitted_by_renderer || shown < total;
+
+        let mut header = block.label.clone().unwrap_or_else(|| block.id.clone());
+        if truncated {
+            if shown == 0 && block.examples.is_empty() && total > 0 {
+                header.push_str(&format!(" ({total} total)"));
+            } else if total > 0 {
+                header.push_str(&format!(" (showing {shown} of {total})"));
+            } else {
+                header.push_str(&format!(" (showing {shown})"));
+            }
+        }
+        if let Some(extract) = block.extract.first() {
+            let label = extract
+                .label
+                .as_deref()
+                .unwrap_or("all matching data")
+                .to_lowercase();
+            header.push_str(&format!(
+                "; use `binoc extract CHANGESET \"{path}\" {}` for {label}",
+                extract.aspect
+            ));
+        }
+
+        if !detail_budget.push_line(out, format!("  - {header}\n")) {
+            return;
+        }
+
+        for example in block.examples.iter().take(example_limit) {
+            let line = format_detail_example(block, example, config);
+            if !detail_budget.push_line(out, format!("    - {line}\n")) {
+                return;
+            }
+        }
+    }
+}
+
+fn format_detail_example(
+    block: &DetailBlock,
+    example: &DetailExample,
+    config: &MarkdownRendererConfig,
+) -> String {
+    if block.kind == "binoc.tabular.cell_changes.v1" {
+        return format_tabular_cell_example(example, config);
+    }
+
+    let locator = if example.locator.is_empty() {
+        None
+    } else {
+        Some(compact_json_map(&example.locator))
+    };
+    let before = example
+        .before
+        .as_ref()
+        .map(|v| format_value_preview(v, config));
+    let after = example
+        .after
+        .as_ref()
+        .map(|v| format_value_preview(v, config));
+
+    match (locator, before, after) {
+        (Some(locator), Some(before), Some(after)) => format!("{locator}: {before} -> {after}"),
+        (Some(locator), None, Some(after)) => format!("{locator}: -> {after}"),
+        (Some(locator), Some(before), None) => format!("{locator}: {before} ->"),
+        (Some(locator), None, None) => locator,
+        (None, Some(before), Some(after)) => format!("{before} -> {after}"),
+        (None, None, Some(after)) => format!("-> {after}"),
+        (None, Some(before), None) => format!("{before} ->"),
+        (None, None, None) => "example".into(),
+    }
+}
+
+fn format_tabular_cell_example(example: &DetailExample, config: &MarkdownRendererConfig) -> String {
+    let row = example
+        .locator
+        .get("row")
+        .and_then(|value| value.as_u64())
+        .map(|row| row + 1)
+        .map(|row| format!("row {row}"));
+    let column = example
+        .locator
+        .get("column")
+        .and_then(|value| value.as_str())
+        .map(|column| {
+            format!(
+                "column '{}'",
+                truncate_text(column, config.max_value_chars).0
+            )
+        });
+    let locator = match (row, column) {
+        (Some(row), Some(column)) => format!("{row}, {column}"),
+        (Some(row), None) => row,
+        (None, Some(column)) => column,
+        (None, None) => "cell".into(),
+    };
+    let before = example
+        .before
+        .as_ref()
+        .map(|v| format_value_preview(v, config))
+        .unwrap_or_else(|| "(none)".into());
+    let after = example
+        .after
+        .as_ref()
+        .map(|v| format_value_preview(v, config))
+        .unwrap_or_else(|| "(none)".into());
+    format!("{locator}: {before} -> {after}")
+}
+
+fn format_value_preview(value: &ValuePreview, config: &MarkdownRendererConfig) -> String {
+    match &value.value {
+        serde_json::Value::String(text) => {
+            let (truncated_text, render_truncated) = truncate_text(text, config.max_value_chars);
+            let mut rendered = format!("'{}'", truncated_text.replace('\'', "\\'"));
+            if value.truncated || render_truncated {
+                rendered.push_str("...");
+            }
+            rendered
+        }
+        other => {
+            let raw = serde_json::to_string(other).unwrap_or_else(|_| "null".into());
+            let (truncated, render_truncated) = truncate_text(&raw, config.max_value_chars);
+            if value.truncated || render_truncated {
+                format!("{truncated}...")
+            } else {
+                truncated
+            }
+        }
+    }
+}
+
+fn truncate_text(input: &str, max_chars: usize) -> (String, bool) {
+    if input.chars().count() <= max_chars {
+        return (input.to_string(), false);
+    }
+    (input.chars().take(max_chars).collect(), true)
+}
+
+fn compact_json_map(map: &BTreeMap<String, serde_json::Value>) -> String {
+    serde_json::to_string(map).unwrap_or_else(|_| "{}".into())
+}
+
+struct DetailBudget {
+    remaining_bytes: usize,
+}
+
+impl DetailBudget {
+    fn new(max_bytes: usize) -> Self {
+        Self {
+            remaining_bytes: max_bytes,
+        }
+    }
+
+    fn push_line(&mut self, out: &mut String, line: String) -> bool {
+        if line.len() > self.remaining_bytes {
+            if self.remaining_bytes > 0 {
+                out.push_str("  - Additional detail omitted (renderer detail budget reached)\n");
+                self.remaining_bytes = 0;
+            }
+            return false;
+        }
+        self.remaining_bytes -= line.len();
+        out.push_str(&line);
+        true
     }
 }
 
@@ -695,5 +942,116 @@ mod tests {
         let config = MarkdownRendererConfig::default();
         let md = render_markdown(&[changeset], &config);
         assert!(md.contains("5,975 rows added; 18,133,333 cells changed"));
+    }
+
+    #[test]
+    fn summary_verbosity_hides_detail_blocks() {
+        let changeset = Changeset::new(
+            "v1",
+            "v2",
+            Some(
+                DiffNode::new("modify", "tabular", "data.csv")
+                    .with_summary("2 cells changed")
+                    .with_detail_block(sample_detail_block(2)),
+            ),
+        );
+        let config = MarkdownRendererConfig {
+            verbosity: Verbosity::Summary,
+            ..Default::default()
+        };
+        let md = render_markdown(&[changeset], &config);
+        assert!(md.contains("- **data.csv**: 2 cells changed"));
+        assert!(!md.contains("Changed cells"));
+        assert!(!md.contains("binoc extract"));
+    }
+
+    #[test]
+    fn examples_verbosity_renders_capped_tabular_examples() {
+        let changeset = Changeset::new(
+            "v1",
+            "v2",
+            Some(
+                DiffNode::new("modify", "tabular", "data.csv")
+                    .with_summary("4 cells changed")
+                    .with_detail_block(sample_detail_block(4)),
+            ),
+        );
+        let config = MarkdownRendererConfig {
+            verbosity: Verbosity::Examples,
+            max_examples_per_block: 2,
+            ..Default::default()
+        };
+        let md = render_markdown(&[changeset], &config);
+        assert!(md.contains("Changed cells (showing 2 of 4); use `binoc extract CHANGESET \"data.csv\" cells_changed` for all changed cells"));
+        assert!(md.contains("row 1, column 'score': '10' -> '12'"));
+        assert!(md.contains("row 2, column 'score': '20' -> '22'"));
+        assert!(!md.contains("row 3, column 'score': '30' -> '32'"));
+    }
+
+    #[test]
+    fn examples_verbosity_renders_extract_only_detail_blocks() {
+        let block = DetailBlock::new("cells_changed", "binoc.tabular.cell_changes.v1")
+            .with_label("Changed cells")
+            .with_total_count(4)
+            .with_extract_hint(ExtractHint::new("cells_changed").with_label("All changed cells"));
+        let changeset = Changeset::new(
+            "v1",
+            "v2",
+            Some(
+                DiffNode::new("modify", "tabular", "large.csv")
+                    .with_summary("4 cells changed")
+                    .with_detail_block(block),
+            ),
+        );
+
+        let md = render_markdown(&[changeset], &MarkdownRendererConfig::default());
+        assert!(md.contains("Changed cells (4 total); use `binoc extract CHANGESET \"large.csv\" cells_changed` for all changed cells"));
+    }
+
+    #[test]
+    fn full_verbosity_renders_all_captured_examples() {
+        let changeset = Changeset::new(
+            "v1",
+            "v2",
+            Some(
+                DiffNode::new("modify", "tabular", "data.csv")
+                    .with_summary("4 cells changed")
+                    .with_detail_block(sample_detail_block(4)),
+            ),
+        );
+        let config = MarkdownRendererConfig {
+            verbosity: Verbosity::Full,
+            max_examples_per_block: 1,
+            ..Default::default()
+        };
+        let md = render_markdown(&[changeset], &config);
+        assert!(md.contains("row 4, column 'score': '40' -> '42'"));
+        assert!(!md.contains("showing 1 of 4"));
+    }
+
+    fn sample_detail_block(total_count: u64) -> DetailBlock {
+        let mut block = DetailBlock::new("cells_changed", "binoc.tabular.cell_changes.v1")
+            .with_label("Changed cells")
+            .with_total_count(total_count)
+            .with_extract_hint(ExtractHint::new("cells_changed").with_label("All changed cells"));
+        for row in 0..total_count {
+            let mut example = DetailExample::new();
+            example.locator.insert("row".into(), serde_json::json!(row));
+            example
+                .locator
+                .insert("column".into(), serde_json::json!("score"));
+            example.before = Some(ValuePreview {
+                value: serde_json::json!(format!("{}", (row + 1) * 10)),
+                media_type: Some("text/plain".into()),
+                truncated: false,
+            });
+            example.after = Some(ValuePreview {
+                value: serde_json::json!(format!("{}", (row + 1) * 10 + 2)),
+                media_type: Some("text/plain".into()),
+                truncated: false,
+            });
+            block.examples.push(example);
+        }
+        block
     }
 }

--- a/binoc-stdlib/src/test_vectors.rs
+++ b/binoc-stdlib/src/test_vectors.rs
@@ -18,7 +18,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 
-use binoc_core::config::{DatasetConfig, PluginRegistry, TransformerConfig};
+use binoc_core::config::{DatasetConfig, OutputConfig, PluginRegistry, TransformerConfig};
 use binoc_core::controller::Controller;
 use binoc_sdk::ir::DiffNode;
 use binoc_sdk::test_support::{AbiCall, AbiComparator, AbiLogCollector, AbiTransformer};
@@ -57,6 +57,8 @@ struct ManifestConfig {
     comparators: Option<Vec<String>>,
     #[serde(default)]
     transformers: Option<Vec<String>>,
+    #[serde(default)]
+    output: Option<OutputConfig>,
     #[serde(default)]
     transformer_config: Option<TransformerConfig>,
 }
@@ -362,10 +364,8 @@ pub fn run_vector(
     let mut stable_changeset = changeset.clone();
     stable_changeset.from_snapshot = "snapshot-a".into();
     stable_changeset.to_snapshot = "snapshot-b".into();
-    let md = markdown::render_markdown(
-        &[stable_changeset.clone()],
-        &markdown::MarkdownRendererConfig::default(),
-    );
+    let md_config = markdown_config_for_dataset(&config);
+    let md = markdown::render_markdown(&[stable_changeset.clone()], &md_config);
 
     let mut settings = insta::Settings::clone_current();
     settings.set_snapshot_path(vector_dir.join("expected-output"));
@@ -465,10 +465,8 @@ pub fn run_vector_with_abi_log(
     let mut stable_changeset = changeset.clone();
     stable_changeset.from_snapshot = "snapshot-a".into();
     stable_changeset.to_snapshot = "snapshot-b".into();
-    let md = markdown::render_markdown(
-        &[stable_changeset.clone()],
-        &markdown::MarkdownRendererConfig::default(),
-    );
+    let md_config = markdown_config_for_dataset(&config);
+    let md = markdown::render_markdown(&[stable_changeset.clone()], &md_config);
 
     let mut settings = insta::Settings::clone_current();
     settings.set_snapshot_path(vector_dir.join("expected-output"));
@@ -552,7 +550,7 @@ fn build_config(manifest: &Manifest) -> DatasetConfig {
                 comparators: cfg.comparators.clone().unwrap_or(default.comparators),
                 transformers: cfg.transformers.clone().unwrap_or(default.transformers),
                 renderers: default.renderers,
-                output: default.output,
+                output: cfg.output.clone().unwrap_or(default.output),
                 transformer_config: cfg
                     .transformer_config
                     .clone()
@@ -561,6 +559,11 @@ fn build_config(manifest: &Manifest) -> DatasetConfig {
         }
         None => DatasetConfig::default_config(),
     }
+}
+
+fn markdown_config_for_dataset(config: &DatasetConfig) -> markdown::MarkdownRendererConfig {
+    let md_val = config.output.get_for_renderer("binoc.markdown");
+    serde_json::from_value(md_val).unwrap_or_default()
 }
 
 fn copy_dir_all(src: &Path, dst: &Path) {

--- a/binoc-stdlib/src/transformers/tabular_analyzer.rs
+++ b/binoc-stdlib/src/transformers/tabular_analyzer.rs
@@ -2,6 +2,9 @@ use std::collections::BTreeSet;
 
 use binoc_sdk::*;
 
+const MAX_CAPTURED_CELL_EXAMPLES: usize = 8;
+const MAX_CAPTURED_VALUE_CHARS: usize = 256;
+
 /// Analyzes tabular data artifacts to detect schema changes, row changes,
 /// and cell-level changes. Source-format-agnostic — works with any
 /// comparator that publishes [`tabular_v1`] artifacts (CSV, Parquet,
@@ -122,6 +125,7 @@ fn transform_modify(mut node: DiffNode, pair: &TabularDataPair) -> TransformResu
 
     let min_rows = left.rows.len().min(right.rows.len());
     let mut cells_changed: u64 = 0;
+    let mut cell_examples = Vec::new();
     for i in 0..min_rows {
         let row_l = &left.rows[i];
         let row_r = &right.rows[i];
@@ -138,6 +142,9 @@ fn transform_modify(mut node: DiffNode, pair: &TabularDataPair) -> TransformResu
                 .unwrap_or("");
             if val_l != val_r {
                 cells_changed += 1;
+                if cell_examples.len() < MAX_CAPTURED_CELL_EXAMPLES {
+                    cell_examples.push(changed_cell_example(i, col, val_l, val_r));
+                }
             }
         }
     }
@@ -163,6 +170,21 @@ fn transform_modify(mut node: DiffNode, pair: &TabularDataPair) -> TransformResu
         .insert("rows_removed".into(), serde_json::json!(rows_removed));
     node.details
         .insert("cells_changed".into(), serde_json::json!(cells_changed));
+
+    if cells_changed > 0 {
+        node.detail_blocks.push(
+            DetailBlock::new("cells_changed", "binoc.tabular.cell_changes.v1")
+                .with_label("Changed cells")
+                .with_total_count(cells_changed)
+                .with_extract_hint(
+                    ExtractHint::new("cells_changed").with_label("All changed cells"),
+                ),
+        );
+        if let Some(block) = node.detail_blocks.last_mut() {
+            block.examples = cell_examples;
+            block.truncated = cells_changed as usize > block.examples.len();
+        }
+    }
 
     if !columns_added.is_empty() {
         node.tags.insert("binoc.column-addition".into());
@@ -273,4 +295,32 @@ fn fmt_quoted_list(items: &[&str]) -> String {
         .map(|s| format!("'{s}'"))
         .collect::<Vec<_>>()
         .join(", ")
+}
+
+fn changed_cell_example(row: usize, column: &str, before: &str, after: &str) -> DetailExample {
+    let mut example = DetailExample::new();
+    example.locator.insert("row".into(), serde_json::json!(row));
+    example
+        .locator
+        .insert("column".into(), serde_json::json!(column));
+    example.before = Some(capture_value_preview(before));
+    example.after = Some(capture_value_preview(after));
+    example
+}
+
+fn capture_value_preview(value: &str) -> ValuePreview {
+    let truncated = value.chars().count() > MAX_CAPTURED_VALUE_CHARS;
+    let value = if truncated {
+        value
+            .chars()
+            .take(MAX_CAPTURED_VALUE_CHARS)
+            .collect::<String>()
+    } else {
+        value.to_string()
+    };
+    ValuePreview {
+        value: serde_json::json!(value),
+        media_type: Some("text/plain".into()),
+        truncated,
+    }
 }

--- a/binoc-stdlib/tests/transformer_tests.rs
+++ b/binoc-stdlib/tests/transformer_tests.rs
@@ -538,6 +538,14 @@ fn tabular_analyzer_detects_cell_changes() {
             assert!(n.tags.contains("binoc.cell-change"));
             assert_eq!(n.details["cells_changed"], 2);
             assert!(n.summary.as_ref().unwrap().contains("2 cells changed"));
+            assert_eq!(n.detail_blocks.len(), 1);
+            let block = &n.detail_blocks[0];
+            assert_eq!(block.id, "cells_changed");
+            assert_eq!(block.kind, "binoc.tabular.cell_changes.v1");
+            assert_eq!(block.total_count, Some(2));
+            assert_eq!(block.examples.len(), 2);
+            assert_eq!(block.extract.len(), 1);
+            assert_eq!(block.extract[0].aspect, "cells_changed");
         }
         _ => panic!("Expected Replace"),
     }

--- a/docs/adr/2026-06-01-example_verbosity.md
+++ b/docs/adr/2026-06-01-example_verbosity.md
@@ -1,0 +1,289 @@
+# Example Verbosity and Plugin-Supplied Details
+
+**Date:** 2026-06-01
+**Status:** Decided
+
+## Context
+
+Binoc's human-readable changelog has to sit between two bad extremes:
+
+- "1 cell changed" is too terse for a steward trying to decide whether a
+  dataset revision matters.
+- Rendering every changed value, row, hunk, or schema element inline makes the
+  changelog unreadable and can create huge output.
+
+The existing IR already has `summary`, `tags`, and plugin-specific `details`.
+The Markdown renderer uses those fields for one-line bullets and significance
+classification. It does not have a stable way to ask, "show a few useful
+examples for this change," without scraping plugin-private payloads or gaining
+domain knowledge about CSV, SQLite, text, or future plugin formats.
+
+This decision must preserve the existing architecture:
+
+- Significance and prose layout remain renderer concerns.
+- Comparators and transformers are the only phases that understand source
+  formats or semantic domains.
+- The controller remains type-ignorant.
+- `binoc extract` remains the way to retrieve exhaustive changed content on
+  demand.
+
+## Decision
+
+Binoc will support three standard renderer verbosity levels:
+
+| Level | Meaning |
+|---|---|
+| `summary` | Render reportable nodes and their one-line summaries only. Do not render examples. |
+| `examples` | Render summaries plus bounded, structured examples where nodes provide them. This is the default for human-readable renderers. |
+| `full` | Render every structured detail block and captured example present in the changeset, subject to hard renderer safety caps. This does not re-open source data or replace `binoc extract`. |
+
+Verbosity is renderer config, not transformer config:
+
+```yaml
+output:
+  markdown:
+    verbosity: examples
+    max_examples_per_block: 3
+    max_detail_blocks_per_node: 4
+    max_value_chars: 160
+    max_rendered_detail_bytes: 200000
+```
+
+Each renderer owns its config schema under `output.<renderer>`, following the
+per-renderer config decision. Standard renderers should use the names above for
+portable behavior, but third-party renderers may add renderer-specific controls.
+
+Example content is not renderer config. Comparators and transformers may attach
+structured detail blocks to `DiffNode`s while they still have domain knowledge
+and access to source-derived artifacts. Renderers choose how much of those
+blocks to display based on verbosity and caps.
+
+### Changeset Shape
+
+`DiffNode` will gain a first-class structured detail field separate from the
+existing plugin-private `details` map. The shape is intentionally generic and
+openly typed:
+
+```rust
+pub struct DiffNode {
+    pub summary: Option<String>,
+    pub tags: BTreeSet<String>,
+    pub details: BTreeMap<String, serde_json::Value>, // plugin-private metrics
+    pub detail_blocks: Vec<DetailBlock>,              // renderer-visible evidence
+    // ...
+}
+
+pub struct DetailBlock {
+    /// Stable within this node, for anchors and extract selection.
+    pub id: String,
+
+    /// Open, namespaced kind such as "binoc.tabular.cell_changes.v1".
+    pub kind: String,
+
+    /// Short renderer-facing label, not a sentence of prose.
+    pub label: Option<String>,
+
+    /// Total matching items if known, including omitted examples.
+    pub total_count: Option<u64>,
+
+    /// Examples captured for inline rendering.
+    pub examples: Vec<DetailExample>,
+
+    /// Optional named extract aspects that can return exhaustive content.
+    pub extract: Vec<ExtractHint>,
+
+    /// Whether the producer truncated capture before exhausting candidates.
+    pub truncated: bool,
+}
+
+pub struct DetailExample {
+    /// Structured locator, for example row/column, line range, key path,
+    /// table name, or schema object. Renderers can display known keys and
+    /// fall back to compact JSON for unknown keys.
+    pub locator: BTreeMap<String, serde_json::Value>,
+
+    /// Values before and after the change. Missing sides represent add/remove.
+    pub before: Option<ValuePreview>,
+    pub after: Option<ValuePreview>,
+
+    /// Extra structured fields for domain-specific context.
+    pub fields: BTreeMap<String, serde_json::Value>,
+}
+
+pub struct ValuePreview {
+    pub value: serde_json::Value,
+    pub media_type: Option<String>,
+    pub truncated: bool,
+}
+
+pub struct ExtractHint {
+    /// Aspect name accepted by `binoc extract`, such as "cell-changes",
+    /// "rows-added", or "text-hunks".
+    pub aspect: String,
+    pub label: Option<String>,
+}
+```
+
+The field is serialized into changeset JSON. It carries bounded evidence and
+extract hooks, not full source data by default. It is distinct from artifacts,
+which are transient session data, and from `details`, which remains available
+for plugin-private metrics and machine checks.
+
+Detail blocks must not contain pre-rendered prose paragraphs. They may contain
+short labels and scalar values, but sentence construction, table layout,
+ordering, and significance grouping are renderer responsibilities.
+
+Example JSON for a tabular cell change:
+
+```json
+{
+  "id": "cells_changed",
+  "kind": "binoc.tabular.cell_changes.v1",
+  "label": "Changed cells",
+  "total_count": 127,
+  "truncated": true,
+  "examples": [
+    {
+      "locator": {"row": 42, "column": "status"},
+      "before": {"value": "draft", "media_type": "text/plain", "truncated": false},
+      "after": {"value": "published", "media_type": "text/plain", "truncated": false},
+      "fields": {}
+    }
+  ],
+  "extract": [{"aspect": "cell-changes", "label": "All changed cells"}]
+}
+```
+
+### Plugin Participation Contract
+
+Plugins participate by emitting data, not by owning renderer behavior.
+
+Comparators and transformers may populate `detail_blocks` on nodes they create
+or rewrite. The plugin that last changes a node is responsible for keeping the
+node's summaries, tags, details, detail blocks, and extract aspects coherent.
+This follows the existing "last toucher owns extraction" rule.
+
+No new renderer callback is introduced. The contract is the data shape above
+plus the existing `extract` methods:
+
+```rust
+pub trait Comparator {
+    fn compare(&self, pair: &ItemPair, data: &dyn DataAccess) -> BinocResult<DiffNode>;
+
+    // If a DetailBlock advertises an ExtractHint, the owning comparator or
+    // last transformer must accept that aspect here.
+    fn extract(
+        &self,
+        node: &DiffNode,
+        aspect: &str,
+        data: &dyn DataAccess,
+    ) -> Option<ExtractResult>;
+}
+
+pub trait Transformer {
+    fn transform(
+        &self,
+        node: DiffNode,
+        data: &dyn DataAccess,
+        config: &serde_json::Value,
+    ) -> TransformResult;
+
+    fn extract(
+        &self,
+        node: &DiffNode,
+        aspect: &str,
+        data: &dyn DataAccess,
+    ) -> Option<ExtractResult>;
+}
+```
+
+SDK helper methods may make this ergonomic, but there is no separate
+`ExampleProvider` or `DetailProvider` plugin registry. A renderer can render
+unknown `kind`s generically because the block structure is stable. A specialized
+renderer may recognize known namespaced kinds for richer layout.
+
+### Output Caps
+
+There are two layers of caps:
+
+1. **Capture caps** limit how much evidence a comparator or transformer records
+   in the changeset. These keep saved changesets bounded. Standard plugins
+   should capture a small, deterministic sample by default. Future
+   comparator/transformer config can expose plugin-specific capture budgets,
+   but those budgets must not live under `output.<renderer>`.
+2. **Render caps** live in renderer config and limit how much of the captured
+   detail a renderer displays in a particular output.
+
+Renderers must always make truncation visible when it affects displayed detail:
+for example, "showing 3 of 127 changed cells." If a block includes an extract
+hint, Markdown should point to the aspect that returns the exhaustive data.
+
+`full` means "render all captured structured detail" and is still bounded by
+hard safety caps such as `max_rendered_detail_bytes`. If the changeset captured
+only examples, `full` renders only those examples and directs the user to
+`binoc extract` for exhaustive content.
+
+### Interaction With `binoc extract`
+
+Inline examples are evidence for scan-and-triage workflows. `binoc extract` is
+the exhaustive retrieval path.
+
+Detail blocks may advertise extract aspects. Renderers may display those aspects
+as follow-up commands, links, or machine-readable references. The aspect string
+is still resolved through the existing provenance chain: the comparator or last
+transformer named on the node handles extraction.
+
+This keeps saved changelogs compact while giving users a clear path from
+"interesting example" to "all underlying changed data."
+
+### Interaction With Diagnostics
+
+Diagnostics are for process health: warnings, parse fallbacks, unavailable
+artifacts, capture failures, and other conditions that affect trust in the run.
+Detail blocks are for user-facing evidence about actual dataset changes.
+
+Expected omission caused by caps belongs in the detail block (`total_count`,
+`truncated`) and in renderer text such as "showing 3 of 127." Unexpected
+problems capturing examples should be emitted through the diagnostics channel
+and may also result in no detail block or a block with fewer examples. Renderers
+should not treat diagnostics as examples, and plugins should not hide process
+warnings inside `detail_blocks`.
+
+## Consequences
+
+- Human-readable renderers get a stable way to show useful examples without
+  learning plugin-private schemas.
+- Plugins can provide domain-specific evidence for generic renderers by filling
+  a structured field.
+- Saved changesets remain bounded because examples are captured samples, not
+  arbitrary raw data dumps.
+- `binoc extract` remains necessary and clearly separated from changelog
+  rendering.
+- The existing `details` map remains useful for metrics and plugin-private
+  machine data, but renderers should prefer `detail_blocks` for inline examples.
+- The implementation is a breaking changeset schema change, acceptable during
+  greenfield development.
+
+## Alternatives Considered
+
+**Renderer scrapes `details`.** Rejected because `details` is plugin-private
+and already contains ad hoc metrics. A renderer would either become domain-aware
+or produce unstable output based on undocumented keys.
+
+**Examples are transformer output only.** Rejected because comparators may be
+the only component that understands a source format, and some changes never pass
+through a semantic transformer. Both comparators and transformers need to be
+able to attach detail blocks.
+
+**Renderer calls plugins to generate examples at render time.** Rejected because
+rendering should work from saved changeset JSON without source access. On-demand
+source reconstruction is already the job of `binoc extract`.
+
+**Store every changed value in the changeset and let renderers hide most of it.**
+Rejected because it makes changeset size scale with the raw diff and creates
+privacy/performance surprises. Capture must be bounded before serialization.
+
+**Add a separate `DetailProvider` plugin trait.** Rejected because it adds
+another dispatch axis and repeats information already known to the comparator or
+transformer that created the node. The existing provenance and extract contract
+is enough.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -8,8 +8,8 @@ Newer entries appear first. Each entry shows its date and current status. Create
 |---|---|---|
 | 2026-06-02 | [Markdown Renderer Groups Replace Significance-Map Grouping](2026-06-02-renderer_groups.md) | Implemented |
 | 2026-06-01 | [Optional First-Party Plugins and `binoc[all]`](2026-06-01-optional_first_party_plugins.md) | Accepted |
-| 2026-06-01 | [Diagnostics Channel for Non-Fatal Warnings and Suggestions](2026-06-01-diagnostics_channel.md) | Implemented |
 | 2026-06-01 | [Example Verbosity and Plugin-Supplied Details](2026-06-01-example_verbosity.md) | Decided |
+| 2026-06-01 | [Diagnostics Channel for Non-Fatal Warnings and Suggestions](2026-06-01-diagnostics_channel.md) | Implemented |
 | 2026-05-13 | [Rename-and-modify detection: fuzzy correlation + transformer-initiated re-dispatch](rename_modify_detection.md) | Implemented |
 | 2026-04-17 | [Documentation Platform and Information Design](2026-04-17-documentation_platform_and_info_design.md) | Proposed |
 | 2026-04-16 | [Transient Fields Are Wire-Visible; Output Stripping Is a Boundary Concern](2026-04-16-transient_fields_on_wire.md) | Implemented |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -9,6 +9,7 @@ Newer entries appear first. Each entry shows its date and current status. Create
 | 2026-06-02 | [Markdown Renderer Groups Replace Significance-Map Grouping](2026-06-02-renderer_groups.md) | Implemented |
 | 2026-06-01 | [Optional First-Party Plugins and `binoc[all]`](2026-06-01-optional_first_party_plugins.md) | Accepted |
 | 2026-06-01 | [Diagnostics Channel for Non-Fatal Warnings and Suggestions](2026-06-01-diagnostics_channel.md) | Implemented |
+| 2026-06-01 | [Example Verbosity and Plugin-Supplied Details](2026-06-01-example_verbosity.md) | Decided |
 | 2026-05-13 | [Rename-and-modify detection: fuzzy correlation + transformer-initiated re-dispatch](rename_modify_detection.md) | Implemented |
 | 2026-04-17 | [Documentation Platform and Information Design](2026-04-17-documentation_platform_and_info_design.md) | Proposed |
 | 2026-04-16 | [Transient Fields Are Wire-Visible; Output Stripping Is a Boundary Concern](2026-04-16-transient_fields_on_wire.md) | Implemented |

--- a/docs/explanation/test-vectors-gallery.md
+++ b/docs/explanation/test-vectors-gallery.md
@@ -13,7 +13,7 @@ audience: new user, data steward, archivist
 
 These are runnable examples from binoc's test suite. Each example links to its source folder on GitHub, tells you whether it needs any extra setup, gives you the exact command to run, and shows the Markdown changelog binoc is expected to print.
 
-Binoc currently ships **30 shared examples** in this gallery.
+Binoc currently ships **31 shared examples** in this gallery.
 
 ## One-time setup
 
@@ -38,6 +38,7 @@ just materialize
 | [`csv-rename-modify`](#csv-rename-modify) | CSV renamed and a column added: detected as a single move with content diff via fuzzy correlation | data_v2.csv: Moved from data.csv (modified) | Default pipeline |
 | [`csv-row-addition`](#csv-row-addition) | New rows appended | data.csv: 2 rows added | Default pipeline |
 | [`csv-row-removal`](#csv-row-removal) | Rows removed from CSV | data.csv: 2 rows removed | Default pipeline |
+| [`csv-verbosity-full`](#csv-verbosity-full) | Markdown full verbosity renders every captured changed-cell example. | data.csv: 5 cells changed | Custom config |
 | [`directory-file-copy`](#directory-file-copy) | New file with same content as an existing unchanged file detected as a copy | duplicate.txt: Copied from original.txt | Default pipeline |
 | [`directory-nested`](#directory-nested) | Subdirectories with mixed changes | data/extra.csv: New table (2 columns, 1 rows) | Default pipeline |
 | [`directory-nested-with-tar`](#directory-nested-with-tar) | Shows binoc diffing a tar archive and a plain directory that contain overlapping internal paths. | data/records.csv: 1 row added | Default pipeline |
@@ -104,6 +105,9 @@ Result:
 # Changelog: snapshot-a → snapshot-b
 
 - **data.csv**: 2 cells changed
+  - Changed cells; use `binoc extract CHANGESET "data.csv" cells_changed` for all changed cells
+    - row 1, column 'score': '85' -> '92'
+    - row 2, column 'score': '90' -> '88'
 ```
 
 ## csv-column-addition
@@ -267,6 +271,43 @@ Result:
 - **data.csv**: 2 rows removed
 ```
 
+## csv-verbosity-full
+
+Markdown full verbosity renders every captured changed-cell example.
+
+- **Browse source:** [csv-verbosity-full](https://github.com/harvard-lil/binoc/tree/main/test-vectors/csv-verbosity-full)
+- **Tags:** `csv`, `cell-change`, `verbosity`
+- **Snapshots:** `snapshot-a` has 1 file — `data.csv`; `snapshot-b` has 1 file — `data.csv`
+- **Setup:** This example sets `output.markdown.verbosity: full` so the changelog prints every captured changed-cell example instead of the default capped sample.
+Save this dataset config as `/tmp/csv-verbosity-full.yaml`:
+
+```yaml
+output:
+  markdown:
+    verbosity: full
+```
+
+
+Run it:
+```bash
+binoc diff \
+  ./test-vectors-materialized/csv-verbosity-full/snapshot-a \
+  ./test-vectors-materialized/csv-verbosity-full/snapshot-b \
+  --config /tmp/csv-verbosity-full.yaml
+```
+Result:
+```markdown
+# Changelog: snapshot-a → snapshot-b
+
+- **data.csv**: 5 cells changed
+  - Changed cells; use `binoc extract CHANGESET "data.csv" cells_changed` for all changed cells
+    - row 1, column 'score': '10' -> '11'
+    - row 2, column 'score': '20' -> '21'
+    - row 3, column 'score': '30' -> '31'
+    - row 4, column 'score': '40' -> '41'
+    - row 5, column 'score': '50' -> '51'
+```
+
 ## directory-file-copy
 
 New file with same content as an existing unchanged file detected as a copy
@@ -331,6 +372,8 @@ Result:
 
 - **data/records.csv**: 1 row added
 - **data.tar.gz/records.csv**: 1 cell changed
+  - Changed cells; use `binoc extract CHANGESET "data.tar.gz/records.csv" cells_changed` for all changed cells
+    - row 2, column 'count': '20' -> '25'
 ```
 
 ## folder-move-nested
@@ -409,6 +452,9 @@ Result:
 - **archive.tar.gz/inventory.csv**: 1 row added
 - **bundle.zip/notes.txt**: 2 lines added, 1 removed
 - **data.csv**: 2 cells changed
+  - Changed cells; use `binoc extract CHANGESET "data.csv" cells_changed` for all changed cells
+    - row 1, column 'age': '30' -> '31'
+    - row 3, column 'city': 'Seattle' -> 'Portland'
 - **docs/new-file.txt**: New file (1 line)
 - **docs/old-notes.txt**: File removed (1 line)
 - **docs/readme.txt**: 2 lines added, 2 removed
@@ -703,6 +749,9 @@ Result:
 # Changelog: snapshot-a → snapshot-b
 
 - **data.tsv**: 2 cells changed
+  - Changed cells; use `binoc extract CHANGESET "data.tsv" cells_changed` for all changed cells
+    - row 1, column 'age': '30' -> '31'
+    - row 2, column 'city': 'Boston' -> 'Cambridge'
 ```
 
 ## zip-nested

--- a/docs/reference/changeset-schema.json
+++ b/docs/reference/changeset-schema.json
@@ -94,6 +94,96 @@
         "pair"
       ]
     },
+    "DetailBlock": {
+      "description": "Renderer-visible, bounded evidence attached to a diff node.",
+      "type": "object",
+      "properties": {
+        "examples": {
+          "description": "Captured examples for inline rendering.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/DetailExample"
+          }
+        },
+        "extract": {
+          "description": "Named extract aspects for exhaustive retrieval.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ExtractHint"
+          }
+        },
+        "id": {
+          "description": "Stable within this node, for anchors and extract selection.",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Open, namespaced kind such as `binoc.tabular.cell_changes.v1`.",
+          "type": "string"
+        },
+        "label": {
+          "description": "Short renderer-facing label.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "total_count": {
+          "description": "Total matching items if known, including omitted examples.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0
+        },
+        "truncated": {
+          "description": "Whether the producer truncated capture before exhausting candidates.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "id",
+        "kind"
+      ]
+    },
+    "DetailExample": {
+      "description": "One bounded example inside a detail block.",
+      "type": "object",
+      "properties": {
+        "after": {
+          "description": "Value after the change, if present.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ValuePreview"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "before": {
+          "description": "Value before the change, if present.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ValuePreview"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "fields": {
+          "description": "Domain-specific structured context.",
+          "type": "object",
+          "additionalProperties": true
+        },
+        "locator": {
+          "description": "Structured locator such as row/column, line range, or key path.",
+          "type": "object",
+          "additionalProperties": true
+        }
+      }
+    },
     "Diagnostic": {
       "type": "object",
       "properties": {
@@ -159,6 +249,13 @@
             "string",
             "null"
           ]
+        },
+        "detail_blocks": {
+          "description": "Renderer-visible, structured evidence blocks. Comparators and\ntransformers populate these with bounded examples while they still have\ndomain knowledge; renderers decide how much to display.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/DetailBlock"
+          }
         },
         "details": {
           "description": "Comparator-specific payload, schema determined by item_type convention.",
@@ -238,6 +335,25 @@
         "path"
       ]
     },
+    "ExtractHint": {
+      "description": "Pointer to an extract aspect that can return exhaustive content.",
+      "type": "object",
+      "properties": {
+        "aspect": {
+          "description": "Aspect name accepted by `binoc extract`.",
+          "type": "string"
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "aspect"
+      ]
+    },
     "ItemPair": {
       "description": "A pair of items to compare. Either side may be None (add/remove).",
       "type": "object",
@@ -303,6 +419,25 @@
       "required": [
         "logical_path",
         "is_dir"
+      ]
+    },
+    "ValuePreview": {
+      "description": "A bounded preview of one value in a detail example.",
+      "type": "object",
+      "properties": {
+        "media_type": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "truncated": {
+          "type": "boolean"
+        },
+        "value": true
+      },
+      "required": [
+        "value"
       ]
     }
   }

--- a/docs/reference/changeset-schema.md
+++ b/docs/reference/changeset-schema.md
@@ -76,6 +76,7 @@ A node in the diff tree — the central data structure of the system. Every comp
 | `artifacts` | array of [`ArtifactDescriptor`](#artifactdescriptor) | no | Published artifacts for this node. Session-scoped working data: carried across the plugin ABI wire as descriptors (the bytes live in the shared `data_root` cache), but not meaningful outside a session. Callers writing changeset output must strip this via [`DiffNode::strip_transient`] before serializing. |
 | `children` | array of [`DiffNode`](#diffnode) | no | Child diff nodes forming the tree structure. |
 | `comparator` | string \| null | no | Which comparator produced this node (provenance for extract chain). |
+| `detail_blocks` | array of [`DetailBlock`](#detailblock) | no | Renderer-visible, structured evidence blocks. Comparators and transformers populate these with bounded examples while they still have domain knowledge; renderers decide how much to display. |
 | `details` | object (free-form) | no | Comparator-specific payload, schema determined by item_type convention. |
 | `diagnostics` | array of [`Diagnostic`](#diagnostic) | no | Node-scoped diagnostics emitted during comparison or transform. Transient: the controller hoists them into [`Changeset::diagnostics`] at the end of the diff, then clears this field so the output shape stays as one durable top-level diagnostics list. |
 | `item_type` | string | yes | Open string: "directory", "file", "tabular", "zip_archive", etc. No built-in types — conventions, not enforcement. |
@@ -140,6 +141,31 @@ String enum. One of:
 - `right`
 - `pair`
 
+### `DetailBlock`
+
+Renderer-visible, bounded evidence attached to a diff node.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `examples` | array of [`DetailExample`](#detailexample) | no | Captured examples for inline rendering. |
+| `extract` | array of [`ExtractHint`](#extracthint) | no | Named extract aspects for exhaustive retrieval. |
+| `id` | string | yes | Stable within this node, for anchors and extract selection. |
+| `kind` | string | yes | Open, namespaced kind such as `binoc.tabular.cell_changes.v1`. |
+| `label` | string \| null | no | Short renderer-facing label. |
+| `total_count` | integer \| null | no | Total matching items if known, including omitted examples. |
+| `truncated` | boolean | no | Whether the producer truncated capture before exhausting candidates. |
+
+### `DetailExample`
+
+One bounded example inside a detail block.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `after` | [`ValuePreview`](#valuepreview) \| null | no | Value after the change, if present. |
+| `before` | [`ValuePreview`](#valuepreview) \| null | no | Value before the change, if present. |
+| `fields` | object (free-form) | no | Domain-specific structured context. |
+| `locator` | object (free-form) | no | Structured locator such as row/column, line range, or key path. |
+
 ### `Diagnostic`
 
 | Field | Type | Required | Description |
@@ -155,3 +181,22 @@ String enum. One of:
 
 - `warning`
 - `suggestion`
+
+### `ExtractHint`
+
+Pointer to an extract aspect that can return exhaustive content.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `aspect` | string | yes | Aspect name accepted by `binoc extract`. |
+| `label` | string \| null | no |  |
+
+### `ValuePreview`
+
+A bounded preview of one value in a detail example.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `media_type` | string \| null | no |  |
+| `truncated` | boolean | no |  |
+| `value` | any | yes |  |

--- a/docs/reference/dataset-config.md
+++ b/docs/reference/dataset-config.md
@@ -117,6 +117,41 @@ section receives an empty object and applies its own defaults.
 
 The Markdown renderer is the most interesting case today.
 
+### `output.markdown.verbosity`
+
+Controls how much renderer-visible evidence the Markdown changelog shows:
+
+- `summary` renders only the main one-line bullet for each reportable node.
+- `examples` renders the summary plus bounded inline examples from any
+  `detail_blocks` attached to the node. This is the default.
+- `full` renders all captured detail blocks and examples from the changeset,
+  still subject to the renderer's hard safety budget.
+
+The renderer never reopens source data. If a node advertises an extract aspect,
+the changelog points you at `binoc extract` for the exhaustive content.
+
+### `output.markdown.max_examples_per_block`
+
+Only used at `verbosity: examples`. Caps how many examples the renderer shows
+from each structured detail block before it switches to a "showing N of M"
+message and an extract hint.
+
+### `output.markdown.max_detail_blocks_per_node`
+
+Only used at `verbosity: examples`. Caps how many structured detail blocks the
+renderer shows under a single changelog bullet.
+
+### `output.markdown.max_value_chars`
+
+Caps how many characters of a single example value the renderer prints inline
+before truncating it with `...`.
+
+### `output.markdown.max_rendered_detail_bytes`
+
+Hard safety budget for all rendered detail lines across the whole Markdown
+output. When the renderer hits this budget it stops printing further inline
+detail and leaves the summary bullets intact.
+
 ### `output.markdown.groups`
 
 An ordered list of group definitions. Each group has a literal `heading`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -163,8 +163,8 @@ nav:
           - adr/README.md
           - 'Markdown Renderer Groups Replace Significance-Map Grouping': adr/2026-06-02-renderer_groups.md
           - 'Optional First-Party Plugins and `binoc[all]`': adr/2026-06-01-optional_first_party_plugins.md
-          - 'Diagnostics Channel for Non-Fatal Warnings and Suggestions': adr/2026-06-01-diagnostics_channel.md
           - 'Example Verbosity and Plugin-Supplied Details': adr/2026-06-01-example_verbosity.md
+          - 'Diagnostics Channel for Non-Fatal Warnings and Suggestions': adr/2026-06-01-diagnostics_channel.md
           - 'Rename-and-modify detection: fuzzy correlation + transformer-initiated re-dispatch': adr/rename_modify_detection.md
           - 'Documentation Platform and Information Design': adr/2026-04-17-documentation_platform_and_info_design.md
           - 'Transient Fields Are Wire-Visible; Output Stripping Is a Boundary Concern': adr/2026-04-16-transient_fields_on_wire.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -164,6 +164,7 @@ nav:
           - 'Markdown Renderer Groups Replace Significance-Map Grouping': adr/2026-06-02-renderer_groups.md
           - 'Optional First-Party Plugins and `binoc[all]`': adr/2026-06-01-optional_first_party_plugins.md
           - 'Diagnostics Channel for Non-Fatal Warnings and Suggestions': adr/2026-06-01-diagnostics_channel.md
+          - 'Example Verbosity and Plugin-Supplied Details': adr/2026-06-01-example_verbosity.md
           - 'Rename-and-modify detection: fuzzy correlation + transformer-initiated re-dispatch': adr/rename_modify_detection.md
           - 'Documentation Platform and Information Design': adr/2026-04-17-documentation_platform_and_info_design.md
           - 'Transient Fields Are Wire-Visible; Output Stripping Is a Boundary Concern': adr/2026-04-16-transient_fields_on_wire.md

--- a/model-plugins/binoc-row-reorder/test-vectors/csv-row-reorder/expected-output/changelog.snap
+++ b/model-plugins/binoc-row-reorder/test-vectors/csv-row-reorder/expected-output/changelog.snap
@@ -5,3 +5,7 @@ expression: "&md"
 # Changelog: snapshot-a → snapshot-b
 
 - **data.csv**: Rows reordered (same data, different sort order)
+  - Changed cells (showing 3 of 9); use `binoc extract CHANGESET "data.csv" cells_changed` for all changed cells
+    - row 1, column 'age': '30' -> '35'
+    - row 1, column 'city': 'NYC' -> 'Chicago'
+    - row 1, column 'name': 'Alice' -> 'Charlie'

--- a/model-plugins/binoc-row-reorder/test-vectors/csv-row-reorder/expected-output/changeset.snap
+++ b/model-plugins/binoc-row-reorder/test-vectors/csv-row-reorder/expected-output/changeset.snap
@@ -40,6 +40,135 @@ expression: "&stable_changeset"
           "rows_removed": 0,
           "rows_right": 3
         },
+        "detail_blocks": [
+          {
+            "id": "cells_changed",
+            "kind": "binoc.tabular.cell_changes.v1",
+            "label": "Changed cells",
+            "total_count": 9,
+            "examples": [
+              {
+                "locator": {
+                  "column": "age",
+                  "row": 0
+                },
+                "before": {
+                  "value": "30",
+                  "media_type": "text/plain"
+                },
+                "after": {
+                  "value": "35",
+                  "media_type": "text/plain"
+                }
+              },
+              {
+                "locator": {
+                  "column": "city",
+                  "row": 0
+                },
+                "before": {
+                  "value": "NYC",
+                  "media_type": "text/plain"
+                },
+                "after": {
+                  "value": "Chicago",
+                  "media_type": "text/plain"
+                }
+              },
+              {
+                "locator": {
+                  "column": "name",
+                  "row": 0
+                },
+                "before": {
+                  "value": "Alice",
+                  "media_type": "text/plain"
+                },
+                "after": {
+                  "value": "Charlie",
+                  "media_type": "text/plain"
+                }
+              },
+              {
+                "locator": {
+                  "column": "age",
+                  "row": 1
+                },
+                "before": {
+                  "value": "25",
+                  "media_type": "text/plain"
+                },
+                "after": {
+                  "value": "30",
+                  "media_type": "text/plain"
+                }
+              },
+              {
+                "locator": {
+                  "column": "city",
+                  "row": 1
+                },
+                "before": {
+                  "value": "LA",
+                  "media_type": "text/plain"
+                },
+                "after": {
+                  "value": "NYC",
+                  "media_type": "text/plain"
+                }
+              },
+              {
+                "locator": {
+                  "column": "name",
+                  "row": 1
+                },
+                "before": {
+                  "value": "Bob",
+                  "media_type": "text/plain"
+                },
+                "after": {
+                  "value": "Alice",
+                  "media_type": "text/plain"
+                }
+              },
+              {
+                "locator": {
+                  "column": "age",
+                  "row": 2
+                },
+                "before": {
+                  "value": "35",
+                  "media_type": "text/plain"
+                },
+                "after": {
+                  "value": "25",
+                  "media_type": "text/plain"
+                }
+              },
+              {
+                "locator": {
+                  "column": "city",
+                  "row": 2
+                },
+                "before": {
+                  "value": "Chicago",
+                  "media_type": "text/plain"
+                },
+                "after": {
+                  "value": "LA",
+                  "media_type": "text/plain"
+                }
+              }
+            ],
+            "extract": [
+              {
+                "aspect": "cells_changed",
+                "label": "All changed cells"
+              }
+            ],
+            "truncated": true
+          }
+        ],
         "comparator": "binoc.csv",
         "transformed_by": [
           "binoc.tabular_analyzer",

--- a/scripts/build_changeset_schema_page.py
+++ b/scripts/build_changeset_schema_page.py
@@ -126,7 +126,7 @@ def clean_description(text: str | None) -> str:
     return " ".join(cleaned.split())
 
 
-def type_display(prop: dict) -> str:
+def type_display(prop: dict | bool) -> str:
     """Render a JSON-Schema type fragment as short human prose.
 
     Handles the shapes schemars actually emits: `type` scalars, `type`
@@ -134,6 +134,11 @@ def type_display(prop: dict) -> str:
     `array` with `items`, `object` with `additionalProperties`, and
     `enum` strings.
     """
+    if prop is True:
+        return "any"
+    if prop is False:
+        return "never"
+
     # Nullable $ref: anyOf: [{$ref}, {type: null}]
     if "anyOf" in prop:
         branches = prop["anyOf"]
@@ -188,12 +193,13 @@ def fields_from_object(def_schema: dict) -> list[Field]:
     props = def_schema.get("properties", {})
     out = []
     for name, prop in sorted(props.items()):
+        description = clean_description(prop.get("description")) if isinstance(prop, dict) else ""
         out.append(
             Field(
                 name=name,
                 type_display=type_display(prop),
                 required=name in required,
-                description=clean_description(prop.get("description")),
+                description=description,
             )
         )
     return out

--- a/scripts/build_test_vector_gallery.py
+++ b/scripts/build_test_vector_gallery.py
@@ -60,6 +60,7 @@ class DocsMeta:
 class ManifestConfig:
     comparators: list[str] | None = None
     transformers: list[str] | None = None
+    output: dict[str, Any] | None = None
     transformer_config: dict[str, Any] | None = None
 
     @property
@@ -69,6 +70,7 @@ class ManifestConfig:
             for value in (
                 self.comparators,
                 self.transformers,
+                self.output,
                 self.transformer_config,
             )
         )
@@ -170,6 +172,7 @@ def _parse_config(manifest_path: Path, raw: Any) -> ManifestConfig:
 
     comparators = raw.get("comparators")
     transformers = raw.get("transformers")
+    output = raw.get("output")
     transformer_config = raw.get("transformer_config")
 
     if comparators is not None:
@@ -180,12 +183,15 @@ def _parse_config(manifest_path: Path, raw: Any) -> ManifestConfig:
         transformers = _validate_str_list(
             transformers, f"{manifest_path}: [config].transformers"
         )
+    if output is not None and not isinstance(output, dict):
+        _die(f"{manifest_path}: [config].output must be a table")
     if transformer_config is not None and not isinstance(transformer_config, dict):
         _die(f"{manifest_path}: [config].transformer_config must be a table")
 
     return ManifestConfig(
         comparators=comparators,
         transformers=transformers,
+        output=output,
         transformer_config=transformer_config,
     )
 
@@ -246,6 +252,8 @@ def _render_config_yaml(config: ManifestConfig) -> str | None:
         data["transformers"] = config.transformers
     if config.transformer_config:
         data["transformer_config"] = config.transformer_config
+    if config.output:
+        data["output"] = config.output
     if not data:
         return None
     return "\n".join(_yaml_lines(data))

--- a/test-vectors/README.md
+++ b/test-vectors/README.md
@@ -42,6 +42,7 @@ tags = ["tag1", "tag2"]
 # Optional: override default pipeline
 # comparators = ["binoc.csv"]
 # transformers = ["binoc.column_reorder_detector"]
+# output = { markdown = { verbosity = "summary" } }
 
 [expected]
 # Structural assertions
@@ -57,7 +58,9 @@ tags = ["tag1", "tag2"]
 - **`[docs]`** — Optional user-facing gallery metadata:
   - `summary` — short, user-facing description used in the examples gallery
   - `setup` — optional setup note that overrides the generator's default text
-- **`[config]`** — Optional pipeline overrides: `comparators`, `transformers`
+- **`[config]`** — Optional dataset config overrides from the normal config schema:
+  `comparators`, `transformers`, `transformer_config`, and renderer config under
+  `output` such as `output.markdown.verbosity`
 - **`[expected]`** — Assertions on the changeset output:
   - `root_kind` — Kind of the root diff node (e.g. `modify`, `add`, `remove`)
   - `child_count` — Number of children at root

--- a/test-vectors/csv-cell-changes/expected-output/changelog.snap
+++ b/test-vectors/csv-cell-changes/expected-output/changelog.snap
@@ -5,3 +5,6 @@ expression: "&md"
 # Changelog: snapshot-a → snapshot-b
 
 - **data.csv**: 2 cells changed
+  - Changed cells; use `binoc extract CHANGESET "data.csv" cells_changed` for all changed cells
+    - row 1, column 'score': '85' -> '92'
+    - row 2, column 'score': '90' -> '88'

--- a/test-vectors/csv-cell-changes/expected-output/changeset.snap
+++ b/test-vectors/csv-cell-changes/expected-output/changeset.snap
@@ -37,6 +37,50 @@ expression: "&stable_changeset"
           "rows_removed": 0,
           "rows_right": 3
         },
+        "detail_blocks": [
+          {
+            "id": "cells_changed",
+            "kind": "binoc.tabular.cell_changes.v1",
+            "label": "Changed cells",
+            "total_count": 2,
+            "examples": [
+              {
+                "locator": {
+                  "column": "score",
+                  "row": 0
+                },
+                "before": {
+                  "value": "85",
+                  "media_type": "text/plain"
+                },
+                "after": {
+                  "value": "92",
+                  "media_type": "text/plain"
+                }
+              },
+              {
+                "locator": {
+                  "column": "score",
+                  "row": 1
+                },
+                "before": {
+                  "value": "90",
+                  "media_type": "text/plain"
+                },
+                "after": {
+                  "value": "88",
+                  "media_type": "text/plain"
+                }
+              }
+            ],
+            "extract": [
+              {
+                "aspect": "cells_changed",
+                "label": "All changed cells"
+              }
+            ]
+          }
+        ],
         "comparator": "binoc.csv",
         "transformed_by": [
           "binoc.tabular_analyzer"

--- a/test-vectors/csv-verbosity-full/expected-output/abi-log.snap
+++ b/test-vectors/csv-verbosity-full/expected-output/abi-log.snap
@@ -1,0 +1,113 @@
+---
+source: binoc-stdlib/src/test_vectors.rs
+expression: "&abi_log"
+---
+[
+  {
+    "method": "compare",
+    "plugin": "binoc.directory",
+    "data_ops": [
+      {
+        "op": "local_path",
+        "handle": ""
+      },
+      {
+        "op": "local_path",
+        "handle": ""
+      },
+      {
+        "op": "register_local",
+        "logical": "data.csv"
+      },
+      {
+        "op": "read_bytes",
+        "handle": "data.csv",
+        "result_size": 88
+      },
+      {
+        "op": "register_local",
+        "logical": "data.csv"
+      },
+      {
+        "op": "read_bytes",
+        "handle": "data.csv",
+        "result_size": 88
+      }
+    ]
+  },
+  {
+    "method": "compare",
+    "plugin": "binoc.csv",
+    "data_ops": [
+      {
+        "op": "local_path",
+        "handle": "data.csv"
+      },
+      {
+        "op": "local_path",
+        "handle": "data.csv"
+      },
+      {
+        "op": "publish_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "subject": "Left",
+        "producer": "binoc.csv",
+        "size": 156
+      },
+      {
+        "op": "publish_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "subject": "Right",
+        "producer": "binoc.csv",
+        "size": 156
+      }
+    ]
+  },
+  {
+    "method": "transform",
+    "plugin": "binoc.correlation_detector",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
+    "plugin": "binoc.fuzzy_correlation_detector",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
+    "plugin": "binoc.folder_move_detector",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
+    "plugin": "binoc.tabular_analyzer",
+    "data_ops": [
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      },
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      }
+    ]
+  }
+]

--- a/test-vectors/csv-verbosity-full/expected-output/changelog.snap
+++ b/test-vectors/csv-verbosity-full/expected-output/changelog.snap
@@ -1,0 +1,13 @@
+---
+source: binoc-stdlib/src/test_vectors.rs
+expression: "&md"
+---
+# Changelog: snapshot-a → snapshot-b
+
+- **data.csv**: 5 cells changed
+  - Changed cells; use `binoc extract CHANGESET "data.csv" cells_changed` for all changed cells
+    - row 1, column 'score': '10' -> '11'
+    - row 2, column 'score': '20' -> '21'
+    - row 3, column 'score': '30' -> '31'
+    - row 4, column 'score': '40' -> '41'
+    - row 5, column 'score': '50' -> '51'

--- a/test-vectors/csv-verbosity-full/expected-output/changeset.snap
+++ b/test-vectors/csv-verbosity-full/expected-output/changeset.snap
@@ -1,0 +1,136 @@
+---
+source: binoc-stdlib/src/test_vectors.rs
+expression: "&stable_changeset"
+---
+{
+  "from_snapshot": "snapshot-a",
+  "to_snapshot": "snapshot-b",
+  "root": {
+    "action": "modify",
+    "item_type": "directory",
+    "path": "",
+    "children": [
+      {
+        "action": "modify",
+        "item_type": "tabular",
+        "path": "data.csv",
+        "summary": "5 cells changed",
+        "tags": [
+          "binoc.cell-change"
+        ],
+        "details": {
+          "cells_changed": 5,
+          "columns_added": [],
+          "columns_left": [
+            "name",
+            "score",
+            "status"
+          ],
+          "columns_removed": [],
+          "columns_right": [
+            "name",
+            "score",
+            "status"
+          ],
+          "hash_left": "39aa5d33ab998f37a8d1450b1b905a610c62dfdbc4c049524fac6f8dd83826fd",
+          "hash_right": "3a6797a7abe1d941dbc9e48b613806f84dc1c61f7e4d26fabb0a444046756758",
+          "rows_added": 0,
+          "rows_left": 5,
+          "rows_removed": 0,
+          "rows_right": 5
+        },
+        "detail_blocks": [
+          {
+            "id": "cells_changed",
+            "kind": "binoc.tabular.cell_changes.v1",
+            "label": "Changed cells",
+            "total_count": 5,
+            "examples": [
+              {
+                "locator": {
+                  "column": "score",
+                  "row": 0
+                },
+                "before": {
+                  "value": "10",
+                  "media_type": "text/plain"
+                },
+                "after": {
+                  "value": "11",
+                  "media_type": "text/plain"
+                }
+              },
+              {
+                "locator": {
+                  "column": "score",
+                  "row": 1
+                },
+                "before": {
+                  "value": "20",
+                  "media_type": "text/plain"
+                },
+                "after": {
+                  "value": "21",
+                  "media_type": "text/plain"
+                }
+              },
+              {
+                "locator": {
+                  "column": "score",
+                  "row": 2
+                },
+                "before": {
+                  "value": "30",
+                  "media_type": "text/plain"
+                },
+                "after": {
+                  "value": "31",
+                  "media_type": "text/plain"
+                }
+              },
+              {
+                "locator": {
+                  "column": "score",
+                  "row": 3
+                },
+                "before": {
+                  "value": "40",
+                  "media_type": "text/plain"
+                },
+                "after": {
+                  "value": "41",
+                  "media_type": "text/plain"
+                }
+              },
+              {
+                "locator": {
+                  "column": "score",
+                  "row": 4
+                },
+                "before": {
+                  "value": "50",
+                  "media_type": "text/plain"
+                },
+                "after": {
+                  "value": "51",
+                  "media_type": "text/plain"
+                }
+              }
+            ],
+            "extract": [
+              {
+                "aspect": "cells_changed",
+                "label": "All changed cells"
+              }
+            ]
+          }
+        ],
+        "comparator": "binoc.csv",
+        "transformed_by": [
+          "binoc.tabular_analyzer"
+        ]
+      }
+    ],
+    "comparator": "binoc.directory"
+  }
+}

--- a/test-vectors/csv-verbosity-full/manifest.toml
+++ b/test-vectors/csv-verbosity-full/manifest.toml
@@ -1,0 +1,14 @@
+[vector]
+name = "csv-verbosity-full"
+description = "Markdown full verbosity renders every captured changed-cell example"
+tags = ["csv", "cell-change", "verbosity"]
+
+[docs]
+summary = "Markdown full verbosity renders every captured changed-cell example."
+setup = "This example sets `output.markdown.verbosity: full` so the changelog prints every captured changed-cell example instead of the default capped sample."
+
+[config]
+output = { markdown = { verbosity = "full" } }
+
+[expected]
+has_tags = ["binoc.cell-change"]

--- a/test-vectors/csv-verbosity-full/snapshot-a/data.csv
+++ b/test-vectors/csv-verbosity-full/snapshot-a/data.csv
@@ -1,0 +1,6 @@
+name,score,status
+Alice,10,draft
+Bob,20,draft
+Carol,30,draft
+Dave,40,draft
+Eve,50,draft

--- a/test-vectors/csv-verbosity-full/snapshot-b/data.csv
+++ b/test-vectors/csv-verbosity-full/snapshot-b/data.csv
@@ -1,0 +1,6 @@
+name,score,status
+Alice,11,draft
+Bob,21,draft
+Carol,31,draft
+Dave,41,draft
+Eve,51,draft

--- a/test-vectors/directory-nested-with-tar/expected-output/changelog.snap
+++ b/test-vectors/directory-nested-with-tar/expected-output/changelog.snap
@@ -6,3 +6,5 @@ expression: "&md"
 
 - **data/records.csv**: 1 row added
 - **data.tar.gz/records.csv**: 1 cell changed
+  - Changed cells; use `binoc extract CHANGESET "data.tar.gz/records.csv" cells_changed` for all changed cells
+    - row 2, column 'count': '20' -> '25'

--- a/test-vectors/directory-nested-with-tar/expected-output/changeset.snap
+++ b/test-vectors/directory-nested-with-tar/expected-output/changeset.snap
@@ -87,6 +87,36 @@ expression: "&stable_changeset"
                   "rows_removed": 0,
                   "rows_right": 3
                 },
+                "detail_blocks": [
+                  {
+                    "id": "cells_changed",
+                    "kind": "binoc.tabular.cell_changes.v1",
+                    "label": "Changed cells",
+                    "total_count": 1,
+                    "examples": [
+                      {
+                        "locator": {
+                          "column": "count",
+                          "row": 1
+                        },
+                        "before": {
+                          "value": "20",
+                          "media_type": "text/plain"
+                        },
+                        "after": {
+                          "value": "25",
+                          "media_type": "text/plain"
+                        }
+                      }
+                    ],
+                    "extract": [
+                      {
+                        "aspect": "cells_changed",
+                        "label": "All changed cells"
+                      }
+                    ]
+                  }
+                ],
                 "comparator": "binoc.csv",
                 "transformed_by": [
                   "binoc.tabular_analyzer"

--- a/test-vectors/kitchen-sink/expected-output/changelog.snap
+++ b/test-vectors/kitchen-sink/expected-output/changelog.snap
@@ -7,6 +7,9 @@ expression: "&md"
 - **archive.tar.gz/inventory.csv**: 1 row added
 - **bundle.zip/notes.txt**: 2 lines added, 1 removed
 - **data.csv**: 2 cells changed
+  - Changed cells; use `binoc extract CHANGESET "data.csv" cells_changed` for all changed cells
+    - row 1, column 'age': '30' -> '31'
+    - row 3, column 'city': 'Seattle' -> 'Portland'
 - **docs/new-file.txt**: New file (1 line)
 - **docs/old-notes.txt**: File removed (1 line)
 - **docs/readme.txt**: 2 lines added, 2 removed

--- a/test-vectors/kitchen-sink/expected-output/changeset.snap
+++ b/test-vectors/kitchen-sink/expected-output/changeset.snap
@@ -130,6 +130,50 @@ expression: "&stable_changeset"
           "rows_removed": 0,
           "rows_right": 3
         },
+        "detail_blocks": [
+          {
+            "id": "cells_changed",
+            "kind": "binoc.tabular.cell_changes.v1",
+            "label": "Changed cells",
+            "total_count": 2,
+            "examples": [
+              {
+                "locator": {
+                  "column": "age",
+                  "row": 0
+                },
+                "before": {
+                  "value": "30",
+                  "media_type": "text/plain"
+                },
+                "after": {
+                  "value": "31",
+                  "media_type": "text/plain"
+                }
+              },
+              {
+                "locator": {
+                  "column": "city",
+                  "row": 2
+                },
+                "before": {
+                  "value": "Seattle",
+                  "media_type": "text/plain"
+                },
+                "after": {
+                  "value": "Portland",
+                  "media_type": "text/plain"
+                }
+              }
+            ],
+            "extract": [
+              {
+                "aspect": "cells_changed",
+                "label": "All changed cells"
+              }
+            ]
+          }
+        ],
         "comparator": "binoc.csv",
         "transformed_by": [
           "binoc.tabular_analyzer"

--- a/test-vectors/tsv-cell-changes/expected-output/changelog.snap
+++ b/test-vectors/tsv-cell-changes/expected-output/changelog.snap
@@ -5,3 +5,6 @@ expression: "&md"
 # Changelog: snapshot-a → snapshot-b
 
 - **data.tsv**: 2 cells changed
+  - Changed cells; use `binoc extract CHANGESET "data.tsv" cells_changed` for all changed cells
+    - row 1, column 'age': '30' -> '31'
+    - row 2, column 'city': 'Boston' -> 'Cambridge'

--- a/test-vectors/tsv-cell-changes/expected-output/changeset.snap
+++ b/test-vectors/tsv-cell-changes/expected-output/changeset.snap
@@ -39,6 +39,50 @@ expression: "&stable_changeset"
           "rows_removed": 0,
           "rows_right": 2
         },
+        "detail_blocks": [
+          {
+            "id": "cells_changed",
+            "kind": "binoc.tabular.cell_changes.v1",
+            "label": "Changed cells",
+            "total_count": 2,
+            "examples": [
+              {
+                "locator": {
+                  "column": "age",
+                  "row": 0
+                },
+                "before": {
+                  "value": "30",
+                  "media_type": "text/plain"
+                },
+                "after": {
+                  "value": "31",
+                  "media_type": "text/plain"
+                }
+              },
+              {
+                "locator": {
+                  "column": "city",
+                  "row": 1
+                },
+                "before": {
+                  "value": "Boston",
+                  "media_type": "text/plain"
+                },
+                "after": {
+                  "value": "Cambridge",
+                  "media_type": "text/plain"
+                }
+              }
+            ],
+            "extract": [
+              {
+                "aspect": "cells_changed",
+                "label": "All changed cells"
+              }
+            ]
+          }
+        ],
         "comparator": "binoc.csv",
         "transformed_by": [
           "binoc.tabular_analyzer"


### PR DESCRIPTION
## Summary

This PR adds the renderer-visible detail-block model described in the example verbosity ADR and demonstrates it on tabular cell changes. `DiffNode` now carries structured `detail_blocks` with bounded examples, value previews, and extract hints; `TabularAnalyzer` captures changed-cell examples while it still has tabular context; and the Markdown renderer supports `summary`, `examples`, and `full` verbosity with per-block, per-node, value-length, and total rendered detail budgets.

The default Markdown behavior remains `examples`, so changelogs show a bounded sample and point to `binoc extract` for exhaustive changed data. `summary` hides detail blocks, and `full` renders all captured examples without reopening source data.

The PR also adds vector harness support for manifest `config.output`, plus `csv-verbosity-full`, a shared vector that sets `output.markdown.verbosity: full` and visibly renders all five captured changed-cell examples.

## Design Notes

- `details` remains plugin-private metrics; `detail_blocks` is the renderer-visible evidence contract.
- Producers capture bounded examples; renderers decide display volume.
- Exhaustive retrieval stays on the existing `binoc extract` path via `ExtractHint`.
- The controller remains type-ignorant. All tabular knowledge stays in stdlib transformer/rendering conventions.

Fixes #52
