### PR TITLE
Add unified dataset config substrate

### DIFF
--- a/binoc-cli/src/lib.rs
+++ b/binoc-cli/src/lib.rs
@@ -283,7 +283,8 @@ pub fn run(
             let resolved = registry.resolve(&dataset_config)?;
             let controller =
                 Controller::new(resolved.comparators.clone(), resolved.transformers.clone())
-                    .with_transformer_configs(dataset_config.transformer_config.as_map());
+                    .with_transformer_configs(dataset_config.transformer_config.as_map())
+                    .with_dataset_config(dataset_config.dataset.clone());
 
             let snapshots: Vec<String> = snapshots
                 .iter()
@@ -365,7 +366,8 @@ pub fn run(
 
             let resolved = registry.resolve(&dataset_config)?;
             let controller = Controller::new(resolved.comparators, resolved.transformers)
-                .with_transformer_configs(dataset_config.transformer_config.as_map());
+                .with_transformer_configs(dataset_config.transformer_config.as_map())
+                .with_dataset_config(dataset_config.dataset.clone());
 
             match controller.extract(&changeset, &node, &aspect, &snap_a, &snap_b) {
                 Ok(result) => match result {

--- a/binoc-core/src/config.rs
+++ b/binoc-core/src/config.rs
@@ -16,6 +16,10 @@ pub struct DatasetConfig {
     pub renderers: Vec<String>,
     #[serde(default)]
     pub output: OutputConfig,
+    /// Dataset-level semantic configuration. Core carries this JSON and passes
+    /// it through to plugins, but does not interpret it.
+    #[serde(default)]
+    pub dataset: serde_json::Value,
     /// Per-transformer configuration, keyed by transformer name
     /// (e.g. `"binoc.folder_move_detector"`). Unset entries pass
     /// [`serde_json::Value::Null`] to the transformer.
@@ -108,6 +112,7 @@ impl DatasetConfig {
             ],
             renderers: default_renderers(),
             output: OutputConfig::default(),
+            dataset: serde_json::Value::Null,
             transformer_config: TransformerConfig::default(),
         }
     }
@@ -374,6 +379,7 @@ mod tests {
             transformers: vec![],
             renderers: vec![],
             output: OutputConfig::default(),
+            dataset: serde_json::Value::Null,
             transformer_config: TransformerConfig::default(),
         };
         let result = registry.resolve(&config);
@@ -398,6 +404,7 @@ mod tests {
             transformers: vec![],
             renderers: vec![],
             output: OutputConfig::default(),
+            dataset: serde_json::Value::Null,
             transformer_config: TransformerConfig::default(),
         };
         let resolved = registry.resolve(&config).unwrap();

--- a/binoc-core/src/controller.rs
+++ b/binoc-core/src/controller.rs
@@ -16,6 +16,7 @@ pub struct Controller {
     comparators: Vec<(Arc<dyn Comparator>, ComparatorDescriptor)>,
     transformers: Vec<(Arc<dyn Transformer>, TransformerDescriptor)>,
     transformer_configs: BTreeMap<String, serde_json::Value>,
+    dataset_config: serde_json::Value,
 }
 
 impl Controller {
@@ -42,6 +43,7 @@ impl Controller {
             comparators,
             transformers,
             transformer_configs: BTreeMap::new(),
+            dataset_config: serde_json::Value::Null,
         }
     }
 
@@ -56,11 +58,37 @@ impl Controller {
         self
     }
 
+    /// Attach dataset-level semantic configuration. The controller does not
+    /// deserialize this value; it is exposed to plugins under `dataset`.
+    pub fn with_dataset_config(mut self, config: serde_json::Value) -> Self {
+        self.dataset_config = config;
+        self
+    }
+
     fn config_for(&self, name: &str) -> serde_json::Value {
-        self.transformer_configs
+        let plugin = self
+            .transformer_configs
             .get(name)
             .cloned()
-            .unwrap_or(serde_json::Value::Null)
+            .unwrap_or(serde_json::Value::Null);
+        if self.dataset_config.is_null() {
+            return plugin;
+        }
+
+        match plugin {
+            serde_json::Value::Object(mut map) => {
+                map.entry("dataset")
+                    .or_insert_with(|| self.dataset_config.clone());
+                serde_json::Value::Object(map)
+            }
+            serde_json::Value::Null => serde_json::json!({
+                "dataset": self.dataset_config.clone(),
+            }),
+            other => serde_json::json!({
+                "plugin": other,
+                "dataset": self.dataset_config.clone(),
+            }),
+        }
     }
 
     /// Diff two snapshots and produce a changeset.
@@ -1140,7 +1168,18 @@ mod tests {
         );
 
         let controller = Controller::new(vec![leaf_comparator()], vec![reader])
-            .with_transformer_configs(configs);
+            .with_transformer_configs(configs)
+            .with_dataset_config(serde_json::json!({
+                "tables": {
+                    "entries": {
+                        "people": {
+                            "row_identity": {
+                                "columns": ["id"]
+                            }
+                        }
+                    }
+                }
+            }));
         let dir = tempfile::tempdir().unwrap();
         controller
             .diff(
@@ -1149,6 +1188,22 @@ mod tests {
             )
             .unwrap();
         let got = out.lock().unwrap().clone();
-        assert_eq!(got, serde_json::json!({ "threshold": 0.42 }));
+        assert_eq!(
+            got,
+            serde_json::json!({
+                "threshold": 0.42,
+                "dataset": {
+                    "tables": {
+                        "entries": {
+                            "people": {
+                                "row_identity": {
+                                    "columns": ["id"]
+                                }
+                            }
+                        }
+                    }
+                }
+            })
+        );
     }
 }

--- a/binoc-python/src/lib.rs
+++ b/binoc-python/src/lib.rs
@@ -1602,7 +1602,9 @@ fn build_controller(
         transformers.push(Arc::new(bridge));
     }
 
-    Ok(Controller::new(comparators, transformers))
+    Ok(Controller::new(comparators, transformers)
+        .with_transformer_configs(config.dataset_config.transformer_config.as_map())
+        .with_dataset_config(config.dataset_config.dataset.clone()))
 }
 
 /// Diff two snapshots and return the resulting :class:`Changeset`.

--- a/binoc-sdk/src/types.rs
+++ b/binoc-sdk/src/types.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 
 use crate::ir::DiffNode;
@@ -117,6 +119,135 @@ impl TabularData {
         }
         out
     }
