### PR TITLE
Add shared tabular collection model

### DIFF
--- a/binoc-core/src/config.rs
+++ b/binoc-core/src/config.rs
@@ -110,6 +110,7 @@ impl DatasetConfig {
                 "binoc.folder_move_detector".into(),
                 "binoc.tabular_analyzer".into(),
                 "binoc.column_reorder_detector".into(),
+                "binoc.table_collection_analyzer".into(),
             ],
             renderers: default_renderers(),
             output: OutputConfig::default(),

--- a/binoc-sdk/src/types.rs
+++ b/binoc-sdk/src/types.rs
@@ -82,6 +82,15 @@ pub fn tabular_v1() -> ArtifactFormat {
     ArtifactFormat::new("binoc", "tabular", 1)
 }
 
+/// Standard manifest format for sources that contain multiple logical tables.
+///
+/// This artifact is a table-set manifest, not a copy of table data. Individual
+/// table nodes should still publish [`tabular_v1`] artifacts for row/column/cell
+/// analysis.
+pub fn tabular_collection_v1() -> ArtifactFormat {
+    ArtifactFormat::new("binoc", "tabular_collection", 1)
+}
+
 // ── Format-neutral data types ───────────────────────────────────────
 
 /// Format-neutral tabular data. Produced by CSV, Excel, Parquet comparators;
@@ -118,6 +127,84 @@ impl TabularData {
             out.push('\n');
         }
         out
+    }
+}
+
+/// Format-neutral manifest for a source that contains multiple logical tables.
+///
+/// This is the codec type for the [`tabular_collection_v1`] artifact format.
+/// Serialize with `serde_json::to_vec`, deserialize with `serde_json::from_slice`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TabularCollectionData {
+    pub tables: Vec<TableMember>,
+}
+
+/// One logical table within a [`TabularCollectionData`] manifest.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TableMember {
+    /// Stable identity used to match this table across snapshots.
+    pub logical_name: String,
+    /// Path of the table node in the IR.
+    pub node_path: String,
+    /// Provenance inside the source item.
+    pub source: TableSourceLocation,
+    /// Cheap shape summary. Full table data lives in `tabular_v1`.
+    pub shape: TableShape,
+    /// Optional plugin/domain metadata. Consumers must ignore unknown fields.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub metadata: BTreeMap<String, serde_json::Value>,
+}
+
+/// Where a logical table came from inside a source item.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TableSourceLocation {
+    /// Logical path of the source item in the Binoc tree.
+    pub item_path: String,
+    /// Open string such as "sheet", "sqlite_table", or "csv_region".
+    pub kind: String,
+    /// Source-specific locator values, such as `{"table": "products"}`.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub locator: BTreeMap<String, serde_json::Value>,
+}
+
+/// Shape summary for one logical table.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TableShape {
+    pub columns: Vec<String>,
+    pub row_count: Option<u64>,
+}
+
+/// A pair of tabular collection manifests (left/right sides of a comparison).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TabularCollectionDataPair {
+    pub left: Option<TabularCollectionData>,
+    pub right: Option<TabularCollectionData>,
+}
+
+impl TabularCollectionDataPair {
+    /// Build a `TabularCollectionDataPair` from [`tabular_collection_v1`]
+    /// artifacts on a node.
+    pub fn from_artifacts(
+        node: &crate::ir::DiffNode,
+        data: &dyn crate::traits::DataAccess,
+    ) -> Option<Self> {
+        let fmt = tabular_collection_v1();
+        let left = node
+            .artifacts
+            .iter()
+            .find(|a| a.format == fmt && a.subject == ArtifactSubject::Left)
+            .and_then(|desc| data.get_artifact(desc).ok()?)
+            .and_then(|bytes| serde_json::from_slice(&bytes).ok());
+        let right = node
+            .artifacts
+            .iter()
+            .find(|a| a.format == fmt && a.subject == ArtifactSubject::Right)
+            .and_then(|desc| data.get_artifact(desc).ok()?)
+            .and_then(|bytes| serde_json::from_slice(&bytes).ok());
+        if left.is_none() && right.is_none() {
+            return None;
+        }
+        Some(Self { left, right })
     }
 }
 

--- a/binoc-stdlib/src/lib.rs
+++ b/binoc-stdlib/src/lib.rs
@@ -31,6 +31,9 @@ pub fn register_stdlib(registry: &mut PluginRegistry) {
     r(registry.register_transformer(Arc::new(
         transformers::column_reorder::ColumnReorderDetector,
     )));
+    r(registry.register_transformer(Arc::new(
+        transformers::table_collection_analyzer::TableCollectionAnalyzer,
+    )));
 
     r(registry.register_renderer(Arc::new(MarkdownRenderer)));
 }

--- a/binoc-stdlib/src/test_vectors.rs
+++ b/binoc-stdlib/src/test_vectors.rs
@@ -332,6 +332,7 @@ pub fn abi_wrapped_default_registry() -> (
     wrap_transformer!(folder_move_detector::FolderMoveDetector);
     wrap_transformer!(tabular_analyzer::TabularAnalyzer);
     wrap_transformer!(column_reorder::ColumnReorderDetector);
+    wrap_transformer!(table_collection_analyzer::TableCollectionAnalyzer);
 
     registry
         .register_renderer(Arc::new(markdown::MarkdownRenderer))

--- a/binoc-stdlib/src/transformers/mod.rs
+++ b/binoc-stdlib/src/transformers/mod.rs
@@ -3,4 +3,5 @@ pub(crate) mod correlation;
 pub mod correlation_detector;
 pub mod folder_move_detector;
 pub mod fuzzy_correlation_detector;
+pub mod table_collection_analyzer;
 pub mod tabular_analyzer;

--- a/binoc-stdlib/src/transformers/table_collection_analyzer.rs
+++ b/binoc-stdlib/src/transformers/table_collection_analyzer.rs
@@ -1,0 +1,336 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use binoc_sdk::*;
+
+/// Analyzes `tabular_collection_v1` manifests to report table additions,
+/// removals, and changed table members without knowing the source format.
+pub struct TableCollectionAnalyzer;
+
+impl Transformer for TableCollectionAnalyzer {
+    fn descriptor(&self) -> TransformerDescriptor {
+        TransformerDescriptor::new("binoc.table_collection_analyzer")
+            .with_match_artifacts(vec![tabular_collection_v1()])
+    }
+
+    fn transform(
+        &self,
+        mut node: DiffNode,
+        data: &dyn DataAccess,
+        _config: &serde_json::Value,
+    ) -> TransformResult {
+        let Some(pair) = TabularCollectionDataPair::from_artifacts(&node, data) else {
+            return TransformResult::Unchanged;
+        };
+
+        let left = pair.left.as_ref().map(member_map).unwrap_or_default();
+        let right = pair.right.as_ref().map(member_map).unwrap_or_default();
+        let duplicate_names = duplicate_logical_names(pair.left.as_ref())
+            .into_iter()
+            .chain(duplicate_logical_names(pair.right.as_ref()))
+            .collect::<BTreeSet<_>>();
+
+        if !duplicate_names.is_empty() {
+            node.tags.insert("binoc.table-identity-ambiguous".into());
+            node.details.insert(
+                "ambiguous_tables".into(),
+                serde_json::json!(duplicate_names.into_iter().collect::<Vec<_>>()),
+            );
+        }
+
+        let mut added = Vec::new();
+        let mut removed = Vec::new();
+        let mut changed = Vec::new();
+
+        for name in right.keys() {
+            if !left.contains_key(name) {
+                added.push(name.clone());
+            }
+        }
+        for name in left.keys() {
+            if !right.contains_key(name) {
+                removed.push(name.clone());
+            }
+        }
+        for (name, left_member) in &left {
+            if let Some(right_member) = right.get(name) {
+                if table_changed(left_member, right_member, &node.children) {
+                    changed.push(name.clone());
+                }
+            }
+        }
+
+        tag_children(
+            &mut node.children,
+            &added,
+            &removed,
+            &changed,
+            &left,
+            &right,
+        );
+
+        if added.is_empty() && removed.is_empty() && changed.is_empty() {
+            if node.tags.contains("binoc.table-identity-ambiguous") {
+                return TransformResult::Replace(Box::new(node));
+            }
+            return TransformResult::Unchanged;
+        }
+
+        node.tags.insert("binoc.tabular-collection-change".into());
+        if !added.is_empty() {
+            node.tags.insert("binoc.table-addition".into());
+            node.details
+                .insert("tables_added".into(), serde_json::json!(added));
+        }
+        if !removed.is_empty() {
+            node.tags.insert("binoc.table-removal".into());
+            node.details
+                .insert("tables_removed".into(), serde_json::json!(removed));
+        }
+        if !changed.is_empty() {
+            node.tags.insert("binoc.table-change".into());
+            node.details
+                .insert("tables_changed".into(), serde_json::json!(changed));
+        }
+
+        node.summary = Some(collection_summary(&node.children, &left, &right));
+
+        TransformResult::Replace(Box::new(node))
+    }
+}
+
+fn member_map(collection: &TabularCollectionData) -> BTreeMap<String, &TableMember> {
+    collection
+        .tables
+        .iter()
+        .map(|member| (member.logical_name.clone(), member))
+        .collect()
+}
+
+fn duplicate_logical_names(collection: Option<&TabularCollectionData>) -> BTreeSet<String> {
+    let mut seen = BTreeSet::new();
+    let mut duplicates = BTreeSet::new();
+    if let Some(collection) = collection {
+        for member in &collection.tables {
+            if !seen.insert(member.logical_name.clone()) {
+                duplicates.insert(member.logical_name.clone());
+            }
+        }
+    }
+    duplicates
+}
+
+fn table_changed(left: &TableMember, right: &TableMember, children: &[DiffNode]) -> bool {
+    if left.shape != right.shape {
+        return true;
+    }
+    children.iter().any(|child| {
+        child.action != "identical"
+            && (child.path == left.node_path
+                || child.path == right.node_path
+                || child
+                    .details
+                    .get("logical_name")
+                    .and_then(|v| v.as_str())
+                    .is_some_and(|name| name == left.logical_name))
+    })
+}
+
+fn tag_children(
+    children: &mut [DiffNode],
+    added: &[String],
+    removed: &[String],
+    changed: &[String],
+    left: &BTreeMap<String, &TableMember>,
+    right: &BTreeMap<String, &TableMember>,
+) {
+    let added: BTreeSet<&str> = added.iter().map(String::as_str).collect();
+    let removed: BTreeSet<&str> = removed.iter().map(String::as_str).collect();
+    let changed: BTreeSet<&str> = changed.iter().map(String::as_str).collect();
+
+    for child in children {
+        let logical_name = logical_name_for_child(child, left, right);
+        let Some(logical_name) = logical_name else {
+            continue;
+        };
+        child
+            .details
+            .entry("logical_name".into())
+            .or_insert_with(|| serde_json::json!(logical_name));
+
+        if added.contains(logical_name.as_str()) {
+            child.tags.insert("binoc.table-addition".into());
+        }
+        if removed.contains(logical_name.as_str()) {
+            child.tags.insert("binoc.table-removal".into());
+        }
+        if changed.contains(logical_name.as_str()) {
+            child.tags.insert("binoc.table-change".into());
+        }
+    }
+}
+
+fn logical_name_for_child(
+    child: &DiffNode,
+    left: &BTreeMap<String, &TableMember>,
+    right: &BTreeMap<String, &TableMember>,
+) -> Option<String> {
+    if let Some(name) = child.details.get("logical_name").and_then(|v| v.as_str()) {
+        return Some(name.to_string());
+    }
+    for (name, member) in left.iter().chain(right.iter()) {
+        if child.path == member.node_path {
+            return Some(name.clone());
+        }
+    }
+    None
+}
+
+fn collection_summary(
+    children: &[DiffNode],
+    left: &BTreeMap<String, &TableMember>,
+    right: &BTreeMap<String, &TableMember>,
+) -> String {
+    let mut parts = Vec::new();
+    for child in children {
+        let Some(logical_name) = logical_name_for_child(child, left, right) else {
+            continue;
+        };
+        let label = table_label(&logical_name, child.action.as_str());
+        let detail = child
+            .summary
+            .clone()
+            .unwrap_or_else(|| fallback_table_summary(child, left, right, &logical_name));
+        parts.push(format!("{label}: {}", lower_first(&detail)));
+    }
+
+    if parts.is_empty() {
+        "Table collection changed".into()
+    } else {
+        parts.join("; ")
+    }
+}
+
+fn table_label(logical_name: &str, action: &str) -> String {
+    match action {
+        "add" => format!("Table {logical_name} added"),
+        "remove" => format!("Table {logical_name} removed"),
+        _ => format!("Table {logical_name} changed"),
+    }
+}
+
+fn fallback_table_summary(
+    child: &DiffNode,
+    left: &BTreeMap<String, &TableMember>,
+    right: &BTreeMap<String, &TableMember>,
+    logical_name: &str,
+) -> String {
+    let member = match child.action.as_str() {
+        "remove" => left.get(logical_name).copied(),
+        _ => right
+            .get(logical_name)
+            .copied()
+            .or_else(|| left.get(logical_name).copied()),
+    };
+    if let Some(member) = member {
+        let columns = member.shape.columns.len();
+        let rows = member.shape.row_count.unwrap_or(0);
+        return format!(
+            "{} column{}, {} row{}",
+            columns,
+            if columns == 1 { "" } else { "s" },
+            rows,
+            if rows == 1 { "" } else { "s" }
+        );
+    }
+    match child.action.as_str() {
+        "add" => "table added".into(),
+        "remove" => "table removed".into(),
+        _ => "table changed".into(),
+    }
+}
+
+fn lower_first(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(first) => first.to_lowercase().to_string() + chars.as_str(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use binoc_sdk::LocalDataAccess;
+
+    fn member(name: &str, path: &str, rows: u64) -> TableMember {
+        TableMember {
+            logical_name: name.into(),
+            node_path: path.into(),
+            source: TableSourceLocation {
+                item_path: "data.sqlite".into(),
+                kind: "sqlite_table".into(),
+                locator: BTreeMap::from([("table".into(), serde_json::json!(name))]),
+            },
+            shape: TableShape {
+                columns: vec!["id".into()],
+                row_count: Some(rows),
+            },
+            metadata: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn summarizes_child_table_changes() {
+        let data = LocalDataAccess::new();
+        let left = TabularCollectionData {
+            tables: vec![member("users", "data.sqlite::users", 1)],
+        };
+        let right = TabularCollectionData {
+            tables: vec![
+                member("users", "data.sqlite::users", 2),
+                member("posts", "data.sqlite::posts", 1),
+            ],
+        };
+        let left_art = data
+            .publish_artifact(
+                &tabular_collection_v1(),
+                ArtifactSubject::Left,
+                "test",
+                &serde_json::to_vec(&left).unwrap(),
+            )
+            .unwrap();
+        let right_art = data
+            .publish_artifact(
+                &tabular_collection_v1(),
+                ArtifactSubject::Right,
+                "test",
+                &serde_json::to_vec(&right).unwrap(),
+            )
+            .unwrap();
+        let node = DiffNode::new("modify", "tabular_collection", "data.sqlite")
+            .with_artifact(left_art)
+            .with_artifact(right_art)
+            .with_children(vec![
+                DiffNode::new("modify", "tabular", "data.sqlite::users")
+                    .with_summary("1 row added"),
+                DiffNode::new("add", "tabular", "data.sqlite::posts")
+                    .with_summary("New table (1 columns, 1 rows)"),
+            ]);
+
+        let TransformResult::Replace(node) =
+            TableCollectionAnalyzer.transform(node, &data, &serde_json::Value::Null)
+        else {
+            panic!("expected replacement");
+        };
+
+        assert!(node.tags.contains("binoc.tabular-collection-change"));
+        assert!(node.tags.contains("binoc.table-addition"));
+        assert!(node.tags.contains("binoc.table-change"));
+        assert_eq!(
+            node.summary.as_deref(),
+            Some("Table users changed: 1 row added; Table posts added: new table (1 columns, 1 rows)")
+        );
+        assert!(node.children[0].tags.contains("binoc.table-change"));
+        assert!(node.children[1].tags.contains("binoc.table-addition"));
+    }
+}

--- a/binoc-stdlib/src/transformers/tabular_analyzer.rs
+++ b/binoc-stdlib/src/transformers/tabular_analyzer.rs
@@ -57,9 +57,11 @@ fn transform_add(mut node: DiffNode, pair: &TabularDataPair) -> TransformResult 
         return TransformResult::Unchanged;
     };
     node.summary = Some(format!(
-        "New table ({} columns, {} rows)",
+        "New table ({} column{}, {} row{})",
         right.headers.len(),
-        right.rows.len()
+        if right.headers.len() == 1 { "" } else { "s" },
+        right.rows.len(),
+        if right.rows.len() == 1 { "" } else { "s" }
     ));
     node.tags.insert("binoc.content-changed".into());
     node.details
@@ -74,9 +76,11 @@ fn transform_remove(mut node: DiffNode, pair: &TabularDataPair) -> TransformResu
         return TransformResult::Unchanged;
     };
     node.summary = Some(format!(
-        "Table removed ({} columns, {} rows)",
+        "Table removed ({} column{}, {} row{})",
         left.headers.len(),
-        left.rows.len()
+        if left.headers.len() == 1 { "" } else { "s" },
+        left.rows.len(),
+        if left.rows.len() == 1 { "" } else { "s" }
     ));
     node.tags.insert("binoc.content-changed".into());
     node.details
@@ -224,7 +228,9 @@ fn transform_modify(mut node: DiffNode, pair: &TabularDataPair) -> TransformResu
         node.annotations
             .insert("tabular_summary".into(), serde_json::json!(tabular_desc));
     } else {
-        node.summary = Some(tabular_desc);
+        if tabular_desc != "Table modified" || node.summary.is_none() {
+            node.summary = Some(tabular_desc);
+        }
     }
 
     TransformResult::Replace(Box::new(node))

--- a/docs/adr/2026-06-01-tabular_collection_artifact_model.md
+++ b/docs/adr/2026-06-01-tabular_collection_artifact_model.md
@@ -1,0 +1,277 @@
+# Tabular Collection Artifact Model
+
+**Date:** 2026-06-01
+**Status:** Accepted
+
+## Context
+
+Binoc already has a standard `binoc.tabular.v1` artifact for one table. That is
+enough for a single CSV, but several common dataset shapes contain multiple
+logical tables:
+
+- an Excel workbook with multiple sheets
+- a SQLite database with multiple tables
+- a directory of CSV files that together form one dataset
+- one CSV containing multiple logical table regions
+
+Today the SQLite plugin is "multi-table-ish" but does its own schema/row-count
+diffing and emits `sqlite_table` child nodes directly. That does not give Excel,
+SQLite, CSV regions, and future formats a shared model for table-level reporting
+or keyed row analysis.
+
+The cross-plugin artifact decision already established the right mechanism:
+standard public artifacts are SDK-owned schema contracts, and the controller
+only carries opaque descriptors and handles.
+
+## Decision
+
+Binoc will standardize a `binoc.tabular_collection.v1` artifact, serialized as
+JSON, for "this source contains multiple logical tables." Individual tables
+continue to publish `binoc.tabular.v1` artifacts.
+
+The collection artifact is a manifest, not a second copy of table data. It
+records table identities, source locations, and shape summaries so generic
+transformers and renderers can reason about table sets without knowing whether
+the source was Excel, SQLite, CSV, or something else.
+
+### Type sketch
+
+```rust
+pub fn tabular_collection_v1() -> ArtifactFormat {
+    ArtifactFormat::new("binoc", "tabular_collection", 1)
+}
+
+pub struct TabularCollectionData {
+    pub tables: Vec<TableMember>,
+}
+
+pub struct TableMember {
+    /// Stable identity used to match this table across snapshots.
+    pub logical_name: String,
+
+    /// Where renderers and extractors should find the table node in the IR.
+    pub node_path: String,
+
+    /// Where the table came from inside the source artifact.
+    pub source: TableSourceLocation,
+
+    /// Cheap shape summary. Full cell data lives in tabular_v1 artifacts on
+    /// table nodes.
+    pub shape: TableShape,
+
+    /// Optional plugin/domain metadata. Consumers must ignore unknown fields.
+    pub metadata: BTreeMap<String, serde_json::Value>,
+}
+
+pub struct TableSourceLocation {
+    /// Logical path of the source item in the Binoc tree.
+    pub item_path: String,
+
+    /// Format-neutral source kind: "file", "sheet", "sqlite_table",
+    /// "csv_region", etc. Open string, not an enum enforced by core.
+    pub kind: String,
+
+    /// Source-specific locator, such as {"sheet": "Products"} or
+    /// {"table": "products"} or {"start_row": 42, "end_row": 99}.
+    pub locator: BTreeMap<String, serde_json::Value>,
+}
+
+pub struct TableShape {
+    pub columns: Vec<String>,
+    pub row_count: Option<u64>,
+}
+```
+
+`logical_name` and `source` are both required. `logical_name` is the stable table
+identity used for matching. `source` is provenance: it lets users understand
+where the table came from and lets extractors reopen the original source if
+needed.
+
+The schema uses open strings and metadata maps for source kinds because the SDK
+must not bake in every table-bearing format. The stable contract is the
+collection/table shape, not a closed list of container technologies.
+
+### IR shape
+
+A multi-table comparator returns a collection node with children:
+
+```text
+data.xlsx                         action: modify  item_type: tabular_collection
+  data.xlsx::Applications          action: modify  item_type: tabular
+  data.xlsx::Products              action: add     item_type: tabular
+  data.xlsx::Submissions           action: modify  item_type: tabular
+```
+
+The collection node publishes left/right `tabular_collection_v1` artifacts. Each
+table child publishes left/right `tabular_v1` artifacts as applicable.
+
+Example artifact layout:
+
+```json
+{
+  "tables": [
+    {
+      "logical_name": "Products",
+      "node_path": "data.xlsx::Products",
+      "source": {
+        "item_path": "data.xlsx",
+        "kind": "sheet",
+        "locator": {"sheet": "Products"}
+      },
+      "shape": {
+        "columns": ["BLA Number", "Product Number", "Drug Name"],
+        "row_count": 214
+      },
+      "metadata": {}
+    }
+  ]
+}
+```
+
+A SQLite comparator uses the same model:
+
+```json
+{
+  "logical_name": "products",
+  "node_path": "data.sqlite::products",
+  "source": {
+    "item_path": "data.sqlite",
+    "kind": "sqlite_table",
+    "locator": {"table": "products"}
+  },
+  "shape": {"columns": ["id", "name"], "row_count": 52},
+  "metadata": {}
+}
+```
+
+One CSV containing multiple logical tables also uses the same model:
+
+```json
+{
+  "logical_name": "adverse_events",
+  "node_path": "report.csv::adverse_events",
+  "source": {
+    "item_path": "report.csv",
+    "kind": "csv_region",
+    "locator": {"start_row": 42, "end_row": 120}
+  },
+  "shape": {"columns": ["case_id", "event_seq"], "row_count": 78},
+  "metadata": {}
+}
+```
+
+### Table matching
+
+Table identity is `logical_name`. Source location is not part of the key because
+sheet names, SQL table names, or CSV regions can move while representing the
+same logical table. Source location is retained as provenance and for diagnostic
+messages.
+
+Comparators derive `logical_name` using this precedence:
+
+1. explicit `dataset.tables.entries.<name>.match` config
+2. native logical name, such as workbook sheet name or SQLite table name
+3. source-derived fallback, such as a CSV stem or generated region name
+
+If two tables in the same side resolve to the same `logical_name`, the
+collection has an ambiguous table identity. The comparator should emit a
+diagnostic tagged `binoc.table-identity-ambiguous` and avoid pretending the
+tables can be matched one-to-one.
+
+### Transformer composition
+
+The existing thin-comparator pattern still applies.
+
+Multi-table comparators:
+
+1. parse the source format
+2. publish `tabular_collection_v1` on the collection node
+3. publish `tabular_v1` on each table child
+4. compare table set identity by `logical_name`
+5. emit bare collection and table nodes with artifacts
+
+Generic transformers then do the analysis:
+
+- `binoc.table_collection_analyzer` compares collection manifests and annotates
+  table additions, removals, table renames if later supported, and collection
+  summaries.
+- `binoc.tabular_analyzer` continues to analyze individual table children using
+  `tabular_v1`.
+- keyed row diffing consumes table-local row identity from dataset config and
+  `tabular_v1` data from the child node.
+- later statistical transformers can tag high-churn tables without needing to
+  know Excel, SQLite, or CSV parsing.
+
+This keeps source parsing in comparators and semantic analysis in transformers.
+The controller remains unaware of table collections.
+
+### Renderer shape
+
+Renderers should treat a collection node as a table set and report table-level
+changes before row/cell details. The Markdown shape should be:
+
+```markdown
+## data.xlsx
+
+- Applications changed: 2 rows added; 1 cell changed.
+- Products added: 214 rows, 3 columns.
+- Submissions churned: 83% of rows changed; review as a replacement candidate.
+```
+
+The collection-level summary should use table names and table actions:
+
+- `table A changed`
+- `table B added`
+- `table C removed`
+- `table D churned`
+
+Detailed row, column, and cell changes remain on table child nodes. The
+collection summary is a navigation layer, not a replacement for child detail.
+
+Standard collection tags:
+
+- `binoc.table-addition`
+- `binoc.table-removal`
+- `binoc.table-change`
+- `binoc.table-churn`
+- `binoc.table-identity-ambiguous`
+- `binoc.tabular-collection-change`
+
+As elsewhere, these are factual tags. Markdown or future renderers map them to
+significance categories through renderer config.
+
+## Consequences
+
+- Excel, SQLite, CSV-region, and directory-of-CSV plugins can share generic
+  collection/table transformers.
+- SQLite can migrate away from plugin-private table child analysis toward
+  standard `tabular_collection_v1` plus `tabular_v1`.
+- `tabular_v1` remains the unit for actual row/column/cell analysis.
+- The collection artifact avoids copying full table data while still making
+  table identity and source provenance available to downstream plugins.
+- The SDK gains another standard public artifact schema, so compatibility rules
+  from the published-artifacts ADR apply.
+
+## Alternatives Considered
+
+**Put all tables into one large `tabular_v1` artifact with a table-name
+column.** Rejected because it loses native table boundaries, makes per-table
+keys awkward, and cannot represent different schemas cleanly.
+
+**Make SQLite/Excel comparators emit only child `tabular_v1` nodes and skip a
+collection artifact.** This gives the renderer a tree but no standard manifest
+for table identity, source locations, or table-set analysis. Generic collection
+transformers would have to infer too much from paths.
+
+**Make table source location part of identity.** Rejected because a sheet can be
+renamed or a table can move inside a CSV while remaining the same logical table.
+Source location is provenance; `logical_name` is identity.
+
+**Standardize a relational-schema artifact instead.** Useful for SQL-specific
+schema work, but too narrow for Excel sheets and CSV regions. Relational-schema
+artifacts can still exist as plugin-owned or future SDK artifacts alongside the
+format-neutral collection manifest.
+
+**Put collection semantics in core IR types.** Rejected because it violates the
+type-ignorant controller rule. A collection is a convention expressed through
+open `item_type`, tags, child nodes, and standard artifacts.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -8,8 +8,8 @@ Newer entries appear first. Each entry shows its date and current status. Create
 |---|---|---|
 | 2026-06-02 | [Markdown Renderer Groups Replace Significance-Map Grouping](2026-06-02-renderer_groups.md) | Implemented |
 | 2026-06-01 | [Unified Dataset Config and Identity Policy](2026-06-01-unified_dataset_config_and_identity.md) | Accepted |
-| 2026-06-01 | [Single-stream gzip as an expanding comparator](2026-06-01-single_stream_gzip_as_expanding_comparator.md) | Implemented |
 | 2026-06-01 | [Tabular Collection Artifact Model](2026-06-01-tabular_collection_artifact_model.md) | Accepted |
+| 2026-06-01 | [Single-stream gzip as an expanding comparator](2026-06-01-single_stream_gzip_as_expanding_comparator.md) | Implemented |
 | 2026-06-01 | [Optional First-Party Plugins and `binoc[all]`](2026-06-01-optional_first_party_plugins.md) | Accepted |
 | 2026-06-01 | [Example Verbosity and Plugin-Supplied Details](2026-06-01-example_verbosity.md) | Decided |
 | 2026-06-01 | [Diagnostics Channel for Non-Fatal Warnings and Suggestions](2026-06-01-diagnostics_channel.md) | Implemented |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -9,6 +9,7 @@ Newer entries appear first. Each entry shows its date and current status. Create
 | 2026-06-02 | [Markdown Renderer Groups Replace Significance-Map Grouping](2026-06-02-renderer_groups.md) | Implemented |
 | 2026-06-01 | [Unified Dataset Config and Identity Policy](2026-06-01-unified_dataset_config_and_identity.md) | Accepted |
 | 2026-06-01 | [Single-stream gzip as an expanding comparator](2026-06-01-single_stream_gzip_as_expanding_comparator.md) | Implemented |
+| 2026-06-01 | [Tabular Collection Artifact Model](2026-06-01-tabular_collection_artifact_model.md) | Accepted |
 | 2026-06-01 | [Optional First-Party Plugins and `binoc[all]`](2026-06-01-optional_first_party_plugins.md) | Accepted |
 | 2026-06-01 | [Example Verbosity and Plugin-Supplied Details](2026-06-01-example_verbosity.md) | Decided |
 | 2026-06-01 | [Diagnostics Channel for Non-Fatal Warnings and Suggestions](2026-06-01-diagnostics_channel.md) | Implemented |

--- a/docs/explanation/test-vectors-gallery.md
+++ b/docs/explanation/test-vectors-gallery.md
@@ -40,7 +40,7 @@ just materialize
 | [`csv-row-removal`](#csv-row-removal) | Rows removed from CSV | data.csv: 2 rows removed | Default pipeline |
 | [`csv-verbosity-full`](#csv-verbosity-full) | Markdown full verbosity renders every captured changed-cell example. | data.csv: 5 cells changed | Custom config |
 | [`directory-file-copy`](#directory-file-copy) | New file with same content as an existing unchanged file detected as a copy | duplicate.txt: Copied from original.txt | Default pipeline |
-| [`directory-nested`](#directory-nested) | Subdirectories with mixed changes | data/extra.csv: New table (2 columns, 1 rows) | Default pipeline |
+| [`directory-nested`](#directory-nested) | Subdirectories with mixed changes | data/extra.csv: New table (2 columns, 1 row) | Default pipeline |
 | [`directory-nested-with-tar`](#directory-nested-with-tar) | Shows binoc diffing a tar archive and a plain directory that contain overlapping internal paths. | data/records.csv: 1 row added | Default pipeline |
 | [`folder-move-nested`](#folder-move-nested) | Detects a whole-folder rename and rolls many file moves up into one folder-move entry. | documentation: Folder moved from docs | Default pipeline |
 | [`folder-move-partial`](#folder-move-partial) | Detects a mostly-moved folder rename and preserves only the added/removed/modified remainder entries beneath it. | FoodData_Central_csv_2026-04-30: Folder moved from FoodData_Central_csv_2,025-12-18 | Custom config |
@@ -348,7 +348,7 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-- **data/extra.csv**: New table (2 columns, 1 rows)
+- **data/extra.csv**: New table (2 columns, 1 row)
 - **data/records.csv**: 1 row added
 - **docs/readme.txt**: 2 lines added, 1 removed
 ```
@@ -427,7 +427,7 @@ Result:
 # Changelog: snapshot-a → snapshot-b
 
 - **FoodData_Central_csv_2026-04-30**: Folder moved from FoodData_Central_csv_2,025-12-18
-- **FoodData_Central_csv_2026-04-30/data/new-table.csv**: New table (2 columns, 1 rows)
+- **FoodData_Central_csv_2026-04-30/data/new-table.csv**: New table (2 columns, 1 row)
 - **FoodData_Central_csv_2026-04-30/docs/modified.txt**: Text modified
 - **FoodData_Central_csv_2026-04-30/docs/old-table.txt**: File removed (1 line)
 ```

--- a/docs/reference/third-party-plugins.md
+++ b/docs/reference/third-party-plugins.md
@@ -50,7 +50,7 @@ A file is routed to this plugin when **either** its path matches one of the **ex
 | `scope` | `Files` |
 | `handles_identical` | `false` |
 
-*Labels you may see in a changeset (not used for routing):* `sqlite_database`, `sqlite_table`
+*Labels you may see in a changeset (not used for routing):* `tabular_collection`, `tabular`
 
 ## binoc-stat-binary
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -164,6 +164,7 @@ nav:
           - 'Markdown Renderer Groups Replace Significance-Map Grouping': adr/2026-06-02-renderer_groups.md
           - 'Unified Dataset Config and Identity Policy': adr/2026-06-01-unified_dataset_config_and_identity.md
           - 'Single-stream gzip as an expanding comparator': adr/2026-06-01-single_stream_gzip_as_expanding_comparator.md
+          - 'Tabular Collection Artifact Model': adr/2026-06-01-tabular_collection_artifact_model.md
           - 'Optional First-Party Plugins and `binoc[all]`': adr/2026-06-01-optional_first_party_plugins.md
           - 'Example Verbosity and Plugin-Supplied Details': adr/2026-06-01-example_verbosity.md
           - 'Diagnostics Channel for Non-Fatal Warnings and Suggestions': adr/2026-06-01-diagnostics_channel.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -163,8 +163,8 @@ nav:
           - adr/README.md
           - 'Markdown Renderer Groups Replace Significance-Map Grouping': adr/2026-06-02-renderer_groups.md
           - 'Unified Dataset Config and Identity Policy': adr/2026-06-01-unified_dataset_config_and_identity.md
-          - 'Single-stream gzip as an expanding comparator': adr/2026-06-01-single_stream_gzip_as_expanding_comparator.md
           - 'Tabular Collection Artifact Model': adr/2026-06-01-tabular_collection_artifact_model.md
+          - 'Single-stream gzip as an expanding comparator': adr/2026-06-01-single_stream_gzip_as_expanding_comparator.md
           - 'Optional First-Party Plugins and `binoc[all]`': adr/2026-06-01-optional_first_party_plugins.md
           - 'Example Verbosity and Plugin-Supplied Details': adr/2026-06-01-example_verbosity.md
           - 'Diagnostics Channel for Non-Fatal Warnings and Suggestions': adr/2026-06-01-diagnostics_channel.md

--- a/model-plugins/binoc-sqlite/README.md
+++ b/model-plugins/binoc-sqlite/README.md
@@ -1,6 +1,6 @@
 # binoc-sqlite
 
-SQLite comparator plugin for [Binoc](https://github.com/example/binoc). Diffs `.sqlite` / `.sqlite3` / `.db` files by **schema** (tables, columns, types) and **row counts** — not row-by-row content — so you get summaries like “1 table modified”, “1 row added (1 → 2 rows)”, or “Table added (2 columns, 5 rows)” instead of a raw binary change.
+SQLite comparator plugin for [Binoc](https://github.com/example/binoc). Diffs `.sqlite` / `.sqlite3` / `.db` files as standard tabular collections: a database is a table set, and each SQLite table publishes normal Binoc tabular data for row, column, and cell analysis.
 
 ## Install
 
@@ -32,18 +32,17 @@ Example output:
 ```markdown
 # Changelog: /tmp/demo/snapshot-a → /tmp/demo/snapshot-b
 
-## Other Changes
-
-- **data.sqlite**: 1 table modified
-- **data.sqlite/t**: 1 row added (1 → 2 rows)
+- **data.sqlite**: Table t changed: 1 row added
+- **data.sqlite::t**: 1 row added
 ```
 
 Without the plugin, the same files would be reported as “Content changed” by the binary comparator.
 
 ## What it compares
 
-- **Schema**: tables added/removed, columns added/removed, column type changes.
-- **Row counts** per table (not cell-level diffs).
+- **Table set**: tables added/removed/changed via `binoc.tabular_collection.v1`.
+- **Schema**: columns added/removed, SQLite column type changes.
+- **Table content**: row count and cell changes via per-table `binoc.tabular.v1`.
 
 Tags emitted include `binoc-sqlite.row-addition`, `binoc-sqlite.table-addition`, `binoc-sqlite.schema-change`, etc. Configure significance (e.g. clerical vs substantive) in your dataset config; see [Writing Binoc Plugins](../docs/writing_plugins.md).
 

--- a/model-plugins/binoc-sqlite/src/sqlite.rs
+++ b/model-plugins/binoc-sqlite/src/sqlite.rs
@@ -108,6 +108,8 @@ fn read_table_data(conn: &Connection, table: &str, info: &TableInfo) -> BinocRes
         }
         tabular_rows.push(values);
     }
+    // SQLite table row order is not semantic; keep positional tabular diffs deterministic.
+    tabular_rows.sort();
 
     Ok(TabularData {
         headers: info.columns.iter().map(|c| c.name.clone()).collect(),
@@ -648,6 +650,36 @@ mod tests {
         ];
         create_test_db(&a, sql);
         create_test_db(&b, sql);
+
+        let data = LocalDataAccess::new();
+        let cmp = SqliteComparator;
+        let pair = make_pair(&data, &a, &b, "test.sqlite");
+        let result = cmp.compare(&pair, &data).unwrap();
+        assert!(matches!(result, CompareResult::Identical));
+    }
+
+    #[test]
+    fn row_order_does_not_change_sqlite_table_identity() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = dir.path().join("a.sqlite");
+        let b = dir.path().join("b.sqlite");
+
+        create_test_db(
+            &a,
+            &[
+                "CREATE TABLE users (name TEXT, state TEXT);",
+                "INSERT INTO users VALUES ('Alice', 'MA');",
+                "INSERT INTO users VALUES ('Bob', 'CA');",
+            ],
+        );
+        create_test_db(
+            &b,
+            &[
+                "CREATE TABLE users (name TEXT, state TEXT);",
+                "INSERT INTO users VALUES ('Bob', 'CA');",
+                "INSERT INTO users VALUES ('Alice', 'MA');",
+            ],
+        );
 
         let data = LocalDataAccess::new();
         let cmp = SqliteComparator;

--- a/model-plugins/binoc-sqlite/src/sqlite.rs
+++ b/model-plugins/binoc-sqlite/src/sqlite.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::path::Path;
 
 use binoc_sdk::*;
+use rusqlite::types::ValueRef;
 use rusqlite::Connection;
 
 #[derive(Default)]
@@ -84,12 +85,193 @@ fn read_row_count(conn: &Connection, table: &str) -> BinocResult<u64> {
     u64::try_from(count).map_err(|e| BinocError::Other(format!("sqlite: {e}")))
 }
 
-fn diff_table(
+fn read_table_data(conn: &Connection, table: &str, info: &TableInfo) -> BinocResult<TabularData> {
+    let sql = format!("SELECT * FROM \"{}\"", table.replace('"', "\"\""));
+    let mut stmt = conn
+        .prepare(&sql)
+        .map_err(|e| BinocError::Other(format!("sqlite: {e}")))?;
+    let column_count = info.columns.len();
+    let mut rows = stmt
+        .query([])
+        .map_err(|e| BinocError::Other(format!("sqlite: {e}")))?;
+    let mut tabular_rows = Vec::new();
+    while let Some(row) = rows
+        .next()
+        .map_err(|e| BinocError::Other(format!("sqlite: {e}")))?
+    {
+        let mut values = Vec::with_capacity(column_count);
+        for idx in 0..column_count {
+            let value = row
+                .get_ref(idx)
+                .map_err(|e| BinocError::Other(format!("sqlite: {e}")))?;
+            values.push(sqlite_value_to_string(value));
+        }
+        tabular_rows.push(values);
+    }
+
+    Ok(TabularData {
+        headers: info.columns.iter().map(|c| c.name.clone()).collect(),
+        rows: tabular_rows,
+    })
+}
+
+fn sqlite_value_to_string(value: ValueRef<'_>) -> String {
+    match value {
+        ValueRef::Null => String::new(),
+        ValueRef::Integer(n) => n.to_string(),
+        ValueRef::Real(n) => n.to_string(),
+        ValueRef::Text(bytes) => String::from_utf8_lossy(bytes).to_string(),
+        ValueRef::Blob(bytes) => bytes.iter().map(|b| format!("{b:02x}")).collect(),
+    }
+}
+
+fn table_node_path(logical_path: &str, table_name: &str) -> String {
+    format!("{logical_path}::{table_name}")
+}
+
+fn publish_tabular(
+    data: &dyn DataAccess,
+    tabular: &TabularData,
+    subject: ArtifactSubject,
+) -> BinocResult<ArtifactDescriptor> {
+    let bytes = serde_json::to_vec(tabular)
+        .map_err(|e| BinocError::Other(format!("serialize tabular artifact: {e}")))?;
+    data.publish_artifact(&tabular_v1(), subject, "binoc-sqlite.sqlite", &bytes)
+}
+
+fn collection_from_schema(
+    logical_path: &str,
+    schema: &BTreeMap<String, TableInfo>,
+) -> TabularCollectionData {
+    TabularCollectionData {
+        tables: schema
+            .iter()
+            .map(|(name, info)| TableMember {
+                logical_name: name.clone(),
+                node_path: table_node_path(logical_path, name),
+                source: TableSourceLocation {
+                    item_path: logical_path.into(),
+                    kind: "sqlite_table".into(),
+                    locator: BTreeMap::from([("table".into(), serde_json::json!(name))]),
+                },
+                shape: TableShape {
+                    columns: info.columns.iter().map(|c| c.name.clone()).collect(),
+                    row_count: Some(info.row_count),
+                },
+                metadata: BTreeMap::new(),
+            })
+            .collect(),
+    }
+}
+
+fn publish_collection(
+    data: &dyn DataAccess,
+    collection: &TabularCollectionData,
+    subject: ArtifactSubject,
+) -> BinocResult<ArtifactDescriptor> {
+    let bytes = serde_json::to_vec(collection)
+        .map_err(|e| BinocError::Other(format!("serialize tabular collection artifact: {e}")))?;
+    data.publish_artifact(
+        &tabular_collection_v1(),
+        subject,
+        "binoc-sqlite.sqlite",
+        &bytes,
+    )
+}
+
+fn table_add_node(
     logical_path: &str,
     table_name: &str,
+    info: &TableInfo,
+    artifact: ArtifactDescriptor,
+) -> DiffNode {
+    let table_path = table_node_path(logical_path, table_name);
+    let col_names: Vec<&str> = info.columns.iter().map(|c| c.name.as_str()).collect();
+    let summary = format!(
+        "Table added ({} column{}, {} row{})",
+        info.columns.len(),
+        if info.columns.len() == 1 { "" } else { "s" },
+        info.row_count,
+        if info.row_count == 1 { "" } else { "s" },
+    );
+    DiffNode::new("add", "tabular", &table_path)
+        .with_summary(summary)
+        .with_tag("binoc-sqlite.table-addition")
+        .with_tag("binoc.table-addition")
+        .with_tag("binoc.schema-change")
+        .with_detail("logical_name", serde_json::json!(table_name))
+        .with_detail("columns", serde_json::json!(col_names))
+        .with_detail("row_count", serde_json::json!(info.row_count))
+        .with_artifact(artifact)
+}
+
+fn table_remove_node(
+    logical_path: &str,
+    table_name: &str,
+    info: &TableInfo,
+    artifact: ArtifactDescriptor,
+) -> DiffNode {
+    let table_path = table_node_path(logical_path, table_name);
+    let col_names: Vec<&str> = info.columns.iter().map(|c| c.name.as_str()).collect();
+    let summary = format!(
+        "Table removed ({} column{}, {} row{})",
+        info.columns.len(),
+        if info.columns.len() == 1 { "" } else { "s" },
+        info.row_count,
+        if info.row_count == 1 { "" } else { "s" },
+    );
+    DiffNode::new("remove", "tabular", &table_path)
+        .with_summary(summary)
+        .with_tag("binoc-sqlite.table-removal")
+        .with_tag("binoc.table-removal")
+        .with_tag("binoc.schema-change")
+        .with_detail("logical_name", serde_json::json!(table_name))
+        .with_detail("columns", serde_json::json!(col_names))
+        .with_detail("row_count", serde_json::json!(info.row_count))
+        .with_artifact(artifact)
+}
+
+struct TableDiffInput<'a> {
+    logical_path: &'a str,
+    table_name: &'a str,
+    left: &'a TableInfo,
+    right: &'a TableInfo,
+    left_data: &'a TabularData,
+    right_data: &'a TabularData,
+    left_artifact: ArtifactDescriptor,
+    right_artifact: ArtifactDescriptor,
+}
+
+fn table_has_change(
     left: &TableInfo,
     right: &TableInfo,
-) -> Option<DiffNode> {
+    left_data: &TabularData,
+    right_data: &TabularData,
+) -> bool {
+    if left_data != right_data {
+        return true;
+    }
+
+    let right_cols: BTreeMap<&str, &ColumnInfo> =
+        right.columns.iter().map(|c| (c.name.as_str(), c)).collect();
+    left.columns.iter().any(|left_col| {
+        right_cols
+            .get(left_col.name.as_str())
+            .is_some_and(|right_col| left_col.col_type != right_col.col_type)
+    })
+}
+
+fn diff_table(input: TableDiffInput<'_>) -> Option<DiffNode> {
+    let TableDiffInput {
+        logical_path,
+        table_name,
+        left,
+        right,
+        left_data,
+        right_data,
+        left_artifact,
+        right_artifact,
+    } = input;
     let left_cols: BTreeMap<&str, &ColumnInfo> =
         left.columns.iter().map(|c| (c.name.as_str(), c)).collect();
     let right_cols: BTreeMap<&str, &ColumnInfo> =
@@ -124,18 +306,21 @@ fn diff_table(
 
     let has_schema_change =
         !cols_added.is_empty() || !cols_removed.is_empty() || !cols_type_changed.is_empty();
-    let has_row_change = left.row_count != right.row_count;
+    let has_row_change = left_data != right_data;
 
     if !has_schema_change && !has_row_change {
         return None;
     }
 
-    let table_path = format!("{logical_path}/{table_name}");
+    let table_path = table_node_path(logical_path, table_name);
 
     let left_col_names: Vec<&str> = left.columns.iter().map(|c| c.name.as_str()).collect();
     let right_col_names: Vec<&str> = right.columns.iter().map(|c| c.name.as_str()).collect();
 
-    let mut node = DiffNode::new("modify", "sqlite_table", &table_path)
+    let mut node = DiffNode::new("modify", "tabular", &table_path)
+        .with_artifact(left_artifact)
+        .with_artifact(right_artifact)
+        .with_detail("logical_name", serde_json::json!(table_name))
         .with_detail("columns_left", serde_json::json!(left_col_names))
         .with_detail("columns_right", serde_json::json!(right_col_names))
         .with_detail("rows_left", serde_json::json!(left.row_count))
@@ -250,6 +435,8 @@ impl Comparator for SqliteComparator {
                 let schema = read_schema(&conn)?;
                 let table_names: Vec<&str> = schema.keys().map(|s| s.as_str()).collect();
                 let total_rows: u64 = schema.values().map(|t| t.row_count).sum();
+                let collection = collection_from_schema(&right.logical_path, &schema);
+                let collection_art = publish_collection(data, &collection, ArtifactSubject::Right)?;
 
                 let summary = format!(
                     "New database ({} table{}, {} row{} total)",
@@ -267,11 +454,20 @@ impl Comparator for SqliteComparator {
                     &bytes,
                 )?;
 
-                let node = DiffNode::new("add", "sqlite_database", &right.logical_path)
+                let mut children = Vec::new();
+                for (name, info) in &schema {
+                    let tabular = read_table_data(&conn, name, info)?;
+                    let artifact = publish_tabular(data, &tabular, ArtifactSubject::Right)?;
+                    children.push(table_add_node(&right.logical_path, name, info, artifact));
+                }
+
+                let node = DiffNode::new("add", "tabular_collection", &right.logical_path)
                     .with_summary(summary)
                     .with_tag("binoc-sqlite.content-changed")
                     .with_detail("tables", serde_json::json!(table_names))
                     .with_detail("total_rows", serde_json::json!(total_rows))
+                    .with_children(children)
+                    .with_artifact(collection_art)
                     .with_artifact(art);
 
                 Ok(CompareResult::Leaf(node))
@@ -282,6 +478,8 @@ impl Comparator for SqliteComparator {
                 let schema = read_schema(&conn)?;
                 let table_names: Vec<&str> = schema.keys().map(|s| s.as_str()).collect();
                 let total_rows: u64 = schema.values().map(|t| t.row_count).sum();
+                let collection = collection_from_schema(&left.logical_path, &schema);
+                let collection_art = publish_collection(data, &collection, ArtifactSubject::Left)?;
 
                 let summary = format!(
                     "Database removed ({} table{}, {} row{} total)",
@@ -299,11 +497,20 @@ impl Comparator for SqliteComparator {
                     &bytes,
                 )?;
 
-                let node = DiffNode::new("remove", "sqlite_database", &left.logical_path)
+                let mut children = Vec::new();
+                for (name, info) in &schema {
+                    let tabular = read_table_data(&conn, name, info)?;
+                    let artifact = publish_tabular(data, &tabular, ArtifactSubject::Left)?;
+                    children.push(table_remove_node(&left.logical_path, name, info, artifact));
+                }
+
+                let node = DiffNode::new("remove", "tabular_collection", &left.logical_path)
                     .with_summary(summary)
                     .with_tag("binoc-sqlite.content-changed")
                     .with_detail("tables", serde_json::json!(table_names))
                     .with_detail("total_rows", serde_json::json!(total_rows))
+                    .with_children(children)
+                    .with_artifact(collection_art)
                     .with_artifact(art);
 
                 Ok(CompareResult::Leaf(node))
@@ -332,7 +539,23 @@ impl SqliteComparator {
 
         for (name, info_l) in &schema_l {
             if let Some(info_r) = schema_r.get(name) {
-                if let Some(node) = diff_table(logical_path, name, info_l, info_r) {
+                let data_l = read_table_data(&conn_l, name, info_l)?;
+                let data_r = read_table_data(&conn_r, name, info_r)?;
+                if !table_has_change(info_l, info_r, &data_l, &data_r) {
+                    continue;
+                }
+                let art_l = publish_tabular(data, &data_l, ArtifactSubject::Left)?;
+                let art_r = publish_tabular(data, &data_r, ArtifactSubject::Right)?;
+                if let Some(node) = diff_table(TableDiffInput {
+                    logical_path,
+                    table_name: name,
+                    left: info_l,
+                    right: info_r,
+                    left_data: &data_l,
+                    right_data: &data_r,
+                    left_artifact: art_l,
+                    right_artifact: art_r,
+                }) {
                     children.push(node);
                 }
             }
@@ -340,43 +563,17 @@ impl SqliteComparator {
 
         for (name, info) in &schema_r {
             if !schema_l.contains_key(name) {
-                let table_path = format!("{logical_path}/{name}");
-                let col_names: Vec<&str> = info.columns.iter().map(|c| c.name.as_str()).collect();
-                let summary = format!(
-                    "Table added ({} column{}, {} row{})",
-                    info.columns.len(),
-                    if info.columns.len() == 1 { "" } else { "s" },
-                    info.row_count,
-                    if info.row_count == 1 { "" } else { "s" },
-                );
-                let node = DiffNode::new("add", "sqlite_table", &table_path)
-                    .with_summary(summary)
-                    .with_tag("binoc-sqlite.table-addition")
-                    .with_tag("binoc.schema-change")
-                    .with_detail("columns", serde_json::json!(col_names))
-                    .with_detail("row_count", serde_json::json!(info.row_count));
-                children.push(node);
+                let table_data = read_table_data(&conn_r, name, info)?;
+                let artifact = publish_tabular(data, &table_data, ArtifactSubject::Right)?;
+                children.push(table_add_node(logical_path, name, info, artifact));
             }
         }
 
         for (name, info) in &schema_l {
             if !schema_r.contains_key(name) {
-                let table_path = format!("{logical_path}/{name}");
-                let col_names: Vec<&str> = info.columns.iter().map(|c| c.name.as_str()).collect();
-                let summary = format!(
-                    "Table removed ({} column{}, {} row{})",
-                    info.columns.len(),
-                    if info.columns.len() == 1 { "" } else { "s" },
-                    info.row_count,
-                    if info.row_count == 1 { "" } else { "s" },
-                );
-                let node = DiffNode::new("remove", "sqlite_table", &table_path)
-                    .with_summary(summary)
-                    .with_tag("binoc-sqlite.table-removal")
-                    .with_tag("binoc.schema-change")
-                    .with_detail("columns", serde_json::json!(col_names))
-                    .with_detail("row_count", serde_json::json!(info.row_count));
-                children.push(node);
+                let table_data = read_table_data(&conn_l, name, info)?;
+                let artifact = publish_tabular(data, &table_data, ArtifactSubject::Left)?;
+                children.push(table_remove_node(logical_path, name, info, artifact));
             }
         }
 
@@ -386,10 +583,14 @@ impl SqliteComparator {
 
         let tables_l: Vec<&str> = schema_l.keys().map(|s| s.as_str()).collect();
         let tables_r: Vec<&str> = schema_r.keys().map(|s| s.as_str()).collect();
+        let collection_l = collection_from_schema(logical_path, &schema_l);
+        let collection_r = collection_from_schema(logical_path, &schema_r);
 
         let bytes_l = serde_json::to_vec(&schema_l).unwrap();
         let bytes_r = serde_json::to_vec(&schema_r).unwrap();
         let format = ArtifactFormat::new("binoc-sqlite", "relational-schema", 1);
+        let collection_art_l = publish_collection(data, &collection_l, ArtifactSubject::Left)?;
+        let collection_art_r = publish_collection(data, &collection_r, ArtifactSubject::Right)?;
         let art_l = data.publish_artifact(
             &format,
             ArtifactSubject::Left,
@@ -403,10 +604,12 @@ impl SqliteComparator {
             &bytes_r,
         )?;
 
-        let node = DiffNode::new("modify", "sqlite_database", logical_path)
+        let node = DiffNode::new("modify", "tabular_collection", logical_path)
             .with_children(children)
             .with_detail("tables_left", serde_json::json!(tables_l))
             .with_detail("tables_right", serde_json::json!(tables_r))
+            .with_artifact(collection_art_l)
+            .with_artifact(collection_art_r)
             .with_artifact(art_l)
             .with_artifact(art_r);
 
@@ -483,9 +686,11 @@ mod tests {
         match result {
             CompareResult::Leaf(node) => {
                 assert_eq!(node.action, "modify");
-                assert_eq!(node.item_type, "sqlite_database");
+                assert_eq!(node.item_type, "tabular_collection");
                 assert_eq!(node.children.len(), 1);
                 let child = &node.children[0];
+                assert_eq!(child.item_type, "tabular");
+                assert_eq!(child.path, "test.sqlite::users");
                 assert!(child.tags.contains("binoc-sqlite.row-addition"));
                 assert_eq!(child.details["rows_left"], serde_json::json!(1));
                 assert_eq!(child.details["rows_right"], serde_json::json!(2));
@@ -524,7 +729,8 @@ mod tests {
                 assert_eq!(node.children.len(), 1);
                 let child = &node.children[0];
                 assert_eq!(child.action, "add");
-                assert_eq!(child.item_type, "sqlite_table");
+                assert_eq!(child.item_type, "tabular");
+                assert_eq!(child.path, "test.sqlite::posts");
                 assert!(child.tags.contains("binoc-sqlite.table-addition"));
             }
             _ => panic!("expected Leaf"),
@@ -591,7 +797,8 @@ mod tests {
         match result {
             CompareResult::Leaf(node) => {
                 assert_eq!(node.action, "add");
-                assert_eq!(node.item_type, "sqlite_database");
+                assert_eq!(node.item_type, "tabular_collection");
+                assert_eq!(node.children.len(), 1);
                 assert!(node.summary.unwrap().contains("1 table"));
             }
             _ => panic!("expected Leaf"),
@@ -617,7 +824,8 @@ mod tests {
         match result {
             CompareResult::Leaf(node) => {
                 assert_eq!(node.action, "remove");
-                assert_eq!(node.item_type, "sqlite_database");
+                assert_eq!(node.item_type, "tabular_collection");
+                assert_eq!(node.children.len(), 2);
                 assert!(node.summary.unwrap().contains("2 tables"));
             }
             _ => panic!("expected Leaf"),

--- a/model-plugins/binoc-sqlite/test-vectors/manifest.toml
+++ b/model-plugins/binoc-sqlite/test-vectors/manifest.toml
@@ -13,5 +13,7 @@ comparators = [
 transformers = [
     "binoc.correlation_detector",
     "binoc.folder_move_detector",
+    "binoc.tabular_analyzer",
     "binoc.column_reorder_detector",
+    "binoc.table_collection_analyzer",
 ]

--- a/model-plugins/binoc-sqlite/test-vectors/sqlite-multitable-changes/expected-output/abi-log.snap
+++ b/model-plugins/binoc-sqlite/test-vectors/sqlite-multitable-changes/expected-output/abi-log.snap
@@ -22,7 +22,7 @@ expression: "&abi_log"
       {
         "op": "read_bytes",
         "handle": "data.sqlite",
-        "result_size": 8192
+        "result_size": 12288
       },
       {
         "op": "register_local",
@@ -31,7 +31,7 @@ expression: "&abi_log"
       {
         "op": "read_bytes",
         "handle": "data.sqlite",
-        "result_size": 12288
+        "result_size": 16384
       }
     ]
   },
@@ -54,6 +54,28 @@ expression: "&abi_log"
           "name": "tabular",
           "version": 1
         },
+        "subject": "Left",
+        "producer": "binoc-sqlite.sqlite",
+        "size": 48
+      },
+      {
+        "op": "publish_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "subject": "Right",
+        "producer": "binoc-sqlite.sqlite",
+        "size": 60
+      },
+      {
+        "op": "publish_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
         "subject": "Right",
         "producer": "binoc-sqlite.sqlite",
         "size": 63
@@ -67,7 +89,7 @@ expression: "&abi_log"
         },
         "subject": "Left",
         "producer": "binoc-sqlite.sqlite",
-        "size": 205
+        "size": 407
       },
       {
         "op": "publish_artifact",
@@ -78,7 +100,7 @@ expression: "&abi_log"
         },
         "subject": "Right",
         "producer": "binoc-sqlite.sqlite",
-        "size": 409
+        "size": 614
       },
       {
         "op": "publish_artifact",
@@ -89,7 +111,7 @@ expression: "&abi_log"
         },
         "subject": "Left",
         "producer": "binoc-sqlite.sqlite",
-        "size": 159
+        "size": 320
       },
       {
         "op": "publish_artifact",
@@ -100,7 +122,7 @@ expression: "&abi_log"
         },
         "subject": "Right",
         "producer": "binoc-sqlite.sqlite",
-        "size": 385
+        "size": 547
       }
     ]
   },
@@ -113,6 +135,30 @@ expression: "&abi_log"
     "method": "transform",
     "plugin": "binoc.folder_move_detector",
     "data_ops": []
+  },
+  {
+    "method": "transform",
+    "plugin": "binoc.tabular_analyzer",
+    "data_ops": [
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      },
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      }
+    ]
   },
   {
     "method": "transform",

--- a/model-plugins/binoc-sqlite/test-vectors/sqlite-multitable-changes/expected-output/changelog.snap
+++ b/model-plugins/binoc-sqlite/test-vectors/sqlite-multitable-changes/expected-output/changelog.snap
@@ -1,0 +1,9 @@
+---
+source: binoc-stdlib/src/test_vectors.rs
+expression: "&md"
+---
+# Changelog: snapshot-a → snapshot-b
+
+- **data.sqlite**: Table users changed: 1 row added; Table orders added: new table (3 columns, 1 row)
+- **data.sqlite::users**: 1 row added
+- **data.sqlite::orders**: New table (3 columns, 1 row)

--- a/model-plugins/binoc-sqlite/test-vectors/sqlite-multitable-changes/expected-output/changeset.snap
+++ b/model-plugins/binoc-sqlite/test-vectors/sqlite-multitable-changes/expected-output/changeset.snap
@@ -14,8 +14,9 @@ expression: "&stable_changeset"
         "action": "modify",
         "item_type": "tabular_collection",
         "path": "data.sqlite",
-        "summary": "Table users changed: 1 row added",
+        "summary": "Table users changed: 1 row added; Table orders added: new table (3 columns, 1 row)",
         "tags": [
+          "binoc.table-addition",
           "binoc.table-change",
           "binoc.tabular-collection-change"
         ],
@@ -51,18 +52,49 @@ expression: "&stable_changeset"
             "transformed_by": [
               "binoc.tabular_analyzer"
             ]
+          },
+          {
+            "action": "add",
+            "item_type": "tabular",
+            "path": "data.sqlite::orders",
+            "summary": "New table (3 columns, 1 row)",
+            "tags": [
+              "binoc-sqlite.table-addition",
+              "binoc.content-changed",
+              "binoc.schema-change",
+              "binoc.table-addition"
+            ],
+            "details": {
+              "columns": [
+                "id",
+                "user_id",
+                "total"
+              ],
+              "logical_name": "orders",
+              "row_count": 1,
+              "rows": 1
+            },
+            "transformed_by": [
+              "binoc.tabular_analyzer"
+            ]
           }
         ],
         "details": {
-          "hash_left": "0bb865f7f287a972d996d07f69dab0d625f02aa5825cc79a6ab79b5c2794355a",
-          "hash_right": "403f22fa3dbe2a501520c6b9bb9c2ecd8f8e431d957f2c050f112d546953bc72",
+          "hash_left": "feea398ad448a3460364a807be20f26be6fdd5f84304663c70692a6b5ed8963e",
+          "hash_right": "b02249e479928626396a89c2a8a05b6dea6568bc4176ee1725feeab68b3c63d6",
+          "tables_added": [
+            "orders"
+          ],
           "tables_changed": [
             "users"
           ],
           "tables_left": [
+            "products",
             "users"
           ],
           "tables_right": [
+            "orders",
+            "products",
             "users"
           ]
         },

--- a/model-plugins/binoc-sqlite/test-vectors/sqlite-multitable-changes/manifest.toml
+++ b/model-plugins/binoc-sqlite/test-vectors/sqlite-multitable-changes/manifest.toml
@@ -1,0 +1,13 @@
+[vector]
+name = "sqlite-multitable-changes"
+description = "SQLite database with one changed table and one added table"
+tags = ["sqlite", "multi-table", "row-addition", "table-addition"]
+
+[expected]
+root_kind = "modify"
+has_tags = [
+    "binoc.tabular-collection-change",
+    "binoc.table-change",
+    "binoc.table-addition",
+    "binoc.row-addition",
+]

--- a/model-plugins/binoc-sqlite/test-vectors/sqlite-multitable-changes/snapshot-a/data.sqlite.d/01_schema.sql
+++ b/model-plugins/binoc-sqlite/test-vectors/sqlite-multitable-changes/snapshot-a/data.sqlite.d/01_schema.sql
@@ -1,0 +1,9 @@
+CREATE TABLE users (
+    id INTEGER PRIMARY KEY,
+    name TEXT
+);
+
+CREATE TABLE products (
+    id INTEGER PRIMARY KEY,
+    name TEXT
+);

--- a/model-plugins/binoc-sqlite/test-vectors/sqlite-multitable-changes/snapshot-a/data.sqlite.d/02_data.sql
+++ b/model-plugins/binoc-sqlite/test-vectors/sqlite-multitable-changes/snapshot-a/data.sqlite.d/02_data.sql
@@ -1,0 +1,2 @@
+INSERT INTO users VALUES (1, 'Alice');
+INSERT INTO products VALUES (1, 'Widget');

--- a/model-plugins/binoc-sqlite/test-vectors/sqlite-multitable-changes/snapshot-b/data.sqlite.d/01_schema.sql
+++ b/model-plugins/binoc-sqlite/test-vectors/sqlite-multitable-changes/snapshot-b/data.sqlite.d/01_schema.sql
@@ -1,0 +1,15 @@
+CREATE TABLE users (
+    id INTEGER PRIMARY KEY,
+    name TEXT
+);
+
+CREATE TABLE products (
+    id INTEGER PRIMARY KEY,
+    name TEXT
+);
+
+CREATE TABLE orders (
+    id INTEGER PRIMARY KEY,
+    user_id INTEGER,
+    total REAL
+);

--- a/model-plugins/binoc-sqlite/test-vectors/sqlite-multitable-changes/snapshot-b/data.sqlite.d/02_data.sql
+++ b/model-plugins/binoc-sqlite/test-vectors/sqlite-multitable-changes/snapshot-b/data.sqlite.d/02_data.sql
@@ -1,0 +1,4 @@
+INSERT INTO users VALUES (1, 'Alice');
+INSERT INTO users VALUES (2, 'Bob');
+INSERT INTO products VALUES (1, 'Widget');
+INSERT INTO orders VALUES (1, 2, 19.95);

--- a/model-plugins/binoc-sqlite/test-vectors/sqlite-row-addition/expected-output/abi-log.snap
+++ b/model-plugins/binoc-sqlite/test-vectors/sqlite-row-addition/expected-output/abi-log.snap
@@ -50,6 +50,50 @@ expression: "&abi_log"
       {
         "op": "publish_artifact",
         "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "subject": "Left",
+        "producer": "binoc-sqlite.sqlite",
+        "size": 48
+      },
+      {
+        "op": "publish_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "subject": "Right",
+        "producer": "binoc-sqlite.sqlite",
+        "size": 60
+      },
+      {
+        "op": "publish_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular_collection",
+          "version": 1
+        },
+        "subject": "Left",
+        "producer": "binoc-sqlite.sqlite",
+        "size": 205
+      },
+      {
+        "op": "publish_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular_collection",
+          "version": 1
+        },
+        "subject": "Right",
+        "producer": "binoc-sqlite.sqlite",
+        "size": 205
+      },
+      {
+        "op": "publish_artifact",
+        "format": {
           "package": "binoc-sqlite",
           "name": "relational-schema",
           "version": 1
@@ -80,5 +124,53 @@ expression: "&abi_log"
     "method": "transform",
     "plugin": "binoc.folder_move_detector",
     "data_ops": []
+  },
+  {
+    "method": "transform",
+    "plugin": "binoc.tabular_analyzer",
+    "data_ops": [
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      },
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      }
+    ]
+  },
+  {
+    "method": "transform",
+    "plugin": "binoc.table_collection_analyzer",
+    "data_ops": [
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular_collection",
+          "version": 1
+        },
+        "found": true
+      },
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular_collection",
+          "version": 1
+        },
+        "found": true
+      }
+    ]
   }
 ]

--- a/model-plugins/binoc-sqlite/test-vectors/sqlite-row-addition/expected-output/changelog.snap
+++ b/model-plugins/binoc-sqlite/test-vectors/sqlite-row-addition/expected-output/changelog.snap
@@ -4,4 +4,5 @@ expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
 
-- **data.sqlite/users**: 1 row added (1 → 2 rows)
+- **data.sqlite**: Table users changed: 1 row added
+- **data.sqlite::users**: 1 row added

--- a/model-plugins/binoc-sqlite/test-vectors/sqlite-table-addition/expected-output/changelog.snap
+++ b/model-plugins/binoc-sqlite/test-vectors/sqlite-table-addition/expected-output/changelog.snap
@@ -4,4 +4,5 @@ expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
 
-- **data.sqlite/posts**: Table added (3 columns, 1 row)
+- **data.sqlite**: Table posts added: new table (3 columns, 1 row)
+- **data.sqlite::posts**: New table (3 columns, 1 row)

--- a/model-plugins/binoc-sqlite/test-vectors/sqlite-table-addition/expected-output/changeset.snap
+++ b/model-plugins/binoc-sqlite/test-vectors/sqlite-table-addition/expected-output/changeset.snap
@@ -12,17 +12,24 @@ expression: "&stable_changeset"
     "children": [
       {
         "action": "modify",
-        "item_type": "sqlite_database",
+        "item_type": "tabular_collection",
         "path": "data.sqlite",
+        "summary": "Table posts added: new table (3 columns, 1 row)",
+        "tags": [
+          "binoc.table-addition",
+          "binoc.tabular-collection-change"
+        ],
         "children": [
           {
             "action": "add",
-            "item_type": "sqlite_table",
-            "path": "data.sqlite/posts",
-            "summary": "Table added (3 columns, 1 row)",
+            "item_type": "tabular",
+            "path": "data.sqlite::posts",
+            "summary": "New table (3 columns, 1 row)",
             "tags": [
               "binoc-sqlite.table-addition",
-              "binoc.schema-change"
+              "binoc.content-changed",
+              "binoc.schema-change",
+              "binoc.table-addition"
             ],
             "details": {
               "columns": [
@@ -30,13 +37,21 @@ expression: "&stable_changeset"
                 "title",
                 "user_id"
               ],
-              "row_count": 1
-            }
+              "logical_name": "posts",
+              "row_count": 1,
+              "rows": 1
+            },
+            "transformed_by": [
+              "binoc.tabular_analyzer"
+            ]
           }
         ],
         "details": {
           "hash_left": "0bb865f7f287a972d996d07f69dab0d625f02aa5825cc79a6ab79b5c2794355a",
           "hash_right": "9b5daff3a1a53db53c7691490daa8d0c7653d681ac95bd1bb2a99baa93fd3c37",
+          "tables_added": [
+            "posts"
+          ],
           "tables_left": [
             "users"
           ],
@@ -45,7 +60,10 @@ expression: "&stable_changeset"
             "users"
           ]
         },
-        "comparator": "binoc-sqlite.sqlite"
+        "comparator": "binoc-sqlite.sqlite",
+        "transformed_by": [
+          "binoc.table_collection_analyzer"
+        ]
       }
     ],
     "comparator": "binoc.directory"

--- a/model-plugins/binoc-stat-binary/README.md
+++ b/model-plugins/binoc-stat-binary/README.md
@@ -3,12 +3,20 @@
 First-party optional Binoc plugin for statistical binary datasets.
 
 The plugin reads Stata `.dta`, SAS `.sas7bdat`, and SAS transport `.xpt` files
-into the standard `tabular_v1` artifact (`headers` plus string rows). It does
-not implement a bespoke diff. Once a file is parsed, the normal
-`binoc.tabular_analyzer` transformer reports column, row, and cell changes.
+into the standard tabular artifacts. Ordinary single-table inputs publish
+`tabular_v1` (`headers` plus string rows). Multi-member `.xpt` files publish a
+`tabular_collection_v1` root plus one `tabular_v1` child per dataset member,
+using the XPT dataset name as the stable logical table name and child path
+suffix (for example `study.xpt::DM`). It does not implement a bespoke diff;
+once a file is parsed, the normal `binoc.tabular_analyzer` and
+`binoc.table_collection_analyzer` transformers report column, row, cell, and
+table-set changes.
 
 Cell values are flattened to strings for diffing. Stata and SAS missing values
 are kept visible as source-format display tokens such as `.`, `.a`, and `.A`
 rather than collapsed to empty strings. Variable labels, formats, and available
 value-label dictionaries are attached to node metadata for context, but value
 labels do not replace cell values during comparison.
+
+For `.xpt`, node metadata includes a `datasets` list so member inventory is
+visible even when a file is empty or only one dataset is present.

--- a/model-plugins/binoc-stat-binary/src/stat_binary.rs
+++ b/model-plugins/binoc-stat-binary/src/stat_binary.rs
@@ -38,7 +38,6 @@ trait StatBinaryFormat {
 
 struct StataFormat;
 struct Sas7bdatFormat;
-struct XptFormat;
 
 impl StatBinaryFormat for StataFormat {
     const NAME: &'static str = "binoc-stat-binary.stata";
@@ -57,16 +56,6 @@ impl StatBinaryFormat for Sas7bdatFormat {
 
     fn parse(path: &Path) -> BinocResult<ParsedTable> {
         parse_sas7bdat(path)
-    }
-}
-
-impl StatBinaryFormat for XptFormat {
-    const NAME: &'static str = "binoc-stat-binary.xpt";
-    const PRODUCER: &'static str = "binoc-stat-binary.xpt";
-    const EXTENSIONS: &'static [&'static str] = &[".xpt"];
-
-    fn parse(path: &Path) -> BinocResult<ParsedTable> {
-        parse_xpt(path)
     }
 }
 
@@ -105,7 +94,26 @@ macro_rules! impl_comparator {
 
 impl_comparator!(StataComparator, StataFormat);
 impl_comparator!(Sas7bdatComparator, Sas7bdatFormat);
-impl_comparator!(XptComparator, XptFormat);
+
+impl Comparator for XptComparator {
+    fn descriptor(&self) -> ComparatorDescriptor {
+        ComparatorDescriptor::new("binoc-stat-binary.xpt").with_extensions(vec![".xpt".to_string()])
+    }
+
+    fn compare(&self, pair: &ItemPair, data: &dyn DataAccess) -> BinocResult<CompareResult> {
+        compare_xpt(pair, data)
+    }
+
+    fn extract(
+        &self,
+        node: &DiffNode,
+        aspect: &str,
+        data: &dyn DataAccess,
+    ) -> Option<ExtractResult> {
+        let pair = TabularDataPair::from_artifacts(node, data)?;
+        tabular_extract(&pair, node, aspect)
+    }
+}
 
 fn compare_as_tabular<F: StatBinaryFormat>(
     pair: &ItemPair,
@@ -180,6 +188,17 @@ fn publish_tabular(
     let bytes = serde_json::to_vec(tabular)
         .map_err(|e| BinocError::Other(format!("serialize tabular artifact: {e}")))?;
     data.publish_artifact(&tabular_v1(), subject, producer, &bytes)
+}
+
+fn publish_tabular_collection(
+    data: &dyn DataAccess,
+    collection: &TabularCollectionData,
+    subject: ArtifactSubject,
+    producer: &str,
+) -> BinocResult<ArtifactDescriptor> {
+    let bytes = serde_json::to_vec(collection)
+        .map_err(|e| BinocError::Other(format!("serialize tabular collection artifact: {e}")))?;
+    data.publish_artifact(&tabular_collection_v1(), subject, producer, &bytes)
 }
 
 fn parse_stata(path: &Path) -> BinocResult<ParsedTable> {
@@ -318,66 +337,641 @@ fn parse_sas7bdat(path: &Path) -> BinocResult<ParsedTable> {
     })
 }
 
-fn parse_xpt(path: &Path) -> BinocResult<ParsedTable> {
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ParsedXptDataset {
+    logical_name: String,
+    node_name: String,
+    tabular: TabularData,
+    metadata: serde_json::Value,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ParsedXptFile {
+    datasets: Vec<ParsedXptDataset>,
+    metadata: serde_json::Value,
+}
+
+fn compare_xpt(pair: &ItemPair, data: &dyn DataAccess) -> BinocResult<CompareResult> {
+    match (&pair.left, &pair.right) {
+        (Some(left), Some(right)) => {
+            let left_file = parse_xpt_via_data(left, data)?;
+            let right_file = parse_xpt_via_data(right, data)?;
+            if xpt_uses_collection(Some(&left_file), Some(&right_file)) {
+                compare_xpt_collection(
+                    Some(&left_file),
+                    Some(&right_file),
+                    pair.logical_path(),
+                    data,
+                )
+            } else {
+                compare_single_tables(
+                    pair.logical_path(),
+                    &left_file.datasets[0],
+                    &right_file.datasets[0],
+                    data,
+                    "binoc-stat-binary.xpt",
+                )
+            }
+        }
+        (None, Some(right)) => {
+            let right_file = parse_xpt_via_data(right, data)?;
+            if xpt_uses_collection(None, Some(&right_file)) {
+                compare_xpt_collection(None, Some(&right_file), &right.logical_path, data)
+            } else {
+                add_single_table(
+                    &right.logical_path,
+                    &right_file.datasets[0],
+                    data,
+                    ArtifactSubject::Right,
+                    "binoc-stat-binary.xpt",
+                )
+            }
+        }
+        (Some(left), None) => {
+            let left_file = parse_xpt_via_data(left, data)?;
+            if xpt_uses_collection(Some(&left_file), None) {
+                compare_xpt_collection(Some(&left_file), None, &left.logical_path, data)
+            } else {
+                add_single_table(
+                    &left.logical_path,
+                    &left_file.datasets[0],
+                    data,
+                    ArtifactSubject::Left,
+                    "binoc-stat-binary.xpt",
+                )
+            }
+        }
+        (None, None) => Ok(CompareResult::Identical),
+    }
+}
+
+fn compare_single_tables(
+    logical_path: &str,
+    left: &ParsedXptDataset,
+    right: &ParsedXptDataset,
+    data: &dyn DataAccess,
+    producer: &str,
+) -> BinocResult<CompareResult> {
+    if left.tabular == right.tabular {
+        return Ok(CompareResult::Identical);
+    }
+
+    let left_artifact = publish_tabular(data, &left.tabular, ArtifactSubject::Left, producer)?;
+    let right_artifact = publish_tabular(data, &right.tabular, ArtifactSubject::Right, producer)?;
+
+    let node = DiffNode::new("modify", "tabular", logical_path)
+        .with_detail("left_metadata", left.metadata.clone())
+        .with_detail("right_metadata", right.metadata.clone())
+        .with_artifact(left_artifact)
+        .with_artifact(right_artifact);
+
+    Ok(CompareResult::Leaf(node))
+}
+
+fn add_single_table(
+    logical_path: &str,
+    table: &ParsedXptDataset,
+    data: &dyn DataAccess,
+    subject: ArtifactSubject,
+    producer: &str,
+) -> BinocResult<CompareResult> {
+    let artifact = publish_tabular(data, &table.tabular, subject, producer)?;
+    let action = match subject {
+        ArtifactSubject::Left => "remove",
+        ArtifactSubject::Right => "add",
+        ArtifactSubject::Pair => unreachable!("single table node never uses pair subject"),
+    };
+    let detail_key = match subject {
+        ArtifactSubject::Left | ArtifactSubject::Right => "metadata",
+        ArtifactSubject::Pair => unreachable!("single table node never uses pair subject"),
+    };
+    let node = DiffNode::new(action, "tabular", logical_path)
+        .with_detail(detail_key, table.metadata.clone())
+        .with_artifact(artifact);
+    Ok(CompareResult::Leaf(node))
+}
+
+fn parse_xpt_via_data(item: &ItemRef, data: &dyn DataAccess) -> BinocResult<ParsedXptFile> {
+    let path = data.local_path(item)?;
+    parse_xpt(path.as_path())
+}
+
+fn xpt_uses_collection(left: Option<&ParsedXptFile>, right: Option<&ParsedXptFile>) -> bool {
+    [left, right]
+        .into_iter()
+        .flatten()
+        .any(|file| file.datasets.len() != 1)
+}
+
+fn compare_xpt_collection(
+    left_file: Option<&ParsedXptFile>,
+    right_file: Option<&ParsedXptFile>,
+    logical_path: &str,
+    data: &dyn DataAccess,
+) -> BinocResult<CompareResult> {
+    if left_file == right_file {
+        return Ok(CompareResult::Identical);
+    }
+
+    let left_collection = left_file.map(|file| xpt_collection_from_file(logical_path, file));
+    let right_collection = right_file.map(|file| xpt_collection_from_file(logical_path, file));
+
+    let mut children = Vec::new();
+    let mut tables_added = Vec::new();
+    let mut tables_removed = Vec::new();
+    let mut tables_changed = Vec::new();
+    let mut summary_parts = Vec::new();
+
+    let left_groups = xpt_dataset_groups(left_file);
+    let right_groups = xpt_dataset_groups(right_file);
+    let all_names: std::collections::BTreeSet<String> = left_groups
+        .keys()
+        .chain(right_groups.keys())
+        .cloned()
+        .collect();
+
+    for name in all_names {
+        let left_group = left_groups.get(&name).cloned().unwrap_or_default();
+        let right_group = right_groups.get(&name).cloned().unwrap_or_default();
+
+        match (left_group.as_slice(), right_group.as_slice()) {
+            ([left_dataset], [right_dataset]) => {
+                if left_dataset.tabular != right_dataset.tabular {
+                    let child_summary =
+                        xpt_table_change_summary(&left_dataset.tabular, &right_dataset.tabular);
+                    let left_artifact = publish_tabular(
+                        data,
+                        &left_dataset.tabular,
+                        ArtifactSubject::Left,
+                        "binoc-stat-binary.xpt",
+                    )?;
+                    let right_artifact = publish_tabular(
+                        data,
+                        &right_dataset.tabular,
+                        ArtifactSubject::Right,
+                        "binoc-stat-binary.xpt",
+                    )?;
+                    let node = DiffNode::new(
+                        "modify",
+                        "tabular",
+                        xpt_table_node_path(logical_path, &right_dataset.node_name),
+                    )
+                    .with_summary(child_summary.clone())
+                    .with_tag("binoc.table-change")
+                    .with_detail("left_metadata", left_dataset.metadata.clone())
+                    .with_detail("right_metadata", right_dataset.metadata.clone())
+                    .with_detail("logical_name", serde_json::json!(name))
+                    .with_artifact(left_artifact)
+                    .with_artifact(right_artifact);
+                    children.push(node);
+                    tables_changed.push(name.clone());
+                    summary_parts.push(format!(
+                        "Table {name} changed: {}",
+                        lower_first(&child_summary)
+                    ));
+                }
+            }
+            _ => {
+                for dataset in left_group {
+                    tables_removed.push(dataset.logical_name.clone());
+                    summary_parts.push(format!(
+                        "Table {} removed: {}",
+                        dataset.logical_name,
+                        lower_first(&removed_table_summary(dataset))
+                    ));
+                    children.push(xpt_table_add_remove_node(
+                        logical_path,
+                        dataset,
+                        ArtifactSubject::Left,
+                        data,
+                    )?);
+                }
+                for dataset in right_group {
+                    tables_added.push(dataset.logical_name.clone());
+                    summary_parts.push(format!(
+                        "Table {} added: {}",
+                        dataset.logical_name,
+                        lower_first(&new_table_summary(dataset))
+                    ));
+                    children.push(xpt_table_add_remove_node(
+                        logical_path,
+                        dataset,
+                        ArtifactSubject::Right,
+                        data,
+                    )?);
+                }
+            }
+        }
+    }
+
+    if children.is_empty() {
+        return Ok(CompareResult::Identical);
+    }
+
+    let mut node = DiffNode::new(
+        xpt_collection_action(left_file.is_some(), right_file.is_some()),
+        "tabular_collection",
+        logical_path,
+    )
+    .with_children(children);
+
+    if !tables_added.is_empty() || !tables_removed.is_empty() || !tables_changed.is_empty() {
+        node = node
+            .with_tag("binoc.tabular-collection-change")
+            .with_summary(summary_parts.join("; "));
+    }
+    if !tables_added.is_empty() {
+        node = node
+            .with_tag("binoc.table-addition")
+            .with_detail("tables_added", serde_json::json!(tables_added));
+    }
+    if !tables_removed.is_empty() {
+        node = node
+            .with_tag("binoc.table-removal")
+            .with_detail("tables_removed", serde_json::json!(tables_removed));
+    }
+    if !tables_changed.is_empty() {
+        node = node
+            .with_tag("binoc.table-change")
+            .with_detail("tables_changed", serde_json::json!(tables_changed));
+    }
+
+    if let Some(file) = left_file {
+        node = node.with_detail("left_metadata", file.metadata.clone());
+    }
+    if let Some(file) = right_file {
+        node = node.with_detail("right_metadata", file.metadata.clone());
+    }
+    if let Some(collection) = &left_collection {
+        node = node.with_artifact(publish_tabular_collection(
+            data,
+            collection,
+            ArtifactSubject::Left,
+            "binoc-stat-binary.xpt",
+        )?);
+    }
+    if let Some(collection) = &right_collection {
+        node = node.with_artifact(publish_tabular_collection(
+            data,
+            collection,
+            ArtifactSubject::Right,
+            "binoc-stat-binary.xpt",
+        )?);
+    }
+
+    Ok(CompareResult::Leaf(node))
+}
+
+fn xpt_collection_action(has_left: bool, has_right: bool) -> &'static str {
+    match (has_left, has_right) {
+        (true, true) => "modify",
+        (false, true) => "add",
+        (true, false) => "remove",
+        (false, false) => "identical",
+    }
+}
+
+fn xpt_collection_from_file(logical_path: &str, file: &ParsedXptFile) -> TabularCollectionData {
+    TabularCollectionData {
+        tables: file
+            .datasets
+            .iter()
+            .map(|dataset| {
+                let dataset_name = dataset.metadata["dataset_name"]
+                    .as_str()
+                    .unwrap_or(dataset.logical_name.as_str())
+                    .to_string();
+                let dataset_index = dataset.metadata["dataset_index"]
+                    .as_u64()
+                    .expect("xpt dataset index is present");
+                let dataset_label = dataset.metadata["dataset_label"].clone();
+                TableMember {
+                    logical_name: dataset.logical_name.clone(),
+                    node_path: xpt_table_node_path(logical_path, &dataset.node_name),
+                    source: TableSourceLocation {
+                        item_path: logical_path.into(),
+                        kind: "sas_xport_dataset".into(),
+                        locator: BTreeMap::from([
+                            ("dataset_name".into(), serde_json::json!(dataset_name)),
+                            ("dataset_index".into(), serde_json::json!(dataset_index)),
+                        ]),
+                    },
+                    shape: TableShape {
+                        columns: dataset.tabular.headers.clone(),
+                        row_count: Some(dataset.tabular.rows.len() as u64),
+                    },
+                    metadata: BTreeMap::from([
+                        ("dataset_label".into(), dataset_label),
+                        ("node_name".into(), serde_json::json!(dataset.node_name)),
+                    ]),
+                }
+            })
+            .collect(),
+    }
+}
+
+fn xpt_dataset_groups(file: Option<&ParsedXptFile>) -> BTreeMap<String, Vec<&ParsedXptDataset>> {
+    let mut groups = BTreeMap::new();
+    if let Some(file) = file {
+        for dataset in &file.datasets {
+            groups
+                .entry(dataset.logical_name.clone())
+                .or_insert_with(Vec::new)
+                .push(dataset);
+        }
+    }
+    groups
+}
+
+fn xpt_table_add_remove_node(
+    logical_path: &str,
+    dataset: &ParsedXptDataset,
+    subject: ArtifactSubject,
+    data: &dyn DataAccess,
+) -> BinocResult<DiffNode> {
+    let action = match subject {
+        ArtifactSubject::Left => "remove",
+        ArtifactSubject::Right => "add",
+        ArtifactSubject::Pair => unreachable!("collection child nodes are single-sided"),
+    };
+    let detail_key = match subject {
+        ArtifactSubject::Left => "metadata",
+        ArtifactSubject::Right => "metadata",
+        ArtifactSubject::Pair => unreachable!("collection child nodes are single-sided"),
+    };
+    let artifact = publish_tabular(data, &dataset.tabular, subject, "binoc-stat-binary.xpt")?;
+    let summary = match subject {
+        ArtifactSubject::Left => removed_table_summary(dataset),
+        ArtifactSubject::Right => new_table_summary(dataset),
+        ArtifactSubject::Pair => unreachable!("collection child nodes are single-sided"),
+    };
+    let tag = match subject {
+        ArtifactSubject::Left => "binoc.table-removal",
+        ArtifactSubject::Right => "binoc.table-addition",
+        ArtifactSubject::Pair => unreachable!("collection child nodes are single-sided"),
+    };
+    Ok(DiffNode::new(
+        action,
+        "tabular",
+        xpt_table_node_path(logical_path, &dataset.node_name),
+    )
+    .with_summary(summary)
+    .with_tag(tag)
+    .with_detail("logical_name", serde_json::json!(dataset.logical_name))
+    .with_detail(detail_key, dataset.metadata.clone())
+    .with_artifact(artifact))
+}
+
+fn xpt_table_node_path(logical_path: &str, node_name: &str) -> String {
+    format!("{logical_path}::{node_name}")
+}
+
+fn xpt_table_change_summary(left: &TabularData, right: &TabularData) -> String {
+    let left_headers: std::collections::BTreeSet<&str> =
+        left.headers.iter().map(String::as_str).collect();
+    let right_headers: std::collections::BTreeSet<&str> =
+        right.headers.iter().map(String::as_str).collect();
+
+    let columns_added: Vec<&str> = right_headers.difference(&left_headers).copied().collect();
+    let columns_removed: Vec<&str> = left_headers.difference(&right_headers).copied().collect();
+    let rows_added = right.rows.len().saturating_sub(left.rows.len());
+    let rows_removed = left.rows.len().saturating_sub(right.rows.len());
+
+    let common_headers: Vec<&str> = left_headers.intersection(&right_headers).copied().collect();
+    let mut cells_changed = 0usize;
+    for row_index in 0..left.rows.len().min(right.rows.len()) {
+        for header in &common_headers {
+            let left_index = left
+                .column_index(header)
+                .expect("common header exists on left");
+            let right_index = right
+                .column_index(header)
+                .expect("common header exists on right");
+            let left_value = left.rows[row_index]
+                .get(left_index)
+                .map(String::as_str)
+                .unwrap_or("");
+            let right_value = right.rows[row_index]
+                .get(right_index)
+                .map(String::as_str)
+                .unwrap_or("");
+            if left_value != right_value {
+                cells_changed += 1;
+            }
+        }
+    }
+
+    let mut parts = Vec::new();
+    if !columns_added.is_empty() {
+        parts.push(match columns_added.as_slice() {
+            [name] => format!("Column added: '{name}'"),
+            names => format!("{} columns added", names.len()),
+        });
+    }
+    if !columns_removed.is_empty() {
+        parts.push(match columns_removed.as_slice() {
+            [name] => format!("Column removed: '{name}'"),
+            names => format!("{} columns removed", names.len()),
+        });
+    }
+    if rows_added > 0 {
+        parts.push(format!(
+            "{rows_added} row{} added",
+            if rows_added == 1 { "" } else { "s" }
+        ));
+    }
+    if rows_removed > 0 {
+        parts.push(format!(
+            "{rows_removed} row{} removed",
+            if rows_removed == 1 { "" } else { "s" }
+        ));
+    }
+    if cells_changed > 0 {
+        parts.push(format!(
+            "{cells_changed} cell{} changed",
+            if cells_changed == 1 { "" } else { "s" }
+        ));
+    }
+
+    if parts.is_empty() {
+        "Table changed".to_string()
+    } else {
+        parts.join("; ")
+    }
+}
+
+fn new_table_summary(dataset: &ParsedXptDataset) -> String {
+    format!(
+        "New table ({} column{}, {} row{})",
+        dataset.tabular.headers.len(),
+        if dataset.tabular.headers.len() == 1 {
+            ""
+        } else {
+            "s"
+        },
+        dataset.tabular.rows.len(),
+        if dataset.tabular.rows.len() == 1 {
+            ""
+        } else {
+            "s"
+        },
+    )
+}
+
+fn removed_table_summary(dataset: &ParsedXptDataset) -> String {
+    format!(
+        "Table removed ({} column{}, {} row{})",
+        dataset.tabular.headers.len(),
+        if dataset.tabular.headers.len() == 1 {
+            ""
+        } else {
+            "s"
+        },
+        dataset.tabular.rows.len(),
+        if dataset.tabular.rows.len() == 1 {
+            ""
+        } else {
+            "s"
+        },
+    )
+}
+
+fn lower_first(value: &str) -> String {
+    let mut chars = value.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(first) => first.to_lowercase().to_string() + chars.as_str(),
+    }
+}
+
+fn parse_xpt(path: &Path) -> BinocResult<ParsedXptFile> {
     let file = std::fs::File::open(path).map_err(BinocError::Io)?;
     let reader =
         XportReader::from_file(file).map_err(|e| BinocError::Other(format!("xpt: {e}")))?;
-    let Some(mut dataset) = reader
+
+    let mut datasets = Vec::new();
+    let mut dataset_names = Vec::new();
+    let mut next_dataset = reader
         .next_dataset()
-        .map_err(|e| BinocError::Other(format!("xpt: {e}")))?
-    else {
-        return Ok(ParsedTable {
-            tabular: TabularData {
-                headers: Vec::new(),
-                rows: Vec::new(),
-            },
+        .map_err(|e| BinocError::Other(format!("xpt: {e}")))?;
+    let mut index = 0usize;
+
+    while let Some(mut dataset) = next_dataset {
+        let schema = dataset.schema().clone();
+        let headers = schema
+            .variables()
+            .iter()
+            .map(|variable| variable.full_name().to_string())
+            .collect();
+        let columns: BTreeMap<String, serde_json::Value> = schema
+            .variables()
+            .iter()
+            .filter_map(|variable| {
+                let has_metadata =
+                    !variable.full_label().is_empty() || !variable.full_format().is_empty();
+                has_metadata.then(|| {
+                    (
+                        variable.full_name().to_string(),
+                        serde_json::json!({
+                            "label": empty_to_null(variable.full_label()),
+                            "format": empty_to_null(variable.full_format()),
+                        }),
+                    )
+                })
+            })
+            .collect();
+
+        let mut rows = Vec::new();
+        for record in dataset.records() {
+            let record = record.map_err(|e| BinocError::Other(format!("xpt: {e}")))?;
+            rows.push(record.iter().map(xpt_value_to_string).collect());
+        }
+
+        let dataset_name = schema.dataset_name().to_string();
+        let logical_name = if dataset_name.is_empty() {
+            format!("dataset_{}", index + 1)
+        } else {
+            dataset_name.clone()
+        };
+        dataset_names.push(logical_name.clone());
+        datasets.push(ParsedXptDataset {
+            logical_name,
+            node_name: String::new(),
+            tabular: TabularData { headers, rows },
             metadata: serde_json::json!({
                 "format": "sas_xport",
-                "datasets": [],
+                "dataset_index": index + 1,
+                "dataset_name": dataset_name,
+                "dataset_label": empty_to_null(schema.dataset_label()),
+                "columns": columns,
                 "cell_encoding": "values flattened to display strings; numeric NaN is treated as SAS missing '.'",
             }),
         });
-    };
 
-    let schema = dataset.schema().clone();
-    let headers = schema
-        .variables()
-        .iter()
-        .map(|variable| variable.full_name().to_string())
-        .collect();
-    let columns: BTreeMap<String, serde_json::Value> = schema
-        .variables()
-        .iter()
-        .filter_map(|variable| {
-            let has_metadata =
-                !variable.full_label().is_empty() || !variable.full_format().is_empty();
-            has_metadata.then(|| {
-                (
-                    variable.full_name().to_string(),
-                    serde_json::json!({
-                        "label": empty_to_null(variable.full_label()),
-                        "format": empty_to_null(variable.full_format()),
-                    }),
-                )
-            })
-        })
-        .collect();
-
-    let mut rows = Vec::new();
-    for record in dataset.records() {
-        let record = record.map_err(|e| BinocError::Other(format!("xpt: {e}")))?;
-        rows.push(record.iter().map(xpt_value_to_string).collect());
+        next_dataset = dataset
+            .next_dataset()
+            .map_err(|e| BinocError::Other(format!("xpt: {e}")))?;
+        index += 1;
     }
 
-    Ok(ParsedTable {
-        tabular: TabularData { headers, rows },
+    let mut name_counts = BTreeMap::new();
+    for name in &dataset_names {
+        *name_counts.entry(name.clone()).or_insert(0usize) += 1;
+    }
+    let mut seen_names = BTreeMap::new();
+    for dataset in &mut datasets {
+        let seen = seen_names
+            .entry(dataset.logical_name.clone())
+            .or_insert(0usize);
+        *seen += 1;
+        dataset.node_name = if name_counts[&dataset.logical_name] == 1 {
+            dataset.logical_name.clone()
+        } else {
+            format!("{}#{}", dataset.logical_name, *seen)
+        };
+    }
+
+    let dataset_inventory = datasets
+        .iter()
+        .map(|dataset| {
+            serde_json::json!({
+                "dataset_index": dataset.metadata["dataset_index"].clone(),
+                "dataset_name": dataset.metadata["dataset_name"].clone(),
+                "dataset_label": dataset.metadata["dataset_label"].clone(),
+                "logical_name": dataset.logical_name.clone(),
+                "node_name": dataset.node_name.clone(),
+                "columns": dataset.tabular.headers.clone(),
+                "rows": dataset.tabular.rows.len(),
+            })
+        })
+        .collect::<Vec<_>>();
+
+    for dataset in &mut datasets {
+        let metadata = dataset
+            .metadata
+            .as_object_mut()
+            .expect("xpt dataset metadata is an object");
+        metadata.insert(
+            "logical_name".into(),
+            serde_json::json!(dataset.logical_name.clone()),
+        );
+        metadata.insert(
+            "node_name".into(),
+            serde_json::json!(dataset.node_name.clone()),
+        );
+        metadata.insert(
+            "datasets".into(),
+            serde_json::json!(dataset_inventory.clone()),
+        );
+    }
+
+    Ok(ParsedXptFile {
         metadata: serde_json::json!({
             "format": "sas_xport",
-            "dataset_name": schema.dataset_name(),
-            "dataset_label": empty_to_null(schema.dataset_label()),
-            "columns": columns,
+            "datasets": dataset_inventory,
             "cell_encoding": "values flattened to display strings; numeric NaN is treated as SAS missing '.'",
         }),
+        datasets,
     })
 }
 
@@ -479,6 +1073,10 @@ mod tests {
     use dta::stata::dta::value::Value;
     use dta::stata::dta::variable::Variable;
     use dta::stata::dta::variable_type::VariableType;
+    use sas_xport::sas::xport::{
+        XportMetadata, XportSchema, XportValue, XportVariable, XportWriter,
+    };
+    use sas_xport::sas::SasVariableType;
 
     fn write_simple_dta(path: &Path, extra_column: bool) {
         let header = Header::builder(Release::V118, ByteOrder::LittleEndian)
@@ -524,6 +1122,146 @@ mod tests {
             .unwrap();
     }
 
+    fn write_multi_xpt(path: &Path) {
+        let dm = XportSchema::builder()
+            .dataset_name("DM")
+            .add_variable({
+                let mut variable = XportVariable::builder();
+                variable
+                    .short_name("id")
+                    .value_type(SasVariableType::Character)
+                    .value_length(8);
+                variable
+            })
+            .add_variable({
+                let mut variable = XportVariable::builder();
+                variable
+                    .short_name("name")
+                    .value_type(SasVariableType::Character)
+                    .value_length(8);
+                variable
+            })
+            .try_build()
+            .unwrap();
+        let ae = XportSchema::builder()
+            .dataset_name("AE")
+            .add_variable({
+                let mut variable = XportVariable::builder();
+                variable
+                    .short_name("id")
+                    .value_type(SasVariableType::Character)
+                    .value_length(8);
+                variable
+            })
+            .add_variable({
+                let mut variable = XportVariable::builder();
+                variable
+                    .short_name("event")
+                    .value_type(SasVariableType::Character)
+                    .value_length(16);
+                variable
+            })
+            .try_build()
+            .unwrap();
+
+        let file = std::fs::File::create(path).unwrap();
+        let writer = XportWriter::from_file(file, XportMetadata::builder().build()).unwrap();
+        let mut writer = writer.write_schema(dm).unwrap();
+        writer
+            .write_record(&[XportValue::from("1"), XportValue::from("Alice")])
+            .unwrap();
+        let writer = writer.next_dataset().unwrap();
+        let mut writer = writer.write_schema(ae).unwrap();
+        writer
+            .write_record(&[XportValue::from("1"), XportValue::from("Headache")])
+            .unwrap();
+        writer.finish().unwrap();
+    }
+
+    fn write_multi_xpt_with_extra_member(path: &Path) {
+        let dm = XportSchema::builder()
+            .dataset_name("DM")
+            .add_variable({
+                let mut variable = XportVariable::builder();
+                variable
+                    .short_name("id")
+                    .value_type(SasVariableType::Character)
+                    .value_length(8);
+                variable
+            })
+            .add_variable({
+                let mut variable = XportVariable::builder();
+                variable
+                    .short_name("name")
+                    .value_type(SasVariableType::Character)
+                    .value_length(8);
+                variable
+            })
+            .try_build()
+            .unwrap();
+        let ae = XportSchema::builder()
+            .dataset_name("AE")
+            .add_variable({
+                let mut variable = XportVariable::builder();
+                variable
+                    .short_name("id")
+                    .value_type(SasVariableType::Character)
+                    .value_length(8);
+                variable
+            })
+            .add_variable({
+                let mut variable = XportVariable::builder();
+                variable
+                    .short_name("event")
+                    .value_type(SasVariableType::Character)
+                    .value_length(16);
+                variable
+            })
+            .try_build()
+            .unwrap();
+        let lb = XportSchema::builder()
+            .dataset_name("LB")
+            .add_variable({
+                let mut variable = XportVariable::builder();
+                variable
+                    .short_name("id")
+                    .value_type(SasVariableType::Character)
+                    .value_length(8);
+                variable
+            })
+            .add_variable({
+                let mut variable = XportVariable::builder();
+                variable
+                    .short_name("lab")
+                    .value_type(SasVariableType::Character)
+                    .value_length(16);
+                variable
+            })
+            .try_build()
+            .unwrap();
+
+        let file = std::fs::File::create(path).unwrap();
+        let writer = XportWriter::from_file(file, XportMetadata::builder().build()).unwrap();
+        let mut writer = writer.write_schema(dm).unwrap();
+        writer
+            .write_record(&[XportValue::from("1"), XportValue::from("Alice")])
+            .unwrap();
+        writer
+            .write_record(&[XportValue::from("2"), XportValue::from("Bob")])
+            .unwrap();
+        let writer = writer.next_dataset().unwrap();
+        let mut writer = writer.write_schema(ae).unwrap();
+        writer
+            .write_record(&[XportValue::from("1"), XportValue::from("Headache")])
+            .unwrap();
+        let writer = writer.next_dataset().unwrap();
+        let mut writer = writer.write_schema(lb).unwrap();
+        writer
+            .write_record(&[XportValue::from("1"), XportValue::from("ALT")])
+            .unwrap();
+        writer.finish().unwrap();
+    }
+
     #[test]
     fn parses_stata_as_tabular() {
         let dir = tempfile::tempdir().unwrap();
@@ -561,6 +1299,46 @@ mod tests {
                     .artifacts
                     .iter()
                     .all(|artifact| artifact.format == tabular_v1()));
+            }
+            _ => panic!("expected changed leaf"),
+        }
+    }
+
+    #[test]
+    fn parses_multi_dataset_xpt() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("data.xpt");
+        write_multi_xpt(&path);
+
+        let parsed = parse_xpt(&path).unwrap();
+        assert_eq!(parsed.datasets.len(), 2);
+        assert_eq!(parsed.datasets[0].logical_name, "DM");
+        assert_eq!(parsed.datasets[1].logical_name, "AE");
+    }
+
+    #[test]
+    fn xpt_comparator_uses_collection_for_multi_dataset_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let left = dir.path().join("left.xpt");
+        let right = dir.path().join("right.xpt");
+        write_multi_xpt(&left);
+        write_multi_xpt_with_extra_member(&right);
+
+        let data = LocalDataAccess::new();
+        let pair = ItemPair::both(
+            data.register_local(&left, "data.xpt").unwrap(),
+            data.register_local(&right, "data.xpt").unwrap(),
+        );
+
+        let result = XptComparator.compare(&pair, &data).unwrap();
+        match result {
+            CompareResult::Leaf(node) => {
+                assert_eq!(node.item_type, "tabular_collection");
+                assert_eq!(node.children.len(), 2);
+                assert!(node
+                    .artifacts
+                    .iter()
+                    .all(|artifact| artifact.format == tabular_collection_v1()));
             }
             _ => panic!("expected changed leaf"),
         }

--- a/model-plugins/binoc-stat-binary/src/test_support.rs
+++ b/model-plugins/binoc-stat-binary/src/test_support.rs
@@ -40,8 +40,8 @@ impl VectorMaterializer for XptMaterializer {
     }
 
     fn build(&self, staging_dir: &Path, out_path: &Path, _all_staging_suffixes: &[&str]) {
-        let fixture = read_csv_fixture(staging_dir);
-        write_xpt(out_path, &fixture.headers, &fixture.rows);
+        let fixtures = read_xpt_fixture(staging_dir);
+        write_xpt(out_path, &fixtures);
     }
 }
 
@@ -57,6 +57,7 @@ impl VectorMaterializer for Sas7bdatMaterializer {
 }
 
 struct CsvFixture {
+    dataset_name: Option<String>,
     headers: Vec<String>,
     rows: Vec<Vec<String>>,
 }
@@ -71,11 +72,44 @@ fn read_csv_fixture(staging_dir: &Path) -> CsvFixture {
         .unwrap_or_else(|| panic!("{} must contain a header row", csv_path.display()));
 
     CsvFixture {
+        dataset_name: None,
         headers: header_line.split(',').map(ToOwned::to_owned).collect(),
         rows: lines
             .map(|line| line.split(',').map(ToOwned::to_owned).collect())
             .collect(),
     }
+}
+
+fn read_xpt_fixture(staging_dir: &Path) -> Vec<CsvFixture> {
+    let single_table = staging_dir.join("table.csv");
+    if single_table.is_file() {
+        return vec![read_csv_fixture(staging_dir)];
+    }
+
+    let mut datasets = Vec::new();
+    let entries = std::fs::read_dir(staging_dir)
+        .unwrap_or_else(|e| panic!("read_dir {}: {e}", staging_dir.display()));
+    let mut dataset_dirs = entries
+        .map(|entry| {
+            entry.unwrap_or_else(|e| panic!("read_dir entry {}: {e}", staging_dir.display()))
+        })
+        .filter(|entry| entry.file_type().map(|ty| ty.is_dir()).unwrap_or(false))
+        .collect::<Vec<_>>();
+    dataset_dirs.sort_by_key(|entry| entry.file_name());
+
+    for entry in dataset_dirs {
+        let dataset_dir = entry.path();
+        let mut fixture = read_csv_fixture(&dataset_dir);
+        fixture.dataset_name = Some(entry.file_name().to_string_lossy().into_owned());
+        datasets.push(fixture);
+    }
+
+    assert!(
+        !datasets.is_empty(),
+        "{} must contain table.csv or dataset subdirectories with table.csv",
+        staging_dir.display()
+    );
+    datasets
 }
 
 fn write_dta(out_path: &Path, headers: &[String], rows: &[Vec<String>]) {
@@ -124,16 +158,58 @@ fn write_dta(out_path: &Path, headers: &[String], rows: &[Vec<String>]) {
         .unwrap_or_else(|e| panic!("finish dta {}: {e}", out_path.display()));
 }
 
-fn write_xpt(out_path: &Path, headers: &[String], rows: &[Vec<String>]) {
+fn write_xpt(out_path: &Path, datasets: &[CsvFixture]) {
     if out_path.exists() {
         std::fs::remove_file(out_path)
             .unwrap_or_else(|e| panic!("remove_file {}: {e}", out_path.display()));
     }
 
+    let file = std::fs::File::create(out_path)
+        .unwrap_or_else(|e| panic!("create {}: {e}", out_path.display()));
+    let writer = XportWriter::from_file(file, XportMetadata::builder().build())
+        .unwrap_or_else(|e| panic!("open xpt writer {}: {e}", out_path.display()));
+    let mut writer = Some(writer);
+
+    for (index, dataset) in datasets.iter().enumerate() {
+        let schema = build_xpt_schema(dataset);
+        let next_writer = writer
+            .take()
+            .expect("xpt writer state")
+            .write_schema(schema)
+            .unwrap_or_else(|e| panic!("write xpt schema {}: {e}", out_path.display()));
+
+        let mut dataset_writer = next_writer;
+        for row in &dataset.rows {
+            let values: Vec<XportValue<'_>> = row
+                .iter()
+                .map(|value| XportValue::from(value.as_str()))
+                .collect();
+            dataset_writer
+                .write_record(&values)
+                .unwrap_or_else(|e| panic!("write xpt record {}: {e}", out_path.display()));
+        }
+
+        if index + 1 == datasets.len() {
+            dataset_writer
+                .finish()
+                .unwrap_or_else(|e| panic!("finish xpt {}: {e}", out_path.display()));
+        } else {
+            writer = Some(
+                dataset_writer
+                    .next_dataset()
+                    .unwrap_or_else(|e| panic!("advance xpt dataset {}: {e}", out_path.display())),
+            );
+        }
+    }
+}
+
+fn build_xpt_schema(dataset: &CsvFixture) -> XportSchema {
+    let dataset_name = dataset.dataset_name.as_deref().unwrap_or("BINOCTST");
     let mut schema_builder = XportSchema::builder();
-    let mut schema = schema_builder.dataset_name("BINOCTST");
-    for (index, header) in headers.iter().enumerate() {
-        let width = rows
+    let mut schema = schema_builder.dataset_name(dataset_name);
+    for (index, header) in dataset.headers.iter().enumerate() {
+        let width = dataset
+            .rows
             .iter()
             .filter_map(|row| row.get(index))
             .map(String::len)
@@ -147,31 +223,9 @@ fn write_xpt(out_path: &Path, headers: &[String], rows: &[Vec<String>]) {
             .value_length(width.try_into().expect("xpt field width fits in u16"));
         schema = schema.add_variable(variable);
     }
-    let schema = schema
+    schema
         .try_build()
-        .unwrap_or_else(|e| panic!("build xpt schema: {e}"));
-
-    let file = std::fs::File::create(out_path)
-        .unwrap_or_else(|e| panic!("create {}: {e}", out_path.display()));
-    let writer = XportWriter::from_file(file, XportMetadata::builder().build())
-        .unwrap_or_else(|e| panic!("open xpt writer {}: {e}", out_path.display()));
-    let mut writer = writer
-        .write_schema(schema)
-        .unwrap_or_else(|e| panic!("write xpt schema {}: {e}", out_path.display()));
-
-    for row in rows {
-        let values: Vec<XportValue<'_>> = row
-            .iter()
-            .map(|value| XportValue::from(value.as_str()))
-            .collect();
-        writer
-            .write_record(&values)
-            .unwrap_or_else(|e| panic!("write xpt record {}: {e}", out_path.display()));
-    }
-
-    writer
-        .finish()
-        .unwrap_or_else(|e| panic!("finish xpt {}: {e}", out_path.display()));
+        .unwrap_or_else(|e| panic!("build xpt schema: {e}"))
 }
 
 fn write_sas7bdat(out_path: &Path, headers: &[String], rows: &[Vec<String>]) {

--- a/model-plugins/binoc-stat-binary/test-vectors/xpt-column-addition/expected-output/changeset.snap
+++ b/model-plugins/binoc-stat-binary/test-vectors/xpt-column-addition/expected-output/changeset.snap
@@ -39,16 +39,51 @@ expression: "&stable_changeset"
           "left_metadata": {
             "cell_encoding": "values flattened to display strings; numeric NaN is treated as SAS missing '.'",
             "columns": {},
+            "dataset_index": 1,
             "dataset_label": null,
             "dataset_name": "BINOCTST",
-            "format": "sas_xport"
+            "datasets": [
+              {
+                "columns": [
+                  "id",
+                  "name"
+                ],
+                "dataset_index": 1,
+                "dataset_label": null,
+                "dataset_name": "BINOCTST",
+                "logical_name": "BINOCTST",
+                "node_name": "BINOCTST",
+                "rows": 2
+              }
+            ],
+            "format": "sas_xport",
+            "logical_name": "BINOCTST",
+            "node_name": "BINOCTST"
           },
           "right_metadata": {
             "cell_encoding": "values flattened to display strings; numeric NaN is treated as SAS missing '.'",
             "columns": {},
+            "dataset_index": 1,
             "dataset_label": null,
             "dataset_name": "BINOCTST",
-            "format": "sas_xport"
+            "datasets": [
+              {
+                "columns": [
+                  "id",
+                  "name",
+                  "score"
+                ],
+                "dataset_index": 1,
+                "dataset_label": null,
+                "dataset_name": "BINOCTST",
+                "logical_name": "BINOCTST",
+                "node_name": "BINOCTST",
+                "rows": 2
+              }
+            ],
+            "format": "sas_xport",
+            "logical_name": "BINOCTST",
+            "node_name": "BINOCTST"
           },
           "rows_added": 0,
           "rows_left": 2,

--- a/model-plugins/binoc-stat-binary/test-vectors/xpt-multidataset-members/expected-output/abi-log.snap
+++ b/model-plugins/binoc-stat-binary/test-vectors/xpt-multidataset-members/expected-output/abi-log.snap
@@ -1,0 +1,146 @@
+---
+source: binoc-stdlib/src/test_vectors.rs
+expression: "&abi_log"
+---
+[
+  {
+    "method": "compare",
+    "plugin": "binoc.directory",
+    "data_ops": [
+      {
+        "op": "local_path",
+        "handle": ""
+      },
+      {
+        "op": "local_path",
+        "handle": ""
+      },
+      {
+        "op": "register_local",
+        "logical": "data.xpt"
+      },
+      {
+        "op": "read_bytes",
+        "handle": "data.xpt",
+        "result_size": 2000
+      },
+      {
+        "op": "register_local",
+        "logical": "data.xpt"
+      },
+      {
+        "op": "read_bytes",
+        "handle": "data.xpt",
+        "result_size": 2880
+      }
+    ]
+  },
+  {
+    "method": "compare",
+    "plugin": "binoc-stat-binary.xpt",
+    "data_ops": [
+      {
+        "op": "local_path",
+        "handle": "data.xpt"
+      },
+      {
+        "op": "local_path",
+        "handle": "data.xpt"
+      },
+      {
+        "op": "publish_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "subject": "Left",
+        "producer": "binoc-stat-binary.xpt",
+        "size": 48
+      },
+      {
+        "op": "publish_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "subject": "Right",
+        "producer": "binoc-stat-binary.xpt",
+        "size": 60
+      },
+      {
+        "op": "publish_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "subject": "Right",
+        "producer": "binoc-stat-binary.xpt",
+        "size": 45
+      },
+      {
+        "op": "publish_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular_collection",
+          "version": 1
+        },
+        "subject": "Left",
+        "producer": "binoc-stat-binary.xpt",
+        "size": 531
+      },
+      {
+        "op": "publish_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular_collection",
+          "version": 1
+        },
+        "subject": "Right",
+        "producer": "binoc-stat-binary.xpt",
+        "size": 789
+      }
+    ]
+  },
+  {
+    "method": "transform",
+    "plugin": "binoc.tabular_analyzer",
+    "data_ops": [
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      },
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      }
+    ]
+  },
+  {
+    "method": "transform",
+    "plugin": "binoc.tabular_analyzer",
+    "data_ops": [
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      }
+    ]
+  }
+]

--- a/model-plugins/binoc-stat-binary/test-vectors/xpt-multidataset-members/expected-output/changelog.snap
+++ b/model-plugins/binoc-stat-binary/test-vectors/xpt-multidataset-members/expected-output/changelog.snap
@@ -1,0 +1,9 @@
+---
+source: binoc-stdlib/src/test_vectors.rs
+expression: "&md"
+---
+# Changelog: snapshot-a → snapshot-b
+
+- **data.xpt**: Table DM changed: 1 row added; Table LB added: new table (2 columns, 1 row)
+- **data.xpt::DM**: 1 row added
+- **data.xpt::LB**: New table (2 columns, 1 row)

--- a/model-plugins/binoc-stat-binary/test-vectors/xpt-multidataset-members/expected-output/changeset.snap
+++ b/model-plugins/binoc-stat-binary/test-vectors/xpt-multidataset-members/expected-output/changeset.snap
@@ -1,0 +1,296 @@
+---
+source: binoc-stdlib/src/test_vectors.rs
+expression: "&stable_changeset"
+---
+{
+  "from_snapshot": "snapshot-a",
+  "to_snapshot": "snapshot-b",
+  "root": {
+    "action": "modify",
+    "item_type": "directory",
+    "path": "",
+    "children": [
+      {
+        "action": "modify",
+        "item_type": "tabular_collection",
+        "path": "data.xpt",
+        "summary": "Table DM changed: 1 row added; Table LB added: new table (2 columns, 1 row)",
+        "tags": [
+          "binoc.table-addition",
+          "binoc.table-change",
+          "binoc.tabular-collection-change"
+        ],
+        "children": [
+          {
+            "action": "modify",
+            "item_type": "tabular",
+            "path": "data.xpt::DM",
+            "summary": "1 row added",
+            "tags": [
+              "binoc.row-addition",
+              "binoc.table-change"
+            ],
+            "details": {
+              "cells_changed": 0,
+              "columns_added": [],
+              "columns_left": [
+                "id",
+                "name"
+              ],
+              "columns_removed": [],
+              "columns_right": [
+                "id",
+                "name"
+              ],
+              "left_metadata": {
+                "cell_encoding": "values flattened to display strings; numeric NaN is treated as SAS missing '.'",
+                "columns": {},
+                "dataset_index": 2,
+                "dataset_label": null,
+                "dataset_name": "DM",
+                "datasets": [
+                  {
+                    "columns": [
+                      "id",
+                      "event"
+                    ],
+                    "dataset_index": 1,
+                    "dataset_label": null,
+                    "dataset_name": "AE",
+                    "logical_name": "AE",
+                    "node_name": "AE",
+                    "rows": 1
+                  },
+                  {
+                    "columns": [
+                      "id",
+                      "name"
+                    ],
+                    "dataset_index": 2,
+                    "dataset_label": null,
+                    "dataset_name": "DM",
+                    "logical_name": "DM",
+                    "node_name": "DM",
+                    "rows": 1
+                  }
+                ],
+                "format": "sas_xport",
+                "logical_name": "DM",
+                "node_name": "DM"
+              },
+              "logical_name": "DM",
+              "right_metadata": {
+                "cell_encoding": "values flattened to display strings; numeric NaN is treated as SAS missing '.'",
+                "columns": {},
+                "dataset_index": 2,
+                "dataset_label": null,
+                "dataset_name": "DM",
+                "datasets": [
+                  {
+                    "columns": [
+                      "id",
+                      "event"
+                    ],
+                    "dataset_index": 1,
+                    "dataset_label": null,
+                    "dataset_name": "AE",
+                    "logical_name": "AE",
+                    "node_name": "AE",
+                    "rows": 1
+                  },
+                  {
+                    "columns": [
+                      "id",
+                      "name"
+                    ],
+                    "dataset_index": 2,
+                    "dataset_label": null,
+                    "dataset_name": "DM",
+                    "logical_name": "DM",
+                    "node_name": "DM",
+                    "rows": 2
+                  },
+                  {
+                    "columns": [
+                      "id",
+                      "lab"
+                    ],
+                    "dataset_index": 3,
+                    "dataset_label": null,
+                    "dataset_name": "LB",
+                    "logical_name": "LB",
+                    "node_name": "LB",
+                    "rows": 1
+                  }
+                ],
+                "format": "sas_xport",
+                "logical_name": "DM",
+                "node_name": "DM"
+              },
+              "rows_added": 1,
+              "rows_left": 1,
+              "rows_removed": 0,
+              "rows_right": 2
+            },
+            "transformed_by": [
+              "binoc.tabular_analyzer"
+            ]
+          },
+          {
+            "action": "add",
+            "item_type": "tabular",
+            "path": "data.xpt::LB",
+            "summary": "New table (2 columns, 1 row)",
+            "tags": [
+              "binoc.content-changed",
+              "binoc.table-addition"
+            ],
+            "details": {
+              "columns": [
+                "id",
+                "lab"
+              ],
+              "logical_name": "LB",
+              "metadata": {
+                "cell_encoding": "values flattened to display strings; numeric NaN is treated as SAS missing '.'",
+                "columns": {},
+                "dataset_index": 3,
+                "dataset_label": null,
+                "dataset_name": "LB",
+                "datasets": [
+                  {
+                    "columns": [
+                      "id",
+                      "event"
+                    ],
+                    "dataset_index": 1,
+                    "dataset_label": null,
+                    "dataset_name": "AE",
+                    "logical_name": "AE",
+                    "node_name": "AE",
+                    "rows": 1
+                  },
+                  {
+                    "columns": [
+                      "id",
+                      "name"
+                    ],
+                    "dataset_index": 2,
+                    "dataset_label": null,
+                    "dataset_name": "DM",
+                    "logical_name": "DM",
+                    "node_name": "DM",
+                    "rows": 2
+                  },
+                  {
+                    "columns": [
+                      "id",
+                      "lab"
+                    ],
+                    "dataset_index": 3,
+                    "dataset_label": null,
+                    "dataset_name": "LB",
+                    "logical_name": "LB",
+                    "node_name": "LB",
+                    "rows": 1
+                  }
+                ],
+                "format": "sas_xport",
+                "logical_name": "LB",
+                "node_name": "LB"
+              },
+              "rows": 1
+            },
+            "transformed_by": [
+              "binoc.tabular_analyzer"
+            ]
+          }
+        ],
+        "details": {
+          "hash_left": "3492ce81a98c3bf771796cd6b006087a3d6a622be4119c51912a637eb93c72f8",
+          "hash_right": "340740cc0412da03cb96e1e1f039a6fdb03585d67fba80b76e18f63b3db82f40",
+          "left_metadata": {
+            "cell_encoding": "values flattened to display strings; numeric NaN is treated as SAS missing '.'",
+            "datasets": [
+              {
+                "columns": [
+                  "id",
+                  "event"
+                ],
+                "dataset_index": 1,
+                "dataset_label": null,
+                "dataset_name": "AE",
+                "logical_name": "AE",
+                "node_name": "AE",
+                "rows": 1
+              },
+              {
+                "columns": [
+                  "id",
+                  "name"
+                ],
+                "dataset_index": 2,
+                "dataset_label": null,
+                "dataset_name": "DM",
+                "logical_name": "DM",
+                "node_name": "DM",
+                "rows": 1
+              }
+            ],
+            "format": "sas_xport"
+          },
+          "right_metadata": {
+            "cell_encoding": "values flattened to display strings; numeric NaN is treated as SAS missing '.'",
+            "datasets": [
+              {
+                "columns": [
+                  "id",
+                  "event"
+                ],
+                "dataset_index": 1,
+                "dataset_label": null,
+                "dataset_name": "AE",
+                "logical_name": "AE",
+                "node_name": "AE",
+                "rows": 1
+              },
+              {
+                "columns": [
+                  "id",
+                  "name"
+                ],
+                "dataset_index": 2,
+                "dataset_label": null,
+                "dataset_name": "DM",
+                "logical_name": "DM",
+                "node_name": "DM",
+                "rows": 2
+              },
+              {
+                "columns": [
+                  "id",
+                  "lab"
+                ],
+                "dataset_index": 3,
+                "dataset_label": null,
+                "dataset_name": "LB",
+                "logical_name": "LB",
+                "node_name": "LB",
+                "rows": 1
+              }
+            ],
+            "format": "sas_xport"
+          },
+          "tables_added": [
+            "LB"
+          ],
+          "tables_changed": [
+            "DM"
+          ]
+        },
+        "comparator": "binoc-stat-binary.xpt"
+      }
+    ],
+    "comparator": "binoc.directory"
+  }
+}

--- a/model-plugins/binoc-stat-binary/test-vectors/xpt-multidataset-members/manifest.toml
+++ b/model-plugins/binoc-stat-binary/test-vectors/xpt-multidataset-members/manifest.toml
@@ -1,0 +1,13 @@
+[vector]
+name = "xpt-multidataset-members"
+description = "Multi-member SAS XPORT files become a tabular collection so later datasets are diffed instead of silently dropped."
+tags = ["xpt", "tabular-collection", "multi-table", "row-addition", "table-addition"]
+
+[expected]
+root_action = "modify"
+has_tags = [
+    "binoc.tabular-collection-change",
+    "binoc.table-change",
+    "binoc.table-addition",
+    "binoc.row-addition",
+]

--- a/model-plugins/binoc-stat-binary/test-vectors/xpt-multidataset-members/snapshot-a/data.xpt.d/AE/table.csv
+++ b/model-plugins/binoc-stat-binary/test-vectors/xpt-multidataset-members/snapshot-a/data.xpt.d/AE/table.csv
@@ -1,0 +1,2 @@
+id,event
+1,Headache

--- a/model-plugins/binoc-stat-binary/test-vectors/xpt-multidataset-members/snapshot-a/data.xpt.d/DM/table.csv
+++ b/model-plugins/binoc-stat-binary/test-vectors/xpt-multidataset-members/snapshot-a/data.xpt.d/DM/table.csv
@@ -1,0 +1,2 @@
+id,name
+1,Alice

--- a/model-plugins/binoc-stat-binary/test-vectors/xpt-multidataset-members/snapshot-b/data.xpt.d/AE/table.csv
+++ b/model-plugins/binoc-stat-binary/test-vectors/xpt-multidataset-members/snapshot-b/data.xpt.d/AE/table.csv
@@ -1,0 +1,2 @@
+id,event
+1,Headache

--- a/model-plugins/binoc-stat-binary/test-vectors/xpt-multidataset-members/snapshot-b/data.xpt.d/DM/table.csv
+++ b/model-plugins/binoc-stat-binary/test-vectors/xpt-multidataset-members/snapshot-b/data.xpt.d/DM/table.csv
@@ -1,0 +1,3 @@
+id,name
+1,Alice
+2,Bob

--- a/model-plugins/binoc-stat-binary/test-vectors/xpt-multidataset-members/snapshot-b/data.xpt.d/LB/table.csv
+++ b/model-plugins/binoc-stat-binary/test-vectors/xpt-multidataset-members/snapshot-b/data.xpt.d/LB/table.csv
@@ -1,0 +1,2 @@
+id,lab
+1,ALT

--- a/test-vectors/directory-nested/expected-output/changelog.snap
+++ b/test-vectors/directory-nested/expected-output/changelog.snap
@@ -4,6 +4,6 @@ expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
 
-- **data/extra.csv**: New table (2 columns, 1 rows)
+- **data/extra.csv**: New table (2 columns, 1 row)
 - **data/records.csv**: 1 row added
 - **docs/readme.txt**: 2 lines added, 1 removed

--- a/test-vectors/directory-nested/expected-output/changeset.snap
+++ b/test-vectors/directory-nested/expected-output/changeset.snap
@@ -19,7 +19,7 @@ expression: "&stable_changeset"
             "action": "add",
             "item_type": "tabular",
             "path": "data/extra.csv",
-            "summary": "New table (2 columns, 1 rows)",
+            "summary": "New table (2 columns, 1 row)",
             "tags": [
               "binoc.content-changed"
             ],

--- a/test-vectors/folder-move-partial/expected-output/changelog.snap
+++ b/test-vectors/folder-move-partial/expected-output/changelog.snap
@@ -5,6 +5,6 @@ expression: "&md"
 # Changelog: snapshot-a → snapshot-b
 
 - **FoodData_Central_csv_2026-04-30**: Folder moved from FoodData_Central_csv_2,025-12-18
-- **FoodData_Central_csv_2026-04-30/data/new-table.csv**: New table (2 columns, 1 rows)
+- **FoodData_Central_csv_2026-04-30/data/new-table.csv**: New table (2 columns, 1 row)
 - **FoodData_Central_csv_2026-04-30/docs/modified.txt**: Text modified
 - **FoodData_Central_csv_2026-04-30/docs/old-table.txt**: File removed (1 line)

--- a/test-vectors/folder-move-partial/expected-output/changeset.snap
+++ b/test-vectors/folder-move-partial/expected-output/changeset.snap
@@ -30,7 +30,7 @@ expression: "&stable_changeset"
                 "action": "add",
                 "item_type": "tabular",
                 "path": "FoodData_Central_csv_2026-04-30/data/new-table.csv",
-                "summary": "New table (2 columns, 1 rows)",
+                "summary": "New table (2 columns, 1 row)",
                 "tags": [
                   "binoc.content-changed"
                 ],

--- a/third_party_plugins.json
+++ b/third_party_plugins.json
@@ -29,7 +29,7 @@
             "scope": "Files",
             "handles_identical": false
           },
-          "ir_item_types": ["sqlite_database", "sqlite_table"]
+          "ir_item_types": ["tabular_collection", "tabular"]
         }
       ],
       "transformers": [],


### PR DESCRIPTION
## Summary
- add a shared `tabular_collection_v1` artifact and SDK data model for multi-table sources
- add a format-neutral `TableCollectionAnalyzer` that summarizes table additions, removals, and changed members
- update SQLite to emit tabular collection parents with table child nodes and canonicalize SQLite table row order for deterministic positional diffs
- update XPT handling to represent multi-dataset transport files as tabular collections