### PR TITLE
Detect stacked logical tables in CSV inputs

### DIFF
--- a/binoc-core/src/config.rs
+++ b/binoc-core/src/config.rs
@@ -108,6 +108,7 @@ impl DatasetConfig {
                 "binoc.correlation_detector".into(),
                 "binoc.fuzzy_correlation_detector".into(),
                 "binoc.folder_move_detector".into(),
+                "binoc.table_splitter".into(),
                 "binoc.tabular_analyzer".into(),
                 "binoc.column_reorder_detector".into(),
                 "binoc.table_collection_analyzer".into(),

--- a/binoc-stdlib/src/lib.rs
+++ b/binoc-stdlib/src/lib.rs
@@ -27,6 +27,7 @@ pub fn register_stdlib(registry: &mut PluginRegistry) {
     r(registry.register_transformer(Arc::new(
         transformers::folder_move_detector::FolderMoveDetector,
     )));
+    r(registry.register_transformer(Arc::new(transformers::table_splitter::TableSplitter)));
     r(registry.register_transformer(Arc::new(transformers::tabular_analyzer::TabularAnalyzer)));
     r(registry.register_transformer(Arc::new(
         transformers::column_reorder::ColumnReorderDetector,

--- a/binoc-stdlib/src/test_vectors.rs
+++ b/binoc-stdlib/src/test_vectors.rs
@@ -330,6 +330,7 @@ pub fn abi_wrapped_default_registry() -> (
     wrap_transformer!(correlation_detector::CorrelationDetector);
     wrap_transformer!(fuzzy_correlation_detector::FuzzyCorrelationDetector);
     wrap_transformer!(folder_move_detector::FolderMoveDetector);
+    wrap_transformer!(table_splitter::TableSplitter);
     wrap_transformer!(tabular_analyzer::TabularAnalyzer);
     wrap_transformer!(column_reorder::ColumnReorderDetector);
     wrap_transformer!(table_collection_analyzer::TableCollectionAnalyzer);

--- a/binoc-stdlib/src/transformers/mod.rs
+++ b/binoc-stdlib/src/transformers/mod.rs
@@ -4,4 +4,5 @@ pub mod correlation_detector;
 pub mod folder_move_detector;
 pub mod fuzzy_correlation_detector;
 pub mod table_collection_analyzer;
+pub mod table_splitter;
 pub mod tabular_analyzer;

--- a/binoc-stdlib/src/transformers/table_splitter.rs
+++ b/binoc-stdlib/src/transformers/table_splitter.rs
@@ -1,0 +1,511 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use binoc_sdk::*;
+
+const PRODUCER: &str = "binoc.table_splitter";
+
+/// Splits a single messy tabular artifact into a collection of logical
+/// tables when the file clearly contains stacked rectangular regions.
+pub struct TableSplitter;
+
+#[derive(Debug, Clone)]
+struct Section {
+    logical_name: String,
+    title: Option<String>,
+    header_row: usize,
+    end_row: usize,
+    data: TabularData,
+}
+
+#[derive(Debug, Clone)]
+struct Detection {
+    sections: Vec<Section>,
+    ambiguous_reason: Option<String>,
+}
+
+impl Transformer for TableSplitter {
+    fn descriptor(&self) -> TransformerDescriptor {
+        TransformerDescriptor::new(PRODUCER).with_match_artifacts(vec![tabular_v1()])
+    }
+
+    fn transform(
+        &self,
+        mut node: DiffNode,
+        data: &dyn DataAccess,
+        _config: &serde_json::Value,
+    ) -> TransformResult {
+        if node.item_type == "tabular_collection" {
+            return TransformResult::Unchanged;
+        }
+
+        let Some(pair) = TabularDataPair::from_artifacts(&node, data) else {
+            return TransformResult::Unchanged;
+        };
+
+        let left_detection = pair.left.as_ref().map(detect_sections);
+        let right_detection = pair.right.as_ref().map(detect_sections);
+
+        if let Some(reason) = ambiguous_reason(&left_detection, &right_detection) {
+            node.push_diagnostic(Diagnostic::suggestion(
+                "binoc.table_splitter.ambiguous",
+                reason,
+            ));
+            return TransformResult::Replace(Box::new(node));
+        }
+
+        if !should_split(&left_detection, &right_detection) {
+            return TransformResult::Unchanged;
+        }
+
+        let original_path = node.path.clone();
+        match split_node(node, data, left_detection, right_detection) {
+            Ok(Some(node)) => TransformResult::Replace(Box::new(node)),
+            Ok(None) => TransformResult::Remove,
+            Err(err) => {
+                let mut fallback = DiffNode::new("modify", "tabular", original_path);
+                fallback.push_diagnostic(Diagnostic::warning(
+                    "binoc.table_splitter.failed",
+                    format!("Could not split logical tables: {err}"),
+                ));
+                TransformResult::Replace(Box::new(fallback))
+            }
+        }
+    }
+}
+
+fn should_split(left: &Option<Detection>, right: &Option<Detection>) -> bool {
+    left.as_ref()
+        .is_some_and(|d| d.ambiguous_reason.is_none() && d.sections.len() >= 2)
+        || right
+            .as_ref()
+            .is_some_and(|d| d.ambiguous_reason.is_none() && d.sections.len() >= 2)
+}
+
+fn ambiguous_reason(left: &Option<Detection>, right: &Option<Detection>) -> Option<String> {
+    for detection in [left.as_ref(), right.as_ref()].into_iter().flatten() {
+        if let Some(reason) = &detection.ambiguous_reason {
+            return Some(reason.clone());
+        }
+    }
+
+    match (left, right) {
+        (Some(left), Some(right))
+            if (left.sections.len() >= 2) ^ (right.sections.len() >= 2) =>
+        {
+            Some(
+                "One side looks like stacked logical tables, but the other side does not; leaving the CSV as one table."
+                    .into(),
+            )
+        }
+        _ => None,
+    }
+}
+
+fn split_node(
+    mut node: DiffNode,
+    data: &dyn DataAccess,
+    left: Option<Detection>,
+    right: Option<Detection>,
+) -> BinocResult<Option<DiffNode>> {
+    let left_sections = left.map(|d| d.sections).unwrap_or_default();
+    let right_sections = right.map(|d| d.sections).unwrap_or_default();
+
+    let left_by_name = section_map(&left_sections);
+    let right_by_name = section_map(&right_sections);
+    let names = left_by_name
+        .keys()
+        .chain(right_by_name.keys())
+        .cloned()
+        .collect::<BTreeSet<_>>();
+
+    let mut children = Vec::new();
+    for name in names {
+        match (left_by_name.get(&name), right_by_name.get(&name)) {
+            (Some(left_section), Some(right_section)) => {
+                if left_section.data == right_section.data {
+                    continue;
+                }
+                let left_artifact =
+                    publish_tabular(data, &left_section.data, ArtifactSubject::Left)?;
+                let right_artifact =
+                    publish_tabular(data, &right_section.data, ArtifactSubject::Right)?;
+                children.push(
+                    table_node(&node, "modify", left_section, Some(right_section))
+                        .with_artifact(left_artifact)
+                        .with_artifact(right_artifact),
+                );
+            }
+            (Some(left_section), None) => {
+                let artifact = publish_tabular(data, &left_section.data, ArtifactSubject::Left)?;
+                children
+                    .push(table_node(&node, "remove", left_section, None).with_artifact(artifact));
+            }
+            (None, Some(right_section)) => {
+                let artifact = publish_tabular(data, &right_section.data, ArtifactSubject::Right)?;
+                children
+                    .push(table_node(&node, "add", right_section, None).with_artifact(artifact));
+            }
+            (None, None) => {}
+        }
+    }
+
+    if children.is_empty() {
+        return Ok(None);
+    }
+
+    let left_collection = collection_from_sections(&node.path, &left_sections);
+    let right_collection = collection_from_sections(&node.path, &right_sections);
+
+    node.item_type = "tabular_collection".into();
+    node.children = children;
+    node.summary = None;
+    node.tags.insert("binoc.tabular-collection".into());
+    node.details.clear();
+    node.artifacts.clear();
+    if !left_sections.is_empty() {
+        node.details.insert(
+            "tables_left".into(),
+            serde_json::json!(table_names(&left_sections)),
+        );
+        node.artifacts.push(publish_collection(
+            data,
+            &left_collection,
+            ArtifactSubject::Left,
+        )?);
+    }
+    if !right_sections.is_empty() {
+        node.details.insert(
+            "tables_right".into(),
+            serde_json::json!(table_names(&right_sections)),
+        );
+        node.artifacts.push(publish_collection(
+            data,
+            &right_collection,
+            ArtifactSubject::Right,
+        )?);
+    }
+
+    Ok(Some(node))
+}
+
+fn detect_sections(table: &TabularData) -> Detection {
+    let rows = raw_rows(table);
+    let mut sections = Vec::new();
+    let mut wide_unclaimed = Vec::new();
+    let mut i = 0;
+
+    while i < rows.len() {
+        let mut title_rows = Vec::new();
+        while i < rows.len() {
+            let width = normalized_width(&rows[i]);
+            if width == 0 {
+                i += 1;
+            } else if width == 1 {
+                title_rows.push(i);
+                i += 1;
+            } else {
+                break;
+            }
+        }
+        if i >= rows.len() {
+            break;
+        }
+
+        let width = normalized_width(&rows[i]);
+        if width < 2 || !looks_like_header(&rows[i]) {
+            if width > 1 {
+                wide_unclaimed.push(i + 1);
+            }
+            i += 1;
+            continue;
+        }
+
+        let header_row = i;
+        let headers = trim_to_width(&rows[header_row], width);
+        let mut data_rows = Vec::new();
+        let mut j = i + 1;
+        while j < rows.len() {
+            let row_width = normalized_width(&rows[j]);
+            if row_width == 0 || row_width != width {
+                break;
+            }
+            let row = trim_to_width(&rows[j], width);
+            if row != headers {
+                data_rows.push(row);
+            }
+            j += 1;
+        }
+
+        if data_rows.is_empty() {
+            wide_unclaimed.push(header_row + 1);
+            i = header_row + 1;
+            continue;
+        }
+
+        let logical_name = format!("table_{}", sections.len() + 1);
+        let title = title_from_rows(&rows, &title_rows);
+        sections.push(Section {
+            logical_name,
+            title,
+            header_row,
+            end_row: j,
+            data: TabularData {
+                headers,
+                rows: data_rows,
+            },
+        });
+        i = j;
+    }
+
+    let ambiguous_reason = if sections.len() >= 2 && !wide_unclaimed.is_empty() {
+        Some(format!(
+            "The CSV has stacked table-like regions, but row{} {} outside any clear rectangle; leaving it as one table.",
+            if wide_unclaimed.len() == 1 { "" } else { "s" },
+            wide_unclaimed
+                .iter()
+                .map(|row| row.to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ))
+    } else {
+        None
+    };
+
+    Detection {
+        sections,
+        ambiguous_reason,
+    }
+}
+
+fn raw_rows(table: &TabularData) -> Vec<Vec<String>> {
+    std::iter::once(table.headers.clone())
+        .chain(table.rows.clone())
+        .collect()
+}
+
+fn normalized_width(row: &[String]) -> usize {
+    row.iter()
+        .rposition(|cell| !cell.trim().is_empty())
+        .map_or(0, |idx| idx + 1)
+}
+
+fn trim_to_width(row: &[String], width: usize) -> Vec<String> {
+    (0..width)
+        .map(|idx| {
+            row.get(idx)
+                .map(|s| s.trim().to_string())
+                .unwrap_or_default()
+        })
+        .collect()
+}
+
+fn looks_like_header(row: &[String]) -> bool {
+    let width = normalized_width(row);
+    if width < 2 {
+        return false;
+    }
+    let cells = trim_to_width(row, width);
+    let non_empty = cells.iter().filter(|cell| !cell.is_empty()).count();
+    if non_empty < 2 {
+        return false;
+    }
+    let unique = cells
+        .iter()
+        .filter(|cell| !cell.is_empty())
+        .collect::<BTreeSet<_>>();
+    if unique.len() != non_empty {
+        return false;
+    }
+    let numericish = cells.iter().filter(|cell| is_numericish(cell)).count();
+    numericish * 2 < non_empty
+}
+
+fn is_numericish(cell: &str) -> bool {
+    let trimmed = cell.trim();
+    !trimmed.is_empty()
+        && trimmed
+            .chars()
+            .all(|c| c.is_ascii_digit() || matches!(c, '.' | '-' | '+' | ',' | '$' | '%'))
+}
+
+fn title_from_rows(rows: &[Vec<String>], title_rows: &[usize]) -> Option<String> {
+    let parts = title_rows
+        .iter()
+        .filter_map(|idx| rows.get(*idx)?.first())
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>();
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join(" / "))
+    }
+}
+
+fn section_map(sections: &[Section]) -> BTreeMap<String, &Section> {
+    sections
+        .iter()
+        .map(|section| (section.logical_name.clone(), section))
+        .collect()
+}
+
+fn table_names(sections: &[Section]) -> Vec<String> {
+    sections
+        .iter()
+        .map(|section| section.logical_name.clone())
+        .collect()
+}
+
+fn table_node(
+    parent: &DiffNode,
+    action: &str,
+    primary: &Section,
+    secondary: Option<&Section>,
+) -> DiffNode {
+    let table_path = table_node_path(&parent.path, &primary.logical_name);
+    let mut node = DiffNode::new(action, "tabular", table_path)
+        .with_detail("logical_name", serde_json::json!(primary.logical_name))
+        .with_detail("header_row", serde_json::json!(primary.header_row + 1))
+        .with_detail("end_row", serde_json::json!(primary.end_row))
+        .with_detail("columns", serde_json::json!(primary.data.headers));
+    if let Some(title) = primary
+        .title
+        .as_ref()
+        .or_else(|| secondary.and_then(|s| s.title.as_ref()))
+    {
+        node = node.with_detail("title", serde_json::json!(title));
+    }
+    node.comparator.clone_from(&parent.comparator);
+    node.source_items.clone_from(&parent.source_items);
+    node
+}
+
+fn table_node_path(parent_path: &str, logical_name: &str) -> String {
+    format!("{parent_path}#{logical_name}")
+}
+
+fn collection_from_sections(parent_path: &str, sections: &[Section]) -> TabularCollectionData {
+    TabularCollectionData {
+        tables: sections
+            .iter()
+            .map(|section| TableMember {
+                logical_name: section.logical_name.clone(),
+                node_path: table_node_path(parent_path, &section.logical_name),
+                source: TableSourceLocation {
+                    item_path: parent_path.into(),
+                    kind: "csv_region".into(),
+                    locator: BTreeMap::from([
+                        (
+                            "header_row".into(),
+                            serde_json::json!(section.header_row + 1),
+                        ),
+                        ("end_row".into(), serde_json::json!(section.end_row)),
+                    ]),
+                },
+                shape: TableShape {
+                    columns: section.data.headers.clone(),
+                    row_count: Some(section.data.rows.len() as u64),
+                },
+                metadata: section
+                    .title
+                    .as_ref()
+                    .map(|title| BTreeMap::from([("title".into(), serde_json::json!(title))]))
+                    .unwrap_or_default(),
+            })
+            .collect(),
+    }
+}
+
+fn publish_tabular(
+    data: &dyn DataAccess,
+    tabular: &TabularData,
+    subject: ArtifactSubject,
+) -> BinocResult<ArtifactDescriptor> {
+    let bytes = serde_json::to_vec(tabular)
+        .map_err(|e| BinocError::Other(format!("serialize split tabular artifact: {e}")))?;
+    data.publish_artifact(&tabular_v1(), subject, PRODUCER, &bytes)
+}
+
+fn publish_collection(
+    data: &dyn DataAccess,
+    collection: &TabularCollectionData,
+    subject: ArtifactSubject,
+) -> BinocResult<ArtifactDescriptor> {
+    let bytes = serde_json::to_vec(collection)
+        .map_err(|e| BinocError::Other(format!("serialize split collection artifact: {e}")))?;
+    data.publish_artifact(&tabular_collection_v1(), subject, PRODUCER, &bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn table(rows: &[&[&str]]) -> TabularData {
+        let mut iter = rows.iter();
+        let headers = iter.next().unwrap().iter().map(|s| s.to_string()).collect();
+        let rows = iter
+            .map(|row| row.iter().map(|s| s.to_string()).collect())
+            .collect();
+        TabularData { headers, rows }
+    }
+
+    #[test]
+    fn detects_stacked_rectangles_with_titles_and_blank_spacers() {
+        let data = table(&[
+            &["Purple Book"],
+            &["Monthly changes"],
+            &["Appl No", "Product", "Change"],
+            &["1", "Alpha", "Added"],
+            &[""],
+            &["Appl No", "Product", "Applicant", "Approval Date"],
+            &["1", "Alpha", "Acme", "2026-01-01"],
+            &["2", "Beta", "Bravo", "2026-02-01"],
+        ]);
+
+        let detection = detect_sections(&data);
+
+        assert!(detection.ambiguous_reason.is_none());
+        assert_eq!(detection.sections.len(), 2);
+        assert_eq!(detection.sections[0].logical_name, "table_1");
+        assert_eq!(
+            detection.sections[0].data.headers,
+            vec!["Appl No", "Product", "Change"]
+        );
+        assert_eq!(
+            detection.sections[0].title.as_deref(),
+            Some("Purple Book / Monthly changes")
+        );
+        assert_eq!(
+            detection.sections[1].data.headers,
+            vec!["Appl No", "Product", "Applicant", "Approval Date"]
+        );
+    }
+
+    #[test]
+    fn ignores_single_clean_table() {
+        let data = table(&[&["id", "name"], &["1", "Alice"], &["2", "Bob"]]);
+
+        let detection = detect_sections(&data);
+
+        assert_eq!(detection.sections.len(), 1);
+        assert!(detection.ambiguous_reason.is_none());
+    }
+
+    #[test]
+    fn marks_wide_unclaimed_rows_ambiguous() {
+        let data = table(&[
+            &["First title"],
+            &["id", "name"],
+            &["1", "Alice"],
+            &["wide", "note", "outside"],
+            &["Second title"],
+            &["code", "value"],
+            &["A", "10"],
+        ]);
+
+        let detection = detect_sections(&data);
+
+        assert_eq!(detection.sections.len(), 2);
+        assert!(detection.ambiguous_reason.is_some());
+    }
+}

--- a/docs/explanation/test-vectors-gallery.md
+++ b/docs/explanation/test-vectors-gallery.md
@@ -13,7 +13,7 @@ audience: new user, data steward, archivist
 
 These are runnable examples from binoc's test suite. Each example links to its source folder on GitHub, tells you whether it needs any extra setup, gives you the exact command to run, and shows the Markdown changelog binoc is expected to print.
 
-Binoc currently ships **32 shared examples** in this gallery.
+Binoc currently ships **33 shared examples** in this gallery.
 
 ## One-time setup
 
@@ -38,6 +38,7 @@ just materialize
 | [`csv-rename-modify`](#csv-rename-modify) | CSV renamed and a column added: detected as a single move with content diff via fuzzy correlation | data_v2.csv: Moved from data.csv (modified) | Default pipeline |
 | [`csv-row-addition`](#csv-row-addition) | New rows appended | data.csv: 2 rows added | Default pipeline |
 | [`csv-row-removal`](#csv-row-removal) | Rows removed from CSV | data.csv: 2 rows removed | Default pipeline |
+| [`csv-stacked-tables`](#csv-stacked-tables) | Detects two logical tables stacked in one messy CSV | data.csv: Table table_2 changed: 1 row added | Default pipeline |
 | [`csv-verbosity-full`](#csv-verbosity-full) | Markdown full verbosity renders every captured changed-cell example. | data.csv: 5 cells changed | Custom config |
 | [`directory-file-copy`](#directory-file-copy) | New file with same content as an existing unchanged file detected as a copy | duplicate.txt: Copied from original.txt | Default pipeline |
 | [`directory-nested`](#directory-nested) | Subdirectories with mixed changes | data/extra.csv: New table (2 columns, 1 row) | Default pipeline |
@@ -270,6 +271,28 @@ Result:
 # Changelog: snapshot-a → snapshot-b
 
 - **data.csv**: 2 rows removed
+```
+
+## csv-stacked-tables
+
+Detects two logical tables stacked in one messy CSV
+
+- **Browse source:** [csv-stacked-tables](https://github.com/harvard-lil/binoc/tree/main/test-vectors/csv-stacked-tables)
+- **Tags:** `csv`, `stacked-tables`, `tabular-collection`, `row-addition`
+- **Snapshots:** `snapshot-a` has 1 file — `data.csv`; `snapshot-b` has 1 file — `data.csv`
+
+Run it:
+```bash
+binoc diff \
+  ./test-vectors-materialized/csv-stacked-tables/snapshot-a \
+  ./test-vectors-materialized/csv-stacked-tables/snapshot-b
+```
+Result:
+```markdown
+# Changelog: snapshot-a → snapshot-b
+
+- **data.csv**: Table table_2 changed: 1 row added
+- **data.csv#table_2**: 1 row added
 ```
 
 ## csv-verbosity-full

--- a/test-vectors/csv-cell-changes/expected-output/abi-log.snap
+++ b/test-vectors/csv-cell-changes/expected-output/abi-log.snap
@@ -88,6 +88,30 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.table_splitter",
+    "data_ops": [
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      },
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      }
+    ]
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.tabular_analyzer",
     "data_ops": [
       {

--- a/test-vectors/csv-column-addition/expected-output/abi-log.snap
+++ b/test-vectors/csv-column-addition/expected-output/abi-log.snap
@@ -88,6 +88,30 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.table_splitter",
+    "data_ops": [
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      },
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      }
+    ]
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.tabular_analyzer",
     "data_ops": [
       {

--- a/test-vectors/csv-column-removal/expected-output/abi-log.snap
+++ b/test-vectors/csv-column-removal/expected-output/abi-log.snap
@@ -88,6 +88,30 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.table_splitter",
+    "data_ops": [
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      },
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      }
+    ]
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.tabular_analyzer",
     "data_ops": [
       {

--- a/test-vectors/csv-mixed-changes/expected-output/abi-log.snap
+++ b/test-vectors/csv-mixed-changes/expected-output/abi-log.snap
@@ -88,6 +88,30 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.table_splitter",
+    "data_ops": [
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      },
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      }
+    ]
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.tabular_analyzer",
     "data_ops": [
       {

--- a/test-vectors/csv-row-addition/expected-output/abi-log.snap
+++ b/test-vectors/csv-row-addition/expected-output/abi-log.snap
@@ -88,6 +88,30 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.table_splitter",
+    "data_ops": [
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      },
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      }
+    ]
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.tabular_analyzer",
     "data_ops": [
       {

--- a/test-vectors/csv-row-removal/expected-output/abi-log.snap
+++ b/test-vectors/csv-row-removal/expected-output/abi-log.snap
@@ -88,6 +88,30 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.table_splitter",
+    "data_ops": [
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      },
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      }
+    ]
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.tabular_analyzer",
     "data_ops": [
       {

--- a/test-vectors/csv-stacked-tables/expected-output/abi-log.snap
+++ b/test-vectors/csv-stacked-tables/expected-output/abi-log.snap
@@ -17,12 +17,12 @@ expression: "&abi_log"
       },
       {
         "op": "register_local",
-        "logical": "data_v2.csv"
+        "logical": "data.csv"
       },
       {
         "op": "read_bytes",
-        "handle": "data_v2.csv",
-        "result_size": 112
+        "handle": "data.csv",
+        "result_size": 261
       },
       {
         "op": "register_local",
@@ -31,7 +31,7 @@ expression: "&abi_log"
       {
         "op": "read_bytes",
         "handle": "data.csv",
-        "result_size": 63
+        "result_size": 297
       }
     ]
   },
@@ -41,25 +41,8 @@ expression: "&abi_log"
     "data_ops": [
       {
         "op": "local_path",
-        "handle": "data_v2.csv"
+        "handle": "data.csv"
       },
-      {
-        "op": "publish_artifact",
-        "format": {
-          "package": "binoc",
-          "name": "tabular",
-          "version": 1
-        },
-        "subject": "Right",
-        "producer": "binoc.csv",
-        "size": 172
-      }
-    ]
-  },
-  {
-    "method": "compare",
-    "plugin": "binoc.csv",
-    "data_ops": [
       {
         "op": "local_path",
         "handle": "data.csv"
@@ -73,7 +56,18 @@ expression: "&abi_log"
         },
         "subject": "Left",
         "producer": "binoc.csv",
-        "size": 115
+        "size": 342
+      },
+      {
+        "op": "publish_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "subject": "Right",
+        "producer": "binoc.csv",
+        "size": 388
       }
     ]
   },
@@ -85,54 +79,7 @@ expression: "&abi_log"
   {
     "method": "transform",
     "plugin": "binoc.fuzzy_correlation_detector",
-    "data_ops": [
-      {
-        "op": "read_bytes",
-        "handle": "data.csv",
-        "result_size": 63
-      },
-      {
-        "op": "read_bytes",
-        "handle": "data_v2.csv",
-        "result_size": 112
-      }
-    ]
-  },
-  {
-    "method": "compare",
-    "plugin": "binoc.csv",
-    "data_ops": [
-      {
-        "op": "local_path",
-        "handle": "data.csv"
-      },
-      {
-        "op": "local_path",
-        "handle": "data_v2.csv"
-      },
-      {
-        "op": "publish_artifact",
-        "format": {
-          "package": "binoc",
-          "name": "tabular",
-          "version": 1
-        },
-        "subject": "Left",
-        "producer": "binoc.csv",
-        "size": 115
-      },
-      {
-        "op": "publish_artifact",
-        "format": {
-          "package": "binoc",
-          "name": "tabular",
-          "version": 1
-        },
-        "subject": "Right",
-        "producer": "binoc.csv",
-        "size": 172
-      }
-    ]
+    "data_ops": []
   },
   {
     "method": "transform",
@@ -160,6 +107,50 @@ expression: "&abi_log"
           "version": 1
         },
         "found": true
+      },
+      {
+        "op": "publish_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "subject": "Left",
+        "producer": "binoc.table_splitter",
+        "size": 157
+      },
+      {
+        "op": "publish_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "subject": "Right",
+        "producer": "binoc.table_splitter",
+        "size": 203
+      },
+      {
+        "op": "publish_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular_collection",
+          "version": 1
+        },
+        "subject": "Left",
+        "producer": "binoc.table_splitter",
+        "size": 579
+      },
+      {
+        "op": "publish_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular_collection",
+          "version": 1
+        },
+        "subject": "Right",
+        "producer": "binoc.table_splitter",
+        "size": 579
       }
     ]
   },
@@ -181,6 +172,30 @@ expression: "&abi_log"
         "format": {
           "package": "binoc",
           "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      }
+    ]
+  },
+  {
+    "method": "transform",
+    "plugin": "binoc.table_collection_analyzer",
+    "data_ops": [
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular_collection",
+          "version": 1
+        },
+        "found": true
+      },
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular_collection",
           "version": 1
         },
         "found": true

--- a/test-vectors/csv-stacked-tables/expected-output/changelog.snap
+++ b/test-vectors/csv-stacked-tables/expected-output/changelog.snap
@@ -1,0 +1,8 @@
+---
+source: binoc-stdlib/src/test_vectors.rs
+expression: "&md"
+---
+# Changelog: snapshot-a → snapshot-b
+
+- **data.csv**: Table table_2 changed: 1 row added
+- **data.csv#table_2**: 1 row added

--- a/test-vectors/csv-stacked-tables/expected-output/changeset.snap
+++ b/test-vectors/csv-stacked-tables/expected-output/changeset.snap
@@ -1,0 +1,91 @@
+---
+source: binoc-stdlib/src/test_vectors.rs
+expression: "&stable_changeset"
+---
+{
+  "from_snapshot": "snapshot-a",
+  "to_snapshot": "snapshot-b",
+  "root": {
+    "action": "modify",
+    "item_type": "directory",
+    "path": "",
+    "children": [
+      {
+        "action": "modify",
+        "item_type": "tabular_collection",
+        "path": "data.csv",
+        "summary": "Table table_2 changed: 1 row added",
+        "tags": [
+          "binoc.table-change",
+          "binoc.tabular-collection",
+          "binoc.tabular-collection-change"
+        ],
+        "children": [
+          {
+            "action": "modify",
+            "item_type": "tabular",
+            "path": "data.csv#table_2",
+            "summary": "1 row added",
+            "tags": [
+              "binoc.row-addition",
+              "binoc.table-change"
+            ],
+            "details": {
+              "cells_changed": 0,
+              "columns": [
+                "Appl No",
+                "Product",
+                "Applicant",
+                "Approval Date"
+              ],
+              "columns_added": [],
+              "columns_left": [
+                "Appl No",
+                "Product",
+                "Applicant",
+                "Approval Date"
+              ],
+              "columns_removed": [],
+              "columns_right": [
+                "Appl No",
+                "Product",
+                "Applicant",
+                "Approval Date"
+              ],
+              "end_row": 8,
+              "header_row": 6,
+              "logical_name": "table_2",
+              "rows_added": 1,
+              "rows_left": 2,
+              "rows_removed": 0,
+              "rows_right": 3
+            },
+            "comparator": "binoc.csv",
+            "transformed_by": [
+              "binoc.tabular_analyzer"
+            ]
+          }
+        ],
+        "details": {
+          "tables_changed": [
+            "table_2"
+          ],
+          "tables_left": [
+            "table_1",
+            "table_2"
+          ],
+          "tables_right": [
+            "table_1",
+            "table_2"
+          ]
+        },
+        "comparator": "binoc.csv",
+        "transformed_by": [
+          "binoc.table_splitter",
+          "binoc.table_collection_analyzer"
+        ]
+      }
+    ],
+    "comparator": "binoc.directory"
+  }
+}

--- a/test-vectors/csv-stacked-tables/manifest.toml
+++ b/test-vectors/csv-stacked-tables/manifest.toml
@@ -1,0 +1,8 @@
+[vector]
+name = "csv-stacked-tables"
+description = "Detects two logical tables stacked in one messy CSV"
+tags = ["csv", "stacked-tables", "tabular-collection", "row-addition"]
+
+[expected]
+root_action = "modify"
+has_tags = ["binoc.tabular-collection-change", "binoc.table-change", "binoc.row-addition"]

--- a/test-vectors/csv-stacked-tables/snapshot-a/data.csv
+++ b/test-vectors/csv-stacked-tables/snapshot-a/data.csv
@@ -1,0 +1,9 @@
+Purple Book monthly report
+Approved drug products with therapeutic equivalence evaluations
+Appl No,Product,Change
+761001,Alpha,Added
+761002,Beta,Removed
+
+Appl No,Product,Applicant,Approval Date
+761001,Alpha,Acme Labs,2026-01-15
+761002,Beta,Bravo Bio,2026-02-20

--- a/test-vectors/csv-stacked-tables/snapshot-b/data.csv
+++ b/test-vectors/csv-stacked-tables/snapshot-b/data.csv
@@ -1,0 +1,10 @@
+Purple Book monthly report
+Approved drug products with therapeutic equivalence evaluations
+Appl No,Product,Change
+761001,Alpha,Added
+761002,Beta,Removed
+
+Appl No,Product,Applicant,Approval Date
+761001,Alpha,Acme Labs,2026-01-15
+761002,Beta,Bravo Bio,2026-02-20
+761003,Gamma,Core Pharma,2026-03-05

--- a/test-vectors/csv-verbosity-full/expected-output/abi-log.snap
+++ b/test-vectors/csv-verbosity-full/expected-output/abi-log.snap
@@ -88,6 +88,30 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.table_splitter",
+    "data_ops": [
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      },
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      }
+    ]
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.tabular_analyzer",
     "data_ops": [
       {

--- a/test-vectors/directory-nested-with-tar/expected-output/abi-log.snap
+++ b/test-vectors/directory-nested-with-tar/expected-output/abi-log.snap
@@ -224,6 +224,54 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.table_splitter",
+    "data_ops": [
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      },
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      }
+    ]
+  },
+  {
+    "method": "transform",
+    "plugin": "binoc.table_splitter",
+    "data_ops": [
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      },
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      }
+    ]
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.tabular_analyzer",
     "data_ops": [
       {

--- a/test-vectors/directory-nested/expected-output/abi-log.snap
+++ b/test-vectors/directory-nested/expected-output/abi-log.snap
@@ -196,6 +196,45 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.table_splitter",
+    "data_ops": [
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      }
+    ]
+  },
+  {
+    "method": "transform",
+    "plugin": "binoc.table_splitter",
+    "data_ops": [
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      },
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      }
+    ]
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.tabular_analyzer",
     "data_ops": [
       {

--- a/test-vectors/folder-move-partial/expected-output/abi-log.snap
+++ b/test-vectors/folder-move-partial/expected-output/abi-log.snap
@@ -624,6 +624,21 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.table_splitter",
+    "data_ops": [
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      }
+    ]
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.tabular_analyzer",
     "data_ops": [
       {

--- a/test-vectors/gzip-inner-dispatch/expected-output/abi-log.snap
+++ b/test-vectors/gzip-inner-dispatch/expected-output/abi-log.snap
@@ -202,30 +202,6 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
-    "plugin": "binoc.table_splitter",
-    "data_ops": [
-      {
-        "op": "get_artifact",
-        "format": {
-          "package": "binoc",
-          "name": "tabular",
-          "version": 1
-        },
-        "found": true
-      },
-      {
-        "op": "get_artifact",
-        "format": {
-          "package": "binoc",
-          "name": "tabular",
-          "version": 1
-        },
-        "found": true
-      }
-    ]
-  },
-  {
-    "method": "transform",
     "plugin": "binoc.tabular_analyzer",
     "data_ops": [
       {

--- a/test-vectors/gzip-inner-dispatch/expected-output/abi-log.snap
+++ b/test-vectors/gzip-inner-dispatch/expected-output/abi-log.snap
@@ -178,6 +178,54 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.table_splitter",
+    "data_ops": [
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      },
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      }
+    ]
+  },
+  {
+    "method": "transform",
+    "plugin": "binoc.table_splitter",
+    "data_ops": [
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      },
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      }
+    ]
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.tabular_analyzer",
     "data_ops": [
       {

--- a/test-vectors/kitchen-sink/expected-output/abi-log.snap
+++ b/test-vectors/kitchen-sink/expected-output/abi-log.snap
@@ -558,6 +558,78 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.table_splitter",
+    "data_ops": [
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      },
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      }
+    ]
+  },
+  {
+    "method": "transform",
+    "plugin": "binoc.table_splitter",
+    "data_ops": [
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      },
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      }
+    ]
+  },
+  {
+    "method": "transform",
+    "plugin": "binoc.table_splitter",
+    "data_ops": [
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      },
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      }
+    ]
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.tabular_analyzer",
     "data_ops": [
       {

--- a/test-vectors/single-file-modify-csv/expected-output/abi-log.snap
+++ b/test-vectors/single-file-modify-csv/expected-output/abi-log.snap
@@ -56,6 +56,30 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.table_splitter",
+    "data_ops": [
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      },
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      }
+    ]
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.tabular_analyzer",
     "data_ops": [
       {

--- a/test-vectors/tar-nested/expected-output/abi-log.snap
+++ b/test-vectors/tar-nested/expected-output/abi-log.snap
@@ -208,6 +208,30 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.table_splitter",
+    "data_ops": [
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      },
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      }
+    ]
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.tabular_analyzer",
     "data_ops": [
       {

--- a/test-vectors/tar-simple/expected-output/abi-log.snap
+++ b/test-vectors/tar-simple/expected-output/abi-log.snap
@@ -182,6 +182,30 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.table_splitter",
+    "data_ops": [
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      },
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      }
+    ]
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.tabular_analyzer",
     "data_ops": [
       {

--- a/test-vectors/tsv-cell-changes/expected-output/abi-log.snap
+++ b/test-vectors/tsv-cell-changes/expected-output/abi-log.snap
@@ -88,6 +88,30 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.table_splitter",
+    "data_ops": [
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      },
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      }
+    ]
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.tabular_analyzer",
     "data_ops": [
       {

--- a/test-vectors/zip-nested/expected-output/abi-log.snap
+++ b/test-vectors/zip-nested/expected-output/abi-log.snap
@@ -208,6 +208,30 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.table_splitter",
+    "data_ops": [
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      },
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      }
+    ]
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.tabular_analyzer",
     "data_ops": [
       {


### PR DESCRIPTION
## Summary
- add a stdlib `binoc.table_splitter` transformer that detects stacked rectangular CSV/TSV regions and rewrites them as a `tabular_collection`
- publish per-logical-table tabular artifacts plus collection metadata so existing tabular analyzers report changes at table scope
- add the `csv-stacked-tables` vector, refresh ABI snapshots, and regenerate the vector gallery