+}
+
+// ── Dataset semantics config ───────────────────────────────────────
+
+/// SDK-owned dataset semantics section shared by plugins.
+///
+/// Hosts pass this through unchanged; plugins deserialize the parts they
+/// understand. The schema is intentionally conservative in v1.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DatasetSemanticsV1 {
+    #[serde(default)]
+    pub files: FileIdentityConfig,
+    #[serde(default)]
+    pub tables: TableConfig,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct FileIdentityConfig {
+    #[serde(default)]
+    pub correspondences: Vec<FileCorrespondenceRule>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileCorrespondenceRule {
+    pub name: String,
+    #[serde(default)]
+    pub left: FileSelector,
+    #[serde(default)]
+    pub right: FileSelector,
+    pub key: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub logical_path: Option<String>,
+    #[serde(default)]
+    pub cardinality: Cardinality,
+    #[serde(default)]
+    pub on_null_key: IdentityFailurePolicy,
+    #[serde(default)]
+    pub on_duplicate_key: IdentityFailurePolicy,
+    #[serde(default)]
+    pub report_path_change: bool,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct FileSelector {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path_regex: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Cardinality {
+    #[default]
+    OneToOne,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IdentityFailurePolicy {
+    #[default]
+    Diagnostic,
+    Error,
+    Ignore,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TableConfig {
+    #[serde(default)]
+    pub defaults: TableDefaults,
+    #[serde(default)]
+    pub entries: BTreeMap<String, TableEntry>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TableDefaults {
+    #[serde(default)]
+    pub parse: TabularParseConfig,
+    #[serde(default)]
+    pub row_identity: RowIdentity,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TableEntry {
+    #[serde(default, rename = "match")]
+    pub match_: TableSelector,
+    #[serde(default)]
+    pub parse: TabularParseConfig,
+    #[serde(default)]
+    pub row_identity: RowIdentity,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TableSelector {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub logical_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<FileSelector>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TabularParseConfig {
+    #[serde(default = "default_header")]
+    pub header: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub delimiter: Option<String>,
+}
+
+impl Default for TabularParseConfig {
+    fn default() -> Self {
+        Self {
+            header: true,
+            delimiter: None,
+        }
+    }
+}
+
+fn default_header() -> bool {
+    true
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RowIdentity {
+    #[serde(default)]
+    pub columns: Vec<String>,
+    #[serde(default)]
+    pub cardinality: Cardinality,
+    #[serde(default)]
+    pub on_null_key: IdentityFailurePolicy,
+    #[serde(default)]
+    pub on_duplicate_key: IdentityFailurePolicy,
 }
 
 /// A pair of tabular data (left/right sides of a comparison).

--- a/binoc-stdlib/src/test_vectors.rs
+++ b/binoc-stdlib/src/test_vectors.rs
@@ -61,6 +61,8 @@ struct ManifestConfig {
     output: Option<OutputConfig>,
     #[serde(default)]
     transformer_config: Option<TransformerConfig>,
+    #[serde(default)]
+    dataset: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -349,7 +351,8 @@ pub fn run_vector(
         )
     });
     let controller = Controller::new(resolved.comparators, resolved.transformers)
-        .with_transformer_configs(config.transformer_config.as_map());
+        .with_transformer_configs(config.transformer_config.as_map())
+        .with_dataset_config(config.dataset.clone());
 
     let changeset = controller
         .diff(diff_a.to_str().unwrap(), diff_b.to_str().unwrap())
@@ -425,7 +428,8 @@ pub fn run_vector_with_abi_log(
     });
     let direct_controller =
         Controller::new(direct_resolved.comparators, direct_resolved.transformers)
-            .with_transformer_configs(config.transformer_config.as_map());
+            .with_transformer_configs(config.transformer_config.as_map())
+            .with_dataset_config(config.dataset.clone());
     let direct_changeset = pool
         .install(|| direct_controller.diff(diff_a.to_str().unwrap(), diff_b.to_str().unwrap()))
         .unwrap_or_else(|e| panic!("Direct diff failed for {}: {e}", manifest.vector.name));
@@ -440,7 +444,8 @@ pub fn run_vector_with_abi_log(
         )
     });
     let abi_controller = Controller::new(abi_resolved.comparators, abi_resolved.transformers)
-        .with_transformer_configs(config.transformer_config.as_map());
+        .with_transformer_configs(config.transformer_config.as_map())
+        .with_dataset_config(config.dataset.clone());
     let abi_changeset = pool
         .install(|| abi_controller.diff(diff_a.to_str().unwrap(), diff_b.to_str().unwrap()))
         .unwrap_or_else(|e| panic!("ABI diff failed for {}: {e}", manifest.vector.name));
@@ -551,6 +556,7 @@ fn build_config(manifest: &Manifest) -> DatasetConfig {
                 transformers: cfg.transformers.clone().unwrap_or(default.transformers),
                 renderers: default.renderers,
                 output: cfg.output.clone().unwrap_or(default.output),
+                dataset: cfg.dataset.clone().unwrap_or(default.dataset),
                 transformer_config: cfg
                     .transformer_config
                     .clone()

--- a/docs/adr/2026-06-01-unified_dataset_config_and_identity.md
+++ b/docs/adr/2026-06-01-unified_dataset_config_and_identity.md
@@ -1,0 +1,352 @@
+# Unified Dataset Config and Identity Policy
+
+**Date:** 2026-06-01
+**Status:** Accepted
+
+Note: the Markdown-renderer grouping example below is superseded by
+[2026-06-02-renderer_groups.md](2026-06-02-renderer_groups.md). Current config
+uses `output.markdown.groups`, not `output.markdown.significance`.
+
+## Context
+
+Several tabular features need the same concept but have been phrased as separate
+requests:
+
+- keyed row identity for tables, such as FDA product rows keyed by
+  `["BLA Number", "Product Number"]`
+- declared file correspondence across snapshots, where two different paths
+  should be treated as the same logical file
+- tabular parse options, especially delimiter selection
+- different table keys and parse options within one multi-table dataset
+- clear behavior when keys are null, duplicated, one-to-many, or many-to-one
+
+Treating each feature as plugin-specific configuration would make real datasets
+awkward to describe. A workbook, a SQLite database, and a directory full of CSVs
+can all be "the same dataset" from the user's perspective. The configuration
+surface should let users describe dataset semantics once, while plugins consume
+the parts they understand.
+
+At the same time, Binoc's core rules still apply:
+
+- the controller must remain type-ignorant
+- comparators parse source data into IR and artifacts
+- transformers optimize or annotate IR and may request re-comparison through
+  `pending_recompare`
+- significance remains a renderer concern
+- configuration is passed into the run, not read from global state
+
+## Decision
+
+Binoc will add a unified, SDK-owned dataset semantics section to the dataset
+config. It describes file identity, table identity, row identity, and parse
+options in one place. Core may carry this config and pass it to plugins, but it
+does not interpret paths, tables, delimiters, or keys.
+
+The existing orchestration sections stay:
+
+```yaml
+comparators:
+  - binoc.zip
+  - binoc.tar
+  - binoc.directory
+  - binoc.csv
+  - binoc.text
+  - binoc.binary
+
+transformers:
+  - binoc.declared_correspondence
+  - binoc.correlation_detector
+  - binoc.fuzzy_correlation_detector
+  - binoc.folder_move_detector
+  - binoc.tabular_analyzer
+  - binoc.column_reorder_detector
+
+output:
+  markdown:
+    groups:
+      - heading: "Substantive changes"
+        tags: [binoc.schema-change, binoc.row-addition]
+      - heading: "Clerical follow-up"
+        tags: [binoc.column-reorder]
+```
+
+The new semantic section is separate from plugin order:
+
+```yaml
+dataset:
+  files:
+    correspondences:
+      - name: fda-quarterly-csvs
+        left:
+          path_regex: '^raw/(?P<table>[^/]+)/(?P<year>[0-9]{4})\.csv$'
+        right:
+          path_regex: '^normalized/(?P<year>[0-9]{4})/(?P<table>[^/]+)\.csv$'
+        key: '${table}:${year}'
+        logical_path: 'tables/${table}-${year}.csv'
+        cardinality: one-to-one
+        on_null_key: diagnostic
+        on_duplicate_key: diagnostic
+        report_path_change: false
+
+  tables:
+    defaults:
+      parse:
+        header: true
+        delimiter: ','
+      row_identity:
+        on_null_key: diagnostic
+        on_duplicate_key: diagnostic
+
+    entries:
+      applications:
+        match:
+          logical_name: applications
+        parse:
+          delimiter: ','
+        row_identity:
+          columns: ['ApplNo']
+
+      products:
+        match:
+          logical_name: products
+        row_identity:
+          columns: ['BLA Number', 'Product Number']
+
+      adverse_events:
+        match:
+          source:
+            path_regex: '^events/.*\.tsv$'
+        parse:
+          delimiter: '\t'
+        row_identity:
+          columns: ['case_id', 'event_seq']
+```
+
+### Type sketch
+
+The SDK owns the schema and helper types. The exact Rust names can move during
+implementation, but the shape is:
+
+```rust
+pub struct DatasetSemanticsV1 {
+    pub files: FileIdentityConfig,
+    pub tables: TableConfig,
+}
+
+pub struct FileIdentityConfig {
+    pub correspondences: Vec<FileCorrespondenceRule>,
+}
+
+pub struct FileCorrespondenceRule {
+    pub name: String,
+    pub left: FileSelector,
+    pub right: FileSelector,
+    pub key: Template,
+    pub logical_path: Option<Template>,
+    pub cardinality: Cardinality,
+    pub on_null_key: IdentityFailurePolicy,
+    pub on_duplicate_key: IdentityFailurePolicy,
+    pub report_path_change: bool,
+}
+
+pub struct TableConfig {
+    pub defaults: TableDefaults,
+    pub entries: BTreeMap<String, TableEntry>,
+}
+
+pub struct TableEntry {
+    pub match_: TableSelector,
+    pub parse: TabularParseOptions,
+    pub row_identity: RowIdentity,
+}
+
+pub struct RowIdentity {
+    pub columns: Vec<String>,
+    pub cardinality: Cardinality,
+    pub on_null_key: IdentityFailurePolicy,
+    pub on_duplicate_key: IdentityFailurePolicy,
+}
+
+pub enum Cardinality {
+    OneToOne,
+}
+
+pub enum IdentityFailurePolicy {
+    Diagnostic,
+    Error,
+    Ignore,
+}
+```
+
+`Cardinality` is intentionally narrow in v1. User language can name the hazard
+as "one-to-many" or "many-to-one", but Binoc will not auto-match those shapes
+until a concrete aggregate matching design exists.
+
+Plugin-specific config remains available for plugin knobs that are not dataset
+semantics. The current `transformer_config` pattern should be mirrored for
+comparators as `comparator_config`; renderers keep using `output.<renderer>`.
+The semantic `dataset` section is the preferred surface for keys, parse options,
+and correspondence rules. The lower-level per-plugin sections remain escape
+hatches, not the main UX.
+
+### Comparators and transformers receive run config
+
+Comparators need configuration for parse options, and transformers need the same
+semantic config for keyed row analysis and declared file correspondence. The
+follow-on implementation should pass a run-config view to plugins, analogous to
+the current renderer and transformer config values:
+
+```rust
+pub struct PluginRunConfig<'a> {
+    /// The comparator_config / transformer_config / output value selected for
+    /// this plugin, depending on plugin kind.
+    pub plugin: &'a serde_json::Value,
+
+    /// The top-level dataset semantics value, passed through unchanged by core.
+    pub dataset: &'a serde_json::Value,
+}
+```
+
+Core only selects the plugin's own config value and passes the dataset semantics
+value through. It does not deserialize or act on table/file fields. SDK/stdlib
+helpers deserialize `dataset` into `DatasetSemanticsV1` for plugins that opt in.
+
+This is a trait/config plumbing change, not a comparator-to-transformer pipeline
+rework. The existing pipeline remains:
+
+1. comparators build the initial tree and publish artifacts
+2. root-scope correlation transformers rewrite or inflate the tree
+3. data-shape transformers analyze artifacts
+4. renderers classify and format tags
+
+### File correspondence is an explicit correlation pass
+
+Declared file correspondence belongs before heuristic move/copy detection. It is
+implemented as a root-scope transformer, tentatively
+`binoc.declared_correspondence`, ordered before `binoc.correlation_detector` and
+`binoc.fuzzy_correlation_detector`.
+
+The transformer:
+
+1. walks residual add/remove leaves
+2. applies user-declared correspondence rules
+3. builds a key index from the left and right selectors
+4. pairs only unambiguous one-to-one matches
+5. creates a node at the declared `logical_path` or the right path
+6. sets `pending_recompare` so the normal comparator pipeline parses the pair
+
+This uses the existing transformer-initiated re-dispatch mechanism from the
+rename-and-modify ADR. No new controller phase is required.
+
+Declared correspondence is not a replacement for the move detectors:
+
+- declared correspondence is user-supplied identity
+- exact/fuzzy correlation is inferred content similarity
+- `folder_move_detector` is a reporting rollup over already-detected file moves
+
+Declared matches are removed from the residual add/remove pool before heuristic
+detectors run, so the two layers do not double count. If
+`report_path_change: false`, a path difference is treated as snapshot layout and
+is not rendered as a move. If `report_path_change: true`, the node gets a factual
+path-change tag and source/destination details; renderers may surface that
+without treating it as a heuristic `binoc.move`.
+
+### Row identity is table-local
+
+Row keys live on table entries, not globally. A dataset can have different keys
+per logical table:
+
+```yaml
+dataset:
+  tables:
+    entries:
+      applications:
+        row_identity:
+          columns: ['ApplNo']
+      products:
+        row_identity:
+          columns: ['BLA Number', 'Product Number']
+```
+
+The tabular analyzer resolves the current table identity from the table
+collection artifact or from the single-table source location. It then applies
+the matching table entry and compares rows by key instead of position.
+
+No configured key means the current positional behavior is retained. That is
+important for simple CSVs without stable IDs.
+
+### Null, duplicate, and many-to-many policy
+
+File keys and row keys use the same identity-index rule:
+
+| Left count | Right count | Result |
+|---|---|---|
+| 1 | 1 | match |
+| 1 | 0 | removal |
+| 0 | 1 | addition |
+| 0 | N | additions, unless null/duplicate policy says otherwise |
+| N | 0 | removals, unless null/duplicate policy says otherwise |
+| 1 | N | ambiguous one-to-many |
+| N | 1 | ambiguous many-to-one |
+| N | M | ambiguous many-to-many |
+
+`N` means more than one item for the same normalized key. The default
+`diagnostic` policy does not guess. It emits an identity diagnostic tag and
+details, leaves the ambiguous members unmatched, and lets normal add/remove
+reporting continue. `error` fails the run with a config/data quality error.
+`ignore` suppresses the diagnostic and treats the members as if no key existed
+for them.
+
+Standard tags:
+
+- `binoc.identity-diagnostic`
+- `binoc.null-key`
+- `binoc.duplicate-key`
+- `binoc.ambiguous-key`
+- `binoc.file-correspondence-ambiguous`
+- `binoc.row-identity-ambiguous`
+
+The renderer may group these as warnings or review-first changes through normal
+significance config. The IR still carries factual tags only.
+
+## Consequences
+
+- Users get one place to describe dataset semantics, even when those semantics
+  affect multiple plugins.
+- CSV delimiter and other parse options now have a proper config path; the CSV
+  comparator will need comparator config plumbing.
+- Keyed row diffs and file correspondence share the same conservative identity
+  failure policy.
+- Declared correspondence runs before heuristic move/copy detectors but does
+  not replace them.
+- The controller remains type-ignorant: it passes JSON config through and
+  handles `pending_recompare`, but it does not understand tables or paths.
+- Follow-on implementation can proceed without a new pipeline architecture.
+
+## Alternatives Considered
+
+**Put everything in per-plugin config.** This fits the current
+`transformer_config` model but creates a scattered UX: CSV delimiter in one
+place, row keys in another, file correspondence in a third. It also makes
+multi-table datasets awkward because the same logical table metadata would need
+to be repeated for each plugin that cares.
+
+**Teach the controller about file correspondence before directory comparison.**
+This would pair files earlier, but it makes the controller understand paths and
+dataset identity. A root-scope declared-correspondence transformer preserves the
+existing type-ignorant controller and reuses `pending_recompare`.
+
+**Treat declared correspondence as a generalization that replaces move
+detectors.** Rejected because declared identity and inferred similarity answer
+different questions. A user declaration can say two changing paths are the same
+logical file even when their contents differ. A heuristic detector can still
+find moves that users did not configure.
+
+**Auto-match duplicate keys greedily.** Rejected for both rows and files.
+Greedy pairing can fabricate precise-looking cell or file changes from
+ambiguous identity. Binoc should report the ambiguity and require either better
+keys or a future explicit aggregate matching mode.
+
+**Promote key failures directly to significance levels.** Rejected for the same
+reason significance is not in the IR. Key failures are factual tags; renderers
+decide whether they are warnings, clerical issues, or substantive review items.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -7,6 +7,7 @@ Newer entries appear first. Each entry shows its date and current status. Create
 | Date | Title | Status |
 |---|---|---|
 | 2026-06-02 | [Markdown Renderer Groups Replace Significance-Map Grouping](2026-06-02-renderer_groups.md) | Implemented |
+| 2026-06-01 | [Unified Dataset Config and Identity Policy](2026-06-01-unified_dataset_config_and_identity.md) | Accepted |
 | 2026-06-01 | [Optional First-Party Plugins and `binoc[all]`](2026-06-01-optional_first_party_plugins.md) | Accepted |
 | 2026-06-01 | [Example Verbosity and Plugin-Supplied Details](2026-06-01-example_verbosity.md) | Decided |
 | 2026-06-01 | [Diagnostics Channel for Non-Fatal Warnings and Suggestions](2026-06-01-diagnostics_channel.md) | Implemented |

--- a/docs/reference/dataset-config.md
+++ b/docs/reference/dataset-config.md
@@ -11,6 +11,8 @@ the defaults handle the built-in comparators. A config becomes
 useful when you want to:
 
 - Restrict or reorder the comparator / transformer pipeline.
+- Declare dataset semantics, such as logical file correspondence and
+  row identity, for plugins that understand those fields.
 - Teach the Markdown renderer how to group plugin-specific tags for
   your domain.
 - Configure a renderer's behavior (HTML theme, CI failure rules, …)
@@ -38,6 +40,35 @@ transformers:
   - binoc.folder_move_detector
   - binoc.tabular_analyzer
   - binoc.column_reorder_detector
+
+dataset:
+  files:
+    correspondences:
+      - name: quarterly-csvs
+        left:
+          path_regex: '^raw/(?P<table>[^/]+)/(?P<year>[0-9]{4})\.csv$'
+        right:
+          path_regex: '^normalized/(?P<year>[0-9]{4})/(?P<table>[^/]+)\.csv$'
+        key: '${table}:${year}'
+        logical_path: 'tables/${table}-${year}.csv'
+        cardinality: one-to-one
+        on_null_key: diagnostic
+        on_duplicate_key: diagnostic
+
+  tables:
+    defaults:
+      parse:
+        header: true
+        delimiter: ','
+      row_identity:
+        on_null_key: diagnostic
+        on_duplicate_key: diagnostic
+    entries:
+      products:
+        match:
+          logical_name: products
+        row_identity:
+          columns: ['BLA Number', 'Product Number']
 
 output:
   markdown:
@@ -108,6 +139,59 @@ transformer_config:
   binoc.folder_move_detector:
     threshold: 0.8
 ```
+
+## `dataset`
+
+The `dataset` block is a top-level semantic description of the dataset being
+compared. Core carries this value through unchanged and exposes it to plugins
+under the `dataset` key in their run config; core does not interpret paths,
+tables, delimiters, or keys.
+
+The SDK owns a shared v1 shape so independently authored plugins can agree on
+common dataset semantics:
+
+- `dataset.files.correspondences` declares that files with different snapshot
+  paths are the same logical file.
+- `dataset.tables.defaults` declares table-wide defaults, such as parse options
+  and row identity failure policy.
+- `dataset.tables.entries` declares per-table selectors, parse options, and row
+  identity keys.
+
+```yaml
+dataset:
+  files:
+    correspondences:
+      - name: state-records
+        left:
+          path_regex: '^data/state_(?P<state>[A-Z]{2})\.csv$'
+        right:
+          path_regex: '^by-state/(?P<state>[A-Z]{2})/records\.csv$'
+        key: '${state}'
+        logical_path: 'states/${state}.csv'
+        cardinality: one-to-one
+        on_null_key: diagnostic
+        on_duplicate_key: diagnostic
+        report_path_change: false
+
+  tables:
+    defaults:
+      row_identity:
+        on_null_key: diagnostic
+        on_duplicate_key: diagnostic
+    entries:
+      products:
+        match:
+          logical_name: products
+        parse:
+          header: true
+          delimiter: ','
+        row_identity:
+          columns: ['BLA Number', 'Product Number']
+```
+
+`cardinality` is currently `one-to-one`. `on_null_key` and
+`on_duplicate_key` accept `diagnostic`, `error`, or `ignore`; plugins decide how
+to apply those policies for the semantics they implement.
 
 ## `output.<renderer>`
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -162,6 +162,7 @@ nav:
           # BEGIN-ADR-NAV
           - adr/README.md
           - 'Markdown Renderer Groups Replace Significance-Map Grouping': adr/2026-06-02-renderer_groups.md
+          - 'Unified Dataset Config and Identity Policy': adr/2026-06-01-unified_dataset_config_and_identity.md
           - 'Optional First-Party Plugins and `binoc[all]`': adr/2026-06-01-optional_first_party_plugins.md
           - 'Example Verbosity and Plugin-Supplied Details': adr/2026-06-01-example_verbosity.md
           - 'Diagnostics Channel for Non-Fatal Warnings and Suggestions': adr/2026-06-01-diagnostics_channel.md


### PR DESCRIPTION
## Summary
- add a top-level `dataset` config value and pass it through to transformer run config without core interpreting it
- add SDK-owned dataset semantics types for file correspondences, table selectors, parse options, and row identity policy
- document the unified dataset config/identity decision and update the dataset config reference

## Notes
This intentionally stops at substrate. It does not implement keyed tabular diffs, declared correspondence matching, or the multitable artifact model. Those can build on this pass-through config and shared SDK schema in follow-up PRs.