### PR TITLE
Add keyed tabular diffs and declared file correspondence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,6 +238,7 @@ dependencies = [
  "insta",
  "mime_guess",
  "rayon",
+ "regex",
  "serde",
  "serde_json",
  "similar 3.1.1",

--- a/binoc-core/src/config.rs
+++ b/binoc-core/src/config.rs
@@ -105,6 +105,7 @@ impl DatasetConfig {
                 "binoc.binary".into(),
             ],
             transformers: vec![
+                "binoc.declared_correspondence".into(),
                 "binoc.correlation_detector".into(),
                 "binoc.fuzzy_correlation_detector".into(),
                 "binoc.folder_move_detector".into(),

--- a/binoc-core/src/controller.rs
+++ b/binoc-core/src/controller.rs
@@ -1235,15 +1235,10 @@ mod tests {
         let controller = Controller::new(vec![leaf_comparator()], vec![reader])
             .with_transformer_configs(configs)
             .with_dataset_config(serde_json::json!({
-                "tables": {
-                    "entries": {
-                        "people": {
-                            "row_identity": {
-                                "columns": ["id"]
-                            }
-                        }
-                    }
-                }
+                "tables": [{
+                    "logical_name": "people",
+                    "columns": ["id"]
+                }]
             }));
         let dir = tempfile::tempdir().unwrap();
         controller
@@ -1258,15 +1253,10 @@ mod tests {
             serde_json::json!({
                 "threshold": 0.42,
                 "dataset": {
-                    "tables": {
-                        "entries": {
-                            "people": {
-                                "row_identity": {
-                                    "columns": ["id"]
-                                }
-                            }
-                        }
-                    }
+                    "tables": [{
+                        "logical_name": "people",
+                        "columns": ["id"]
+                    }]
                 }
             })
         );

--- a/binoc-core/src/controller.rs
+++ b/binoc-core/src/controller.rs
@@ -199,23 +199,29 @@ impl Controller {
             Path::new(snapshot_a),
             Path::new(snapshot_b),
         )?);
-        let mut current_pair = Self::make_root_pair(snapshot_a, snapshot_b, &data)?;
-
-        for ancestor in &ancestor_chain {
-            if ancestor.path == node_path {
-                break;
+        let current_pair = if let Some(pair) =
+            Self::explicit_replay_pair(target, snapshot_a, snapshot_b, &data)?
+        {
+            pair
+        } else {
+            let mut pair = Self::make_root_pair(snapshot_a, snapshot_b, &data)?;
+            for ancestor in &ancestor_chain {
+                if ancestor.path == node_path {
+                    break;
+                }
+                let comp_name = ancestor.comparator.as_deref().ok_or_else(|| {
+                    BinocError::Extract(format!(
+                        "ancestor '{}' has no comparator recorded",
+                        ancestor.path
+                    ))
+                })?;
+                let comparator = self.find_comparator_by_name(comp_name).ok_or_else(|| {
+                    BinocError::Extract(format!("comparator '{comp_name}' not found in registry"))
+                })?;
+                pair = comparator.reopen(&pair, node_path, data.as_ref())?;
             }
-            let comp_name = ancestor.comparator.as_deref().ok_or_else(|| {
-                BinocError::Extract(format!(
-                    "ancestor '{}' has no comparator recorded",
-                    ancestor.path
-                ))
-            })?;
-            let comparator = self.find_comparator_by_name(comp_name).ok_or_else(|| {
-                BinocError::Extract(format!("comparator '{comp_name}' not found in registry"))
-            })?;
-            current_pair = comparator.reopen(&current_pair, node_path, data.as_ref())?;
-        }
+            pair
+        };
 
         let comp_name = target.comparator.as_deref().ok_or_else(|| {
             BinocError::Extract(format!("node '{}' has no comparator recorded", target.path))
@@ -576,44 +582,99 @@ impl Controller {
     /// escapes a session.
     fn inflate_pending_recompares(&self, node: &mut DiffNode, data: &Arc<LocalDataAccess>) {
         if let Some(pair) = node.pending_recompare.take() {
-            if let Ok(result) = self.process_pair(pair, data) {
-                if result.action != "identical" {
-                    node.item_type.clone_from(&result.item_type);
-                    if result.comparator.is_some() {
-                        node.comparator.clone_from(&result.comparator);
-                    }
-                    if result.source_items.is_some() {
-                        node.source_items = result.source_items;
-                    }
-                    node.artifacts.extend(result.artifacts);
-                    // Union content-derived tags (e.g. binoc.content-changed,
-                    // binoc.lines-added) into the host so the move node
-                    // reflects both the rename and the content change.
-                    node.tags.extend(result.tags);
-                    for (k, v) in result.details {
-                        node.details.entry(k).or_insert(v);
-                    }
-                    if let Some(summary) = &result.summary {
-                        if !summary.is_empty() {
-                            node.annotations
-                                .entry("content_summary".into())
-                                .or_insert_with(|| serde_json::json!(summary));
-                        }
-                    }
-                    // Splice point: a future non-Root transformer that
-                    // wants to recurse through the inflated subtree in a
-                    // single pass would re-apply itself here. Today's only
-                    // caller is Root-shaped (FuzzyCorrelationDetector), so
-                    // recursing would be a no-op — and subsequent
-                    // transformers in the outer pipeline loop already pick
-                    // up the inflated subtree on later iterations.
-                    node.children = result.children;
+            let replay_pair = pair.clone();
+            match self.process_pair(pair, data) {
+                Ok(result) => Self::merge_recompare_result(node, replay_pair, result),
+                Err(err) => {
+                    node.push_diagnostic(
+                        Diagnostic::warning(
+                            "binoc.recompare-failed",
+                            format!("Could not recompare '{}': {err}", node.path),
+                        )
+                        .with_location(node.path.clone()),
+                    );
                 }
             }
         }
         for child in &mut node.children {
             self.inflate_pending_recompares(child, data);
         }
+    }
+
+    fn merge_recompare_result(node: &mut DiffNode, pair: ItemPair, result: DiffNode) {
+        if result.action == "identical" {
+            node.source_items = Some(pair);
+            for (k, v) in result.details {
+                node.details.entry(k).or_insert(v);
+            }
+            if node.action == "modify"
+                && node.source_path.is_none()
+                && !node.tags.contains("binoc.path-change")
+            {
+                node.action = "identical".into();
+            } else {
+                node.details
+                    .entry("content_identical".into())
+                    .or_insert_with(|| serde_json::json!(true));
+            }
+            return;
+        }
+
+        node.item_type.clone_from(&result.item_type);
+        if result.comparator.is_some() {
+            node.comparator.clone_from(&result.comparator);
+        }
+        if result.source_items.is_some() {
+            node.source_items = result.source_items;
+        } else {
+            node.source_items = Some(pair);
+        }
+        node.artifacts.extend(result.artifacts);
+        // Union content-derived tags (e.g. binoc.content-changed,
+        // binoc.lines-added) into the host so the correspondence node
+        // reflects both identity and content changes.
+        node.tags.extend(result.tags);
+        for (k, v) in result.details {
+            node.details.entry(k).or_insert(v);
+        }
+        if let Some(summary) = &result.summary {
+            if !summary.is_empty() {
+                if node.summary.is_none() {
+                    node.summary = Some(summary.clone());
+                }
+                node.annotations
+                    .entry("content_summary".into())
+                    .or_insert_with(|| serde_json::json!(summary));
+            }
+        }
+        // Splice point: future non-Root transformers that need same-pass
+        // recursion through inflated children can re-apply themselves here.
+        // Subsequent transformers in the outer pipeline already see these
+        // children on later iterations.
+        node.children = result.children;
+    }
+
+    fn explicit_replay_pair(
+        target: &DiffNode,
+        snapshot_a: &str,
+        snapshot_b: &str,
+        data: &Arc<LocalDataAccess>,
+    ) -> BinocResult<Option<ItemPair>> {
+        let left_path = target
+            .source_path
+            .as_deref()
+            .or_else(|| detail_str(target, "source_path"));
+        let right_path = detail_str(target, "destination_path");
+        if left_path.is_none() && right_path.is_none() {
+            return Ok(None);
+        }
+
+        let logical = target.path.as_str();
+        let left_rel = left_path.unwrap_or(logical);
+        let right_rel = right_path.unwrap_or(logical);
+        let left = data.register_local(&Path::new(snapshot_a).join(left_rel), logical)?;
+        let right = data.register_local(&Path::new(snapshot_b).join(right_rel), logical)?;
+        Ok(Some(ItemPair::both(left, right)))
     }
 
     /// All fields are AND (every non-empty field must pass).
@@ -655,6 +716,10 @@ impl Controller {
             || !desc.match_actions.is_empty()
             || !desc.match_artifacts.is_empty()
     }
+}
+
+fn detail_str<'a>(node: &'a DiffNode, key: &str) -> Option<&'a str> {
+    node.details.get(key)?.as_str()
 }
 
 #[cfg(test)]

--- a/binoc-python/src/lib.rs
+++ b/binoc-python/src/lib.rs
@@ -791,7 +791,7 @@ impl PyDiffNodeIter {
 /// A ``Changeset`` records the two snapshot names it was computed from, the
 /// root of the diff tree (``None`` if the snapshots are identical), and a
 /// free-form ``metadata`` dict for plugin use. Structured ``diagnostics``
-/// carry warnings or suggestions without failing the diff. Serialize with
+/// carry plugin and renderer findings. Serialize with
 /// :meth:`to_json` / :meth:`to_dict`, or via the module-level :func:`to_json`
 /// and :func:`to_markdown`.
 #[pyclass(name = "Changeset", module = "binoc._binoc", from_py_object)]
@@ -844,7 +844,7 @@ impl PyChangeset {
         }
         Ok(dict)
     }
-    /// Structured warnings/suggestions attached to this changeset.
+    /// Structured diagnostics attached to this changeset.
     #[getter]
     fn diagnostics<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let value = serde_json::to_value(&self.inner.diagnostics)

--- a/binoc-sdk/src/ir.rs
+++ b/binoc-sdk/src/ir.rs
@@ -7,6 +7,7 @@ use crate::types::{ArtifactDescriptor, ItemPair};
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum DiagnosticSeverity {
+    Error,
     Warning,
     Suggestion,
 }
@@ -37,6 +38,10 @@ impl Diagnostic {
 
     pub fn warning(code: impl Into<String>, message: impl Into<String>) -> Self {
         Self::new(DiagnosticSeverity::Warning, code, message)
+    }
+
+    pub fn error(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self::new(DiagnosticSeverity::Error, code, message)
     }
 
     pub fn suggestion(code: impl Into<String>, message: impl Into<String>) -> Self {
@@ -139,14 +144,17 @@ pub struct DiffNode {
     pub artifacts: Vec<ArtifactDescriptor>,
 
     /// Request that the controller re-dispatch the given `ItemPair` through
-    /// the comparator pipeline and merge the result into this node before
-    /// the next transformer runs. Set by transformers (e.g. fuzzy
-    /// correlation) that have decided two leaves represent the same logical
-    /// item but need a content diff under the new (move) node. Session-
-    /// scoped working data: wire-visible so plugins can set it across the
-    /// ABI boundary, but cleared by [`DiffNode::strip_transient`] before
-    /// changeset output. The controller takes (clears) this field as it
-    /// processes it; nodes in a finalized changeset never carry it.
+    /// the comparator pipeline and merge the result into this semantic wrapper
+    /// node before the next transformer runs. Set by transformers that have
+    /// discovered a correspondence (for example, a rename-with-edits or a
+    /// config-declared logical file pair) but still need normal comparators to
+    /// parse the paired content. If the recomparison is identical, a plain
+    /// `modify` wrapper is converted to `identical` so it can be pruned, while
+    /// semantic wrappers such as moves remain reportable. Session-scoped
+    /// working data: wire-visible so plugins can set it across the ABI
+    /// boundary, but cleared by [`DiffNode::strip_transient`] before changeset
+    /// output. The controller takes (clears) this field as it processes it;
+    /// nodes in a finalized changeset never carry it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pending_recompare: Option<ItemPair>,
 }

--- a/binoc-sdk/src/types.rs
+++ b/binoc-sdk/src/types.rs
@@ -251,6 +251,8 @@ pub struct FileCorrespondenceRule {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct FileSelector {
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub path_regex: Option<String>,
 }
 

--- a/binoc-sdk/src/types.rs
+++ b/binoc-sdk/src/types.rs
@@ -272,12 +272,39 @@ pub enum IdentityFailurePolicy {
     Ignore,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize)]
 pub struct TableConfig {
     #[serde(default)]
     pub defaults: TableDefaults,
     #[serde(default)]
-    pub entries: BTreeMap<String, TableEntry>,
+    pub entries: Vec<TableEntry>,
+}
+
+impl<'de> Deserialize<'de> for TableConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Repr {
+            Entries(Vec<TableEntry>),
+            Full {
+                #[serde(default)]
+                defaults: TableDefaults,
+                #[serde(default)]
+                entries: Vec<TableEntry>,
+            },
+        }
+
+        match Repr::deserialize(deserializer)? {
+            Repr::Entries(entries) => Ok(Self {
+                defaults: TableDefaults::default(),
+                entries,
+            }),
+            Repr::Full { defaults, entries } => Ok(Self { defaults, entries }),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -288,7 +315,7 @@ pub struct TableDefaults {
     pub row_identity: RowIdentity,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize)]
 pub struct TableEntry {
     #[serde(default, rename = "match")]
     pub match_: TableSelector,
@@ -296,6 +323,64 @@ pub struct TableEntry {
     pub parse: TabularParseConfig,
     #[serde(default)]
     pub row_identity: RowIdentity,
+}
+
+impl<'de> Deserialize<'de> for TableEntry {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Default, Deserialize)]
+        struct RawTableEntry {
+            #[serde(default, rename = "match")]
+            match_: TableSelector,
+            #[serde(default)]
+            parse: TabularParseConfig,
+            #[serde(default)]
+            row_identity: RowIdentity,
+            #[serde(default)]
+            logical_name: Option<String>,
+            #[serde(default)]
+            path: Option<String>,
+            #[serde(default)]
+            path_regex: Option<String>,
+            #[serde(default)]
+            columns: Vec<String>,
+            #[serde(default)]
+            on_null_key: Option<IdentityFailurePolicy>,
+            #[serde(default)]
+            on_duplicate_key: Option<IdentityFailurePolicy>,
+        }
+
+        let raw = RawTableEntry::deserialize(deserializer)?;
+        let mut match_ = raw.match_;
+        if match_.logical_name.is_none() {
+            match_.logical_name = raw.logical_name;
+        }
+        if match_.source.is_none() && (raw.path.is_some() || raw.path_regex.is_some()) {
+            match_.source = Some(FileSelector {
+                path: raw.path,
+                path_regex: raw.path_regex,
+            });
+        }
+
+        let mut row_identity = raw.row_identity;
+        if row_identity.columns.is_empty() {
+            row_identity.columns = raw.columns;
+        }
+        if let Some(policy) = raw.on_null_key {
+            row_identity.on_null_key = policy;
+        }
+        if let Some(policy) = raw.on_duplicate_key {
+            row_identity.on_duplicate_key = policy;
+        }
+
+        Ok(Self {
+            match_,
+            parse: raw.parse,
+            row_identity,
+        })
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/binoc-stdlib/Cargo.toml
+++ b/binoc-stdlib/Cargo.toml
@@ -27,6 +27,7 @@ blake3 = "1.8.5"
 csv = "1.4.0"
 infer = "0.19"
 mime_guess = "2.0.5"
+regex = "1.12.2"
 serde = { workspace = true }
 serde_json = { workspace = true }
 similar = "3.1.1"

--- a/binoc-stdlib/src/lib.rs
+++ b/binoc-stdlib/src/lib.rs
@@ -19,6 +19,9 @@ pub fn register_stdlib(registry: &mut PluginRegistry) {
     r(registry.register_comparator(Arc::new(comparators::binary::BinaryComparator)));
 
     r(registry.register_transformer(Arc::new(
+        transformers::declared_correspondence::DeclaredCorrespondence,
+    )));
+    r(registry.register_transformer(Arc::new(
         transformers::correlation_detector::CorrelationDetector,
     )));
     r(registry.register_transformer(Arc::new(

--- a/binoc-stdlib/src/renderers/markdown.rs
+++ b/binoc-stdlib/src/renderers/markdown.rs
@@ -128,6 +128,7 @@ pub fn render_markdown(changesets: &[Changeset], config: &MarkdownRendererConfig
         }
 
         let diagnostics = display_diagnostics(&changeset.diagnostics, config.max_diagnostics);
+        format_diagnostics_section(&mut out, "Errors", DiagnosticSeverity::Error, &diagnostics);
         format_diagnostics_section(
             &mut out,
             "Warnings",
@@ -474,6 +475,29 @@ fn format_detail_example(
 }
 
 fn format_tabular_cell_example(example: &DetailExample, config: &MarkdownRendererConfig) -> String {
+    let key = example.locator.get("key").and_then(|value| {
+        let map = value.as_object()?;
+        if map.is_empty() {
+            return None;
+        }
+        let parts: Vec<String> = map
+            .iter()
+            .filter_map(|(column, value)| {
+                value.as_str().map(|text| {
+                    format!(
+                        "{} '{}'",
+                        truncate_text(column, config.max_value_chars).0,
+                        truncate_text(text, config.max_value_chars).0
+                    )
+                })
+            })
+            .collect();
+        if parts.is_empty() {
+            None
+        } else {
+            Some(format!("key {}", parts.join(", ")))
+        }
+    });
     let row = example
         .locator
         .get("row")
@@ -490,11 +514,13 @@ fn format_tabular_cell_example(example: &DetailExample, config: &MarkdownRendere
                 truncate_text(column, config.max_value_chars).0
             )
         });
-    let locator = match (row, column) {
-        (Some(row), Some(column)) => format!("{row}, {column}"),
-        (Some(row), None) => row,
-        (None, Some(column)) => column,
-        (None, None) => "cell".into(),
+    let locator = match (key, row, column) {
+        (Some(key), _, Some(column)) => format!("{key}, {column}"),
+        (Some(key), _, None) => key,
+        (None, Some(row), Some(column)) => format!("{row}, {column}"),
+        (None, Some(row), None) => row,
+        (None, None, Some(column)) => column,
+        (None, None, None) => "cell".into(),
     };
     let before = example
         .before

--- a/binoc-stdlib/src/test_vectors.rs
+++ b/binoc-stdlib/src/test_vectors.rs
@@ -327,6 +327,7 @@ pub fn abi_wrapped_default_registry() -> (
     wrap_comparator!(text::TextComparator);
     wrap_comparator!(binary::BinaryComparator);
 
+    wrap_transformer!(declared_correspondence::DeclaredCorrespondence);
     wrap_transformer!(correlation_detector::CorrelationDetector);
     wrap_transformer!(fuzzy_correlation_detector::FuzzyCorrelationDetector);
     wrap_transformer!(folder_move_detector::FolderMoveDetector);

--- a/binoc-stdlib/src/transformers/correlation.rs
+++ b/binoc-stdlib/src/transformers/correlation.rs
@@ -195,32 +195,44 @@ impl RewritePlan {
 /// - Children are sorted by path after modification.
 pub(crate) fn apply_rewrite(node: DiffNode, plan: &RewritePlan) -> DiffNode {
     let mut inserts = plan.inserts.clone();
-    apply_rewrite_inner(node, &plan.remove_paths, &mut inserts)
+    apply_rewrite_inner(node, &plan.remove_paths, &mut inserts, true)
+        .expect("rewrite must keep the root node")
 }
 
 fn apply_rewrite_inner(
     mut node: DiffNode,
     remove_paths: &BTreeSet<String>,
     inserts: &mut BTreeMap<String, Vec<DiffNode>>,
-) -> DiffNode {
+    is_root: bool,
+) -> Option<DiffNode> {
     if node.children.is_empty() {
-        return node;
+        return Some(node);
     }
 
+    let had_children = !node.children.is_empty();
     let mut new_children: Vec<DiffNode> = node
         .children
         .into_iter()
         .filter(|child| !remove_paths.contains(&child.path))
-        .map(|child| apply_rewrite_inner(child, remove_paths, inserts))
+        .filter_map(|child| apply_rewrite_inner(child, remove_paths, inserts, false))
         .collect();
 
     if let Some(added) = inserts.remove(&node.path) {
         new_children.extend(added);
     }
 
+    if !is_root
+        && had_children
+        && new_children.is_empty()
+        && node.details.is_empty()
+        && node.tags.is_empty()
+    {
+        return None;
+    }
+
     new_children.sort_by(|a, b| a.path.cmp(&b.path));
     node.children = new_children;
-    node
+    Some(node)
 }
 
 /// Group a flat list of leaf entries by content hash.

--- a/binoc-stdlib/src/transformers/declared_correspondence.rs
+++ b/binoc-stdlib/src/transformers/declared_correspondence.rs
@@ -1,0 +1,505 @@
+//! Config-declared file correspondence.
+//!
+//! This root-scope pass runs before heuristic correlation. It pairs residual
+//! add/remove file leaves by user-declared identity rules and asks the
+//! controller to re-dispatch each pair through the normal comparator pipeline.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use binoc_sdk::*;
+use regex::Regex;
+
+use super::correlation::{apply_rewrite, parent_path_of, RewritePlan};
+
+pub struct DeclaredCorrespondence;
+
+impl Transformer for DeclaredCorrespondence {
+    fn descriptor(&self) -> TransformerDescriptor {
+        TransformerDescriptor::new("binoc.declared_correspondence")
+            .with_node_shape(NodeShapeFilter::Root)
+    }
+
+    fn transform(
+        &self,
+        mut node: DiffNode,
+        _data: &dyn DataAccess,
+        config: &serde_json::Value,
+    ) -> TransformResult {
+        let dataset = dataset_config(config);
+        let semantics: DatasetSemanticsV1 =
+            serde_json::from_value(dataset.clone()).unwrap_or_default();
+        if semantics.files.correspondences.is_empty() {
+            return TransformResult::Unchanged;
+        }
+
+        let mut adds = Vec::new();
+        let mut removes = Vec::new();
+        collect_file_leaves(&node, &mut adds, &mut removes);
+        if adds.is_empty() || removes.is_empty() {
+            return TransformResult::Unchanged;
+        }
+
+        let container_paths = collect_container_paths(&node);
+        let mut used_adds = BTreeSet::new();
+        let mut used_removes = BTreeSet::new();
+        let mut plan = RewritePlan::default();
+
+        for rule in &semantics.files.correspondences {
+            let mut ctx = RuleContext {
+                adds: &adds,
+                removes: &removes,
+                container_paths: &container_paths,
+                used_adds: &mut used_adds,
+                used_removes: &mut used_removes,
+                plan: &mut plan,
+                diagnostics_node: &mut node,
+            };
+            apply_rule(rule, &mut ctx);
+        }
+
+        if plan.is_empty() {
+            if node.diagnostics.is_empty() {
+                TransformResult::Unchanged
+            } else {
+                TransformResult::Replace(Box::new(node))
+            }
+        } else {
+            TransformResult::Replace(Box::new(apply_rewrite(node, &plan)))
+        }
+    }
+}
+
+fn dataset_config(config: &serde_json::Value) -> &serde_json::Value {
+    config.get("dataset").unwrap_or(config)
+}
+
+#[derive(Debug, Clone)]
+struct FileLeaf {
+    path: String,
+    item_type: String,
+    item: ItemRef,
+}
+
+fn collect_file_leaves(node: &DiffNode, adds: &mut Vec<FileLeaf>, removes: &mut Vec<FileLeaf>) {
+    if node.children.is_empty() {
+        if let Some(leaf) = as_file_leaf(node) {
+            match node.action.as_str() {
+                "add" => adds.push(leaf),
+                "remove" => removes.push(leaf),
+                _ => {}
+            }
+        }
+        return;
+    }
+    for child in &node.children {
+        collect_file_leaves(child, adds, removes);
+    }
+}
+
+fn as_file_leaf(node: &DiffNode) -> Option<FileLeaf> {
+    let pair = node.source_items.as_ref()?;
+    let item = match node.action.as_str() {
+        "add" => pair.right.clone()?,
+        "remove" => pair.left.clone()?,
+        _ => return None,
+    };
+    if item.is_dir {
+        return None;
+    }
+    Some(FileLeaf {
+        path: node.path.clone(),
+        item_type: node.item_type.clone(),
+        item,
+    })
+}
+
+fn collect_container_paths(root: &DiffNode) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    collect_container_paths_inner(root, &mut out);
+    out
+}
+
+fn collect_container_paths_inner(node: &DiffNode, out: &mut BTreeSet<String>) {
+    if !node.children.is_empty() {
+        out.insert(node.path.clone());
+    }
+    for child in &node.children {
+        collect_container_paths_inner(child, out);
+    }
+}
+
+struct RuleContext<'a> {
+    adds: &'a [FileLeaf],
+    removes: &'a [FileLeaf],
+    container_paths: &'a BTreeSet<String>,
+    used_adds: &'a mut BTreeSet<usize>,
+    used_removes: &'a mut BTreeSet<usize>,
+    plan: &'a mut RewritePlan,
+    diagnostics_node: &'a mut DiffNode,
+}
+
+fn apply_rule(rule: &FileCorrespondenceRule, ctx: &mut RuleContext<'_>) {
+    if rule.cardinality != Cardinality::OneToOne {
+        push_identity_diagnostic(
+            ctx.diagnostics_node,
+            IdentityFailurePolicy::Diagnostic,
+            "binoc.declared_correspondence.unsupported_cardinality",
+            format!(
+                "File correspondence rule '{}' requested unsupported cardinality",
+                rule.name
+            ),
+            None,
+        );
+        return;
+    }
+
+    let Ok(left_selector) = compile_selector(&rule.left) else {
+        push_identity_diagnostic(
+            ctx.diagnostics_node,
+            IdentityFailurePolicy::Diagnostic,
+            "binoc.declared_correspondence.invalid_left_regex",
+            format!(
+                "File correspondence rule '{}' has an invalid left path_regex",
+                rule.name
+            ),
+            None,
+        );
+        return;
+    };
+    let Ok(right_selector) = compile_selector(&rule.right) else {
+        push_identity_diagnostic(
+            ctx.diagnostics_node,
+            IdentityFailurePolicy::Diagnostic,
+            "binoc.declared_correspondence.invalid_right_regex",
+            format!(
+                "File correspondence rule '{}' has an invalid right path_regex",
+                rule.name
+            ),
+            None,
+        );
+        return;
+    };
+
+    let left = build_index(
+        rule,
+        Side::Left,
+        ctx.removes,
+        ctx.used_removes,
+        &left_selector,
+        ctx.diagnostics_node,
+    );
+    let right = build_index(
+        rule,
+        Side::Right,
+        ctx.adds,
+        ctx.used_adds,
+        &right_selector,
+        ctx.diagnostics_node,
+    );
+
+    for key in left.keys().filter(|key| right.contains_key(*key)) {
+        let left_matches = &left[key];
+        let right_matches = &right[key];
+        if left_matches.len() != 1 || right_matches.len() != 1 {
+            report_duplicate(
+                rule,
+                key,
+                left_matches.len(),
+                right_matches.len(),
+                ctx.diagnostics_node,
+            );
+            continue;
+        }
+
+        let remove_idx = left_matches[0].index;
+        let add_idx = right_matches[0].index;
+        if ctx.used_removes.contains(&remove_idx) || ctx.used_adds.contains(&add_idx) {
+            continue;
+        }
+
+        let remove = &ctx.removes[remove_idx];
+        let add = &ctx.adds[add_idx];
+        let logical_path = rule
+            .logical_path
+            .as_ref()
+            .and_then(|template| expand_template(template, &right_matches[0].captures))
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| add.path.clone());
+        let node = build_correspondence_node(rule, key, remove, add, &logical_path);
+        let parent = insertion_parent(ctx.container_paths, parent_path_of(&logical_path));
+
+        ctx.plan.schedule_remove(&remove.path);
+        ctx.plan.schedule_remove(&add.path);
+        ctx.plan.schedule_insert(parent, node);
+        ctx.used_removes.insert(remove_idx);
+        ctx.used_adds.insert(add_idx);
+    }
+}
+
+#[derive(Debug)]
+struct CompiledSelector {
+    path: Option<String>,
+    path_regex: Option<Regex>,
+}
+
+fn compile_selector(selector: &FileSelector) -> Result<CompiledSelector, regex::Error> {
+    Ok(CompiledSelector {
+        path: selector.path.clone(),
+        path_regex: selector.path_regex.as_deref().map(Regex::new).transpose()?,
+    })
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Side {
+    Left,
+    Right,
+}
+
+impl Side {
+    fn label(self) -> &'static str {
+        match self {
+            Side::Left => "left",
+            Side::Right => "right",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct KeyedMatch {
+    index: usize,
+    captures: BTreeMap<String, String>,
+}
+
+fn build_index(
+    rule: &FileCorrespondenceRule,
+    side: Side,
+    leaves: &[FileLeaf],
+    used: &BTreeSet<usize>,
+    selector: &CompiledSelector,
+    diagnostics_node: &mut DiffNode,
+) -> BTreeMap<String, Vec<KeyedMatch>> {
+    let mut out: BTreeMap<String, Vec<KeyedMatch>> = BTreeMap::new();
+    for (index, leaf) in leaves.iter().enumerate() {
+        if used.contains(&index) {
+            continue;
+        }
+        let Some(captures) = match_path(selector, &leaf.path) else {
+            continue;
+        };
+        let Some(key) = expand_template(&rule.key, &captures).filter(|s| !s.is_empty()) else {
+            handle_null_key(rule, side, &leaf.path, diagnostics_node);
+            continue;
+        };
+        out.entry(key)
+            .or_default()
+            .push(KeyedMatch { index, captures });
+    }
+    out.retain(|key, matches| {
+        if matches.len() > 1 {
+            report_side_duplicate(rule, side, key, matches.len(), diagnostics_node);
+            false
+        } else {
+            true
+        }
+    });
+    out
+}
+
+fn match_path(selector: &CompiledSelector, path: &str) -> Option<BTreeMap<String, String>> {
+    if selector
+        .path
+        .as_deref()
+        .is_some_and(|expected| expected != path)
+    {
+        return None;
+    }
+    let Some(regex) = &selector.path_regex else {
+        return Some(BTreeMap::new());
+    };
+    let captures = regex.captures(path)?;
+    let mut out = BTreeMap::new();
+    for name in regex.capture_names().flatten() {
+        if let Some(value) = captures.name(name) {
+            out.insert(name.to_string(), value.as_str().to_string());
+        }
+    }
+    Some(out)
+}
+
+fn expand_template(template: &str, captures: &BTreeMap<String, String>) -> Option<String> {
+    let mut out = String::new();
+    let mut rest = template;
+    while let Some(start) = rest.find("${") {
+        out.push_str(&rest[..start]);
+        let after_start = &rest[start + 2..];
+        let end = after_start.find('}')?;
+        let name = &after_start[..end];
+        let value = captures.get(name)?;
+        out.push_str(value);
+        rest = &after_start[end + 1..];
+    }
+    out.push_str(rest);
+    Some(out)
+}
+
+fn handle_null_key(
+    rule: &FileCorrespondenceRule,
+    side: Side,
+    path: &str,
+    diagnostics_node: &mut DiffNode,
+) {
+    match rule.on_null_key {
+        IdentityFailurePolicy::Ignore => {}
+        IdentityFailurePolicy::Diagnostic | IdentityFailurePolicy::Error => {
+            push_identity_diagnostic(
+                diagnostics_node,
+                rule.on_null_key,
+                "binoc.declared_correspondence.null_key",
+                format!(
+                    "File correspondence rule '{}' produced no key for {} path '{}'",
+                    rule.name,
+                    side.label(),
+                    path
+                ),
+                Some(path),
+            );
+        }
+    }
+}
+
+fn report_duplicate(
+    rule: &FileCorrespondenceRule,
+    key: &str,
+    left_count: usize,
+    right_count: usize,
+    diagnostics_node: &mut DiffNode,
+) {
+    match rule.on_duplicate_key {
+        IdentityFailurePolicy::Ignore => {}
+        IdentityFailurePolicy::Diagnostic | IdentityFailurePolicy::Error => {
+            push_identity_diagnostic(
+                diagnostics_node,
+                rule.on_duplicate_key,
+                "binoc.declared_correspondence.duplicate_key",
+                format!(
+                    "File correspondence rule '{}' has ambiguous key '{}' (left matches: {}, right matches: {})",
+                    rule.name, key, left_count, right_count
+                ),
+                None,
+            );
+        }
+    }
+}
+
+fn report_side_duplicate(
+    rule: &FileCorrespondenceRule,
+    side: Side,
+    key: &str,
+    count: usize,
+    diagnostics_node: &mut DiffNode,
+) {
+    match rule.on_duplicate_key {
+        IdentityFailurePolicy::Ignore => {}
+        IdentityFailurePolicy::Diagnostic | IdentityFailurePolicy::Error => {
+            push_identity_diagnostic(
+                diagnostics_node,
+                rule.on_duplicate_key,
+                "binoc.declared_correspondence.duplicate_key",
+                format!(
+                    "File correspondence rule '{}' has duplicate {} key '{}' (matches: {})",
+                    rule.name,
+                    side.label(),
+                    key,
+                    count
+                ),
+                None,
+            );
+        }
+    }
+}
+
+fn push_identity_diagnostic(
+    node: &mut DiffNode,
+    policy: IdentityFailurePolicy,
+    code: impl Into<String>,
+    message: impl Into<String>,
+    location: Option<&str>,
+) {
+    let diagnostic = match policy {
+        IdentityFailurePolicy::Error => Diagnostic::error(code, message),
+        IdentityFailurePolicy::Diagnostic => Diagnostic::warning(code, message),
+        IdentityFailurePolicy::Ignore => return,
+    };
+    node.push_diagnostic(match location {
+        Some(path) => diagnostic.with_location(path),
+        None => diagnostic,
+    });
+}
+
+fn build_correspondence_node(
+    rule: &FileCorrespondenceRule,
+    key: &str,
+    remove: &FileLeaf,
+    add: &FileLeaf,
+    logical_path: &str,
+) -> DiffNode {
+    let mut left = remove.item.clone();
+    let mut right = add.item.clone();
+    left.logical_path = logical_path.to_string();
+    right.logical_path = logical_path.to_string();
+
+    let action = if rule.report_path_change {
+        "move"
+    } else {
+        "modify"
+    };
+    let mut node = DiffNode::new(action, &add.item_type, logical_path)
+        .with_tag("binoc.declared-correspondence")
+        .with_detail("correspondence_rule", serde_json::json!(&rule.name))
+        .with_detail("correspondence_key", serde_json::json!(key))
+        .with_detail("source_path", serde_json::json!(remove.path))
+        .with_detail("destination_path", serde_json::json!(add.path));
+    if rule.report_path_change {
+        node.source_path = Some(remove.path.clone());
+        node.summary = Some(format!("Moved from {}", remove.path));
+        node.tags.insert("binoc.path-change".into());
+    }
+    node.pending_recompare = Some(ItemPair::both(left, right));
+    node
+}
+
+fn insertion_parent<'a>(container_paths: &'a BTreeSet<String>, parent: &'a str) -> &'a str {
+    let mut current = parent;
+    loop {
+        if container_paths.contains(current) {
+            return current;
+        }
+        if current.is_empty() {
+            return "";
+        }
+        current = parent_path_of(current);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn template_expands_named_captures() {
+        let captures = BTreeMap::from([
+            ("table".to_string(), "records".to_string()),
+            ("year".to_string(), "2026".to_string()),
+        ]);
+        assert_eq!(
+            expand_template("${table}:${year}", &captures).as_deref(),
+            Some("records:2026")
+        );
+    }
+
+    #[test]
+    fn template_missing_capture_is_null() {
+        let captures = BTreeMap::from([("table".to_string(), "records".to_string())]);
+        assert_eq!(expand_template("${table}:${year}", &captures), None);
+    }
+}

--- a/binoc-stdlib/src/transformers/mod.rs
+++ b/binoc-stdlib/src/transformers/mod.rs
@@ -1,6 +1,7 @@
 pub mod column_reorder;
 pub(crate) mod correlation;
 pub mod correlation_detector;
+pub mod declared_correspondence;
 pub mod folder_move_detector;
 pub mod fuzzy_correlation_detector;
 pub mod table_collection_analyzer;

--- a/binoc-stdlib/src/transformers/tabular_analyzer.rs
+++ b/binoc-stdlib/src/transformers/tabular_analyzer.rs
@@ -680,12 +680,37 @@ struct DatasetSemanticsConfig {
     tables: TableConfig,
 }
 
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default)]
 struct TableConfig {
-    #[serde(default)]
     defaults: TableDefaults,
-    #[serde(default)]
-    entries: BTreeMap<String, TableEntry>,
+    entries: Vec<TableEntry>,
+}
+
+impl<'de> Deserialize<'de> for TableConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Repr {
+            Entries(Vec<TableEntry>),
+            Full {
+                #[serde(default)]
+                defaults: TableDefaults,
+                #[serde(default)]
+                entries: Vec<TableEntry>,
+            },
+        }
+
+        match Repr::deserialize(deserializer)? {
+            Repr::Entries(entries) => Ok(Self {
+                defaults: TableDefaults::default(),
+                entries,
+            }),
+            Repr::Full { defaults, entries } => Ok(Self { defaults, entries }),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -694,12 +719,65 @@ struct TableDefaults {
     row_identity: RowIdentityConfig,
 }
 
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default)]
 struct TableEntry {
-    #[serde(default, rename = "match")]
     match_: TableSelector,
-    #[serde(default)]
     row_identity: RowIdentityConfig,
+}
+
+impl<'de> Deserialize<'de> for TableEntry {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Default, Deserialize)]
+        struct RawTableEntry {
+            #[serde(default, rename = "match")]
+            match_: TableSelector,
+            #[serde(default)]
+            row_identity: RowIdentityConfig,
+            #[serde(default)]
+            logical_name: Option<String>,
+            #[serde(default)]
+            path: Option<String>,
+            #[serde(default)]
+            path_regex: Option<String>,
+            #[serde(default)]
+            columns: Vec<String>,
+            #[serde(default)]
+            on_null_key: Option<IdentityFailurePolicy>,
+            #[serde(default)]
+            on_duplicate_key: Option<IdentityFailurePolicy>,
+        }
+
+        let raw = RawTableEntry::deserialize(deserializer)?;
+        let mut match_ = raw.match_;
+        if match_.logical_name.is_none() {
+            match_.logical_name = raw.logical_name;
+        }
+        if match_.source.is_none() && (raw.path.is_some() || raw.path_regex.is_some()) {
+            match_.source = Some(TableSourceSelector {
+                path: raw.path,
+                path_regex: raw.path_regex,
+            });
+        }
+
+        let mut row_identity = raw.row_identity;
+        if row_identity.columns.is_empty() {
+            row_identity.columns = raw.columns;
+        }
+        if raw.on_null_key.is_some() {
+            row_identity.on_null_key = raw.on_null_key;
+        }
+        if raw.on_duplicate_key.is_some() {
+            row_identity.on_duplicate_key = raw.on_duplicate_key;
+        }
+
+        Ok(Self {
+            match_,
+            row_identity,
+        })
+    }
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -739,8 +817,8 @@ fn row_identity_for_node(
     let semantics: DatasetSemanticsConfig = serde_json::from_value(dataset.clone()).ok()?;
     let defaults = semantics.tables.defaults.row_identity;
 
-    for (entry_name, entry) in &semantics.tables.entries {
-        if table_entry_matches(entry_name, entry, node) {
+    for entry in &semantics.tables.entries {
+        if table_entry_matches(entry, node) {
             let columns = if entry.row_identity.columns.is_empty() {
                 defaults.columns.clone()
             } else {
@@ -774,7 +852,7 @@ fn row_identity_for_node(
     }
 }
 
-fn table_entry_matches(entry_name: &str, entry: &TableEntry, node: &DiffNode) -> bool {
+fn table_entry_matches(entry: &TableEntry, node: &DiffNode) -> bool {
     if let Some(expected) = &entry.match_.logical_name {
         return node_logical_name(node).is_some_and(|logical| logical == expected);
     }
@@ -794,12 +872,7 @@ fn table_entry_matches(entry_name: &str, entry: &TableEntry, node: &DiffNode) ->
         return false;
     }
 
-    node_logical_name(node).is_some_and(|logical| logical == entry_name)
-        || node.path == entry_name
-        || std::path::Path::new(&node.path)
-            .file_stem()
-            .and_then(|stem| stem.to_str())
-            .is_some_and(|stem| stem == entry_name)
+    false
 }
 
 fn node_logical_name(node: &DiffNode) -> Option<&str> {

--- a/binoc-stdlib/src/transformers/tabular_analyzer.rs
+++ b/binoc-stdlib/src/transformers/tabular_analyzer.rs
@@ -853,26 +853,43 @@ fn row_identity_for_node(
 }
 
 fn table_entry_matches(entry: &TableEntry, node: &DiffNode) -> bool {
+    let mut has_selector = false;
+
     if let Some(expected) = &entry.match_.logical_name {
-        return node_logical_name(node).is_some_and(|logical| logical == expected);
+        has_selector = true;
+        if node_logical_name(node).is_none_or(|logical| logical != expected) {
+            return false;
+        }
     }
 
     if let Some(source) = &entry.match_.source {
-        let paths = node_source_paths(node);
-        if let Some(expected) = &source.path {
-            if paths.iter().any(|path| path == expected) {
-                return true;
-            }
+        has_selector = true;
+        if !source_selector_matches(source, node) {
+            return false;
         }
-        if let Some(pattern) = &source.path_regex {
-            if let Ok(regex) = regex::Regex::new(pattern) {
-                return paths.iter().any(|path| regex.is_match(path));
-            }
-        }
-        return false;
     }
 
-    false
+    has_selector
+}
+
+fn source_selector_matches(source: &TableSourceSelector, node: &DiffNode) -> bool {
+    if source.path.is_none() && source.path_regex.is_none() {
+        return false;
+    }
+    let regex = match source.path_regex.as_deref() {
+        Some(pattern) => match regex::Regex::new(pattern) {
+            Ok(regex) => Some(regex),
+            Err(_) => return false,
+        },
+        None => None,
+    };
+    node_source_paths(node).iter().any(|path| {
+        source
+            .path
+            .as_deref()
+            .is_none_or(|expected| *path == expected)
+            && regex.as_ref().is_none_or(|regex| regex.is_match(path))
+    })
 }
 
 fn node_logical_name(node: &DiffNode) -> Option<&str> {
@@ -1291,4 +1308,55 @@ fn tabular_columns_in_common_local(left: &TabularData, right: &TabularData) -> V
         .filter(|h| left_set.contains(h.as_str()))
         .cloned()
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn item(path: &str) -> ItemRef {
+        ItemRef {
+            logical_path: path.into(),
+            is_dir: false,
+            content_hash: None,
+            size: None,
+            media_type: None,
+            handle: String::new(),
+        }
+    }
+
+    fn table_node(source_path: &str, logical_name: &str) -> DiffNode {
+        let left = item(source_path);
+        let right = item(source_path);
+        DiffNode::new("modify", "tabular", format!("{source_path}#{logical_name}"))
+            .with_detail("logical_name", serde_json::json!(logical_name))
+            .with_source_items(ItemPair::both(left, right))
+    }
+
+    #[test]
+    fn table_entry_requires_logical_name_and_source_when_both_are_set() {
+        let node = table_node("workbook.xlsx", "Products");
+        let mismatched_source = serde_json::json!({
+            "tables": [{
+                "logical_name": "Products",
+                "path": "other.xlsx",
+                "columns": ["id"]
+            }]
+        });
+        let matched_source = serde_json::json!({
+            "tables": [{
+                "logical_name": "Products",
+                "path": "workbook.xlsx",
+                "columns": ["id"]
+            }]
+        });
+
+        assert!(row_identity_for_node(&node, &mismatched_source).is_none());
+        assert_eq!(
+            row_identity_for_node(&node, &matched_source)
+                .expect("row identity")
+                .columns,
+            vec!["id"]
+        );
+    }
 }

--- a/binoc-stdlib/src/transformers/tabular_analyzer.rs
+++ b/binoc-stdlib/src/transformers/tabular_analyzer.rs
@@ -1,6 +1,7 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 use binoc_sdk::*;
+use serde::{Deserialize, Serialize};
 
 const MAX_CAPTURED_CELL_EXAMPLES: usize = 8;
 const MAX_CAPTURED_VALUE_CHARS: usize = 256;
@@ -24,7 +25,7 @@ impl Transformer for TabularAnalyzer {
         &self,
         node: DiffNode,
         data: &dyn DataAccess,
-        _config: &serde_json::Value,
+        config: &serde_json::Value,
     ) -> TransformResult {
         let Some(pair) = TabularDataPair::from_artifacts(&node, data) else {
             return TransformResult::Unchanged;
@@ -36,7 +37,7 @@ impl Transformer for TabularAnalyzer {
             // `move` nodes from fuzzy correlation carry tabular artifacts
             // from the re-dispatched content diff; analyze them the same
             // way as a `modify`, but preserve the move summary.
-            "modify" | "move" => transform_modify(node, &pair),
+            "modify" | "move" => transform_modify(node, &pair, config),
             _ => TransformResult::Unchanged,
         }
     }
@@ -48,6 +49,9 @@ impl Transformer for TabularAnalyzer {
         data: &dyn DataAccess,
     ) -> Option<ExtractResult> {
         let pair = TabularDataPair::from_artifacts(node, data)?;
+        if let Some(result) = keyed_tabular_extract(&pair, node, aspect) {
+            return Some(result);
+        }
         tabular_extract(&pair, node, aspect)
     }
 }
@@ -90,7 +94,11 @@ fn transform_remove(mut node: DiffNode, pair: &TabularDataPair) -> TransformResu
     TransformResult::Replace(Box::new(node))
 }
 
-fn transform_modify(mut node: DiffNode, pair: &TabularDataPair) -> TransformResult {
+fn transform_modify(
+    mut node: DiffNode,
+    pair: &TabularDataPair,
+    config: &serde_json::Value,
+) -> TransformResult {
     let (Some(left), Some(right)) = (&pair.left, &pair.right) else {
         return TransformResult::Unchanged;
     };
@@ -126,6 +134,51 @@ fn transform_modify(mut node: DiffNode, pair: &TabularDataPair) -> TransformResu
             .collect();
         common_order_l != common_order_r
     };
+
+    if let Some(row_identity) = row_identity_for_node(&node, config) {
+        if row_identity
+            .columns
+            .iter()
+            .all(|col| left.column_index(col).is_some() && right.column_index(col).is_some())
+        {
+            return transform_modify_keyed(
+                node,
+                left,
+                right,
+                TabularColumnChange {
+                    columns_added,
+                    columns_removed,
+                    columns_common,
+                    order_changed,
+                },
+                row_identity,
+            );
+        }
+
+        let missing_columns: Vec<&str> = row_identity
+            .columns
+            .iter()
+            .filter(|col| left.column_index(col).is_none() || right.column_index(col).is_none())
+            .map(|col| col.as_str())
+            .collect();
+        node.tags.insert("binoc.identity-diagnostic".into());
+        node.tags.insert("binoc.row-identity-ambiguous".into());
+        node.details.insert(
+            "row_identity_missing_columns".into(),
+            serde_json::json!(missing_columns),
+        );
+        node.diagnostics.push(
+            Diagnostic::warning(
+                "binoc.row-identity-missing-columns",
+                format!(
+                    "Configured row identity references missing column{}: {}",
+                    if missing_columns.len() == 1 { "" } else { "s" },
+                    fmt_quoted_list(&missing_columns)
+                ),
+            )
+            .with_location(node.path.clone()),
+        );
+    }
 
     let min_rows = left.rows.len().min(right.rows.len());
     let mut cells_changed: u64 = 0;
@@ -236,6 +289,163 @@ fn transform_modify(mut node: DiffNode, pair: &TabularDataPair) -> TransformResu
     TransformResult::Replace(Box::new(node))
 }
 
+struct TabularColumnChange {
+    columns_added: Vec<String>,
+    columns_removed: Vec<String>,
+    columns_common: Vec<String>,
+    order_changed: bool,
+}
+
+fn transform_modify_keyed(
+    mut node: DiffNode,
+    left: &TabularData,
+    right: &TabularData,
+    column_change: TabularColumnChange,
+    row_identity: EffectiveRowIdentity,
+) -> TransformResult {
+    let key_columns = row_identity.columns.clone();
+    let key_match = build_key_match(left, right, &row_identity);
+
+    let mut cells_changed: u64 = 0;
+    let mut rows_modified: u64 = 0;
+    let mut cell_examples = Vec::new();
+
+    for matched in &key_match.matched {
+        let row_l = &left.rows[matched.left_index];
+        let row_r = &right.rows[matched.right_index];
+        let mut row_changed = false;
+        for col in &column_change.columns_common {
+            let val_l = left
+                .column_index(col)
+                .and_then(|j| row_l.get(j))
+                .map(|s| s.as_str())
+                .unwrap_or("");
+            let val_r = right
+                .column_index(col)
+                .and_then(|j| row_r.get(j))
+                .map(|s| s.as_str())
+                .unwrap_or("");
+            if val_l != val_r {
+                row_changed = true;
+                cells_changed += 1;
+                if cell_examples.len() < MAX_CAPTURED_CELL_EXAMPLES {
+                    cell_examples.push(changed_cell_example_with_key(
+                        &key_columns,
+                        &matched.key,
+                        col,
+                        val_l,
+                        val_r,
+                    ));
+                }
+            }
+        }
+        if row_changed {
+            rows_modified += 1;
+        }
+    }
+
+    let rows_added = key_match.unmatched_right.len() as u64;
+    let rows_removed = key_match.unmatched_left.len() as u64;
+
+    node.details
+        .insert("columns_left".into(), serde_json::json!(left.headers));
+    node.details
+        .insert("columns_right".into(), serde_json::json!(right.headers));
+    node.details.insert(
+        "columns_added".into(),
+        serde_json::json!(&column_change.columns_added),
+    );
+    node.details.insert(
+        "columns_removed".into(),
+        serde_json::json!(&column_change.columns_removed),
+    );
+    node.details
+        .insert("rows_left".into(), serde_json::json!(left.rows.len()));
+    node.details
+        .insert("rows_right".into(), serde_json::json!(right.rows.len()));
+    node.details
+        .insert("rows_added".into(), serde_json::json!(rows_added));
+    node.details
+        .insert("rows_removed".into(), serde_json::json!(rows_removed));
+    node.details
+        .insert("rows_modified".into(), serde_json::json!(rows_modified));
+    node.details
+        .insert("cells_changed".into(), serde_json::json!(cells_changed));
+    node.details.insert(
+        "row_identity".into(),
+        serde_json::json!({
+            "columns": &key_columns,
+            "matched_rows": key_match.matched.len(),
+            "mode": "keyed",
+            "on_null_key": row_identity.on_null_key,
+            "on_duplicate_key": row_identity.on_duplicate_key
+        }),
+    );
+    if !key_match.unmatched_left.is_empty() {
+        node.details.insert(
+            "rows_removed_keys".into(),
+            serde_json::json!(keyed_rows_for_detail(
+                &key_columns,
+                &key_match.unmatched_left
+            )),
+        );
+    }
+    if !key_match.unmatched_right.is_empty() {
+        node.details.insert(
+            "rows_added_keys".into(),
+            serde_json::json!(keyed_rows_for_detail(
+                &key_columns,
+                &key_match.unmatched_right
+            )),
+        );
+    }
+
+    if cells_changed > 0 {
+        node.detail_blocks.push(
+            DetailBlock::new("cells_changed", "binoc.tabular.cell_changes.v1")
+                .with_label("Changed cells")
+                .with_total_count(cells_changed)
+                .with_extract_hint(
+                    ExtractHint::new("cells_changed").with_label("All changed cells"),
+                ),
+        );
+        if let Some(block) = node.detail_blocks.last_mut() {
+            block.examples = cell_examples;
+            block.truncated = cells_changed as usize > block.examples.len();
+        }
+    }
+
+    apply_tabular_tags(
+        &mut node,
+        &column_change.columns_added,
+        &column_change.columns_removed,
+        column_change.order_changed,
+        rows_added,
+        rows_removed,
+        cells_changed,
+    );
+    apply_key_diagnostics(&mut node, &key_match.diagnostics);
+
+    let tabular_desc = keyed_tabular_summary(
+        &column_change.columns_added,
+        &column_change.columns_removed,
+        column_change.order_changed,
+        rows_added,
+        rows_removed,
+        rows_modified,
+        cells_changed,
+    );
+
+    if node.action == "move" {
+        node.annotations
+            .insert("tabular_summary".into(), serde_json::json!(tabular_desc));
+    } else if tabular_desc != "Table modified" || node.summary.is_none() {
+        node.summary = Some(tabular_desc);
+    }
+
+    TransformResult::Replace(Box::new(node))
+}
+
 fn tabular_summary(
     columns_added: &[String],
     columns_removed: &[String],
@@ -314,6 +524,26 @@ fn changed_cell_example(row: usize, column: &str, before: &str, after: &str) -> 
     example
 }
 
+fn changed_cell_example_with_key(
+    key_columns: &[String],
+    key: &[String],
+    column: &str,
+    before: &str,
+    after: &str,
+) -> DetailExample {
+    let mut example = DetailExample::new();
+    example.locator.insert(
+        "key".into(),
+        serde_json::json!(key_to_map(key_columns, key)),
+    );
+    example
+        .locator
+        .insert("column".into(), serde_json::json!(column));
+    example.before = Some(capture_value_preview(before));
+    example.after = Some(capture_value_preview(after));
+    example
+}
+
 fn capture_value_preview(value: &str) -> ValuePreview {
     let truncated = value.chars().count() > MAX_CAPTURED_VALUE_CHARS;
     let value = if truncated {
@@ -329,4 +559,663 @@ fn capture_value_preview(value: &str) -> ValuePreview {
         media_type: Some("text/plain".into()),
         truncated,
     }
+}
+
+fn apply_tabular_tags(
+    node: &mut DiffNode,
+    columns_added: &[String],
+    columns_removed: &[String],
+    order_changed: bool,
+    rows_added: u64,
+    rows_removed: u64,
+    cells_changed: u64,
+) {
+    if !columns_added.is_empty() {
+        node.tags.insert("binoc.column-addition".into());
+    }
+    if !columns_removed.is_empty() {
+        node.tags.insert("binoc.column-removal".into());
+    }
+    if order_changed {
+        node.tags.insert("binoc.column-reorder".into());
+    }
+    if rows_added > 0 {
+        node.tags.insert("binoc.row-addition".into());
+    }
+    if rows_removed > 0 {
+        node.tags.insert("binoc.row-removal".into());
+    }
+    if cells_changed > 0 {
+        node.tags.insert("binoc.cell-change".into());
+    }
+    if !columns_added.is_empty() || !columns_removed.is_empty() {
+        node.tags.insert("binoc.schema-change".into());
+    }
+}
+
+fn keyed_tabular_summary(
+    columns_added: &[String],
+    columns_removed: &[String],
+    order_changed: bool,
+    rows_added: u64,
+    rows_removed: u64,
+    rows_modified: u64,
+    cells_changed: u64,
+) -> String {
+    let mut parts = Vec::new();
+
+    if !columns_added.is_empty() {
+        let names: Vec<&str> = columns_added.iter().map(|s| s.as_str()).collect();
+        if names.len() == 1 {
+            parts.push(format!("column added: '{}'", names[0]));
+        } else {
+            parts.push(format!("columns added: {}", fmt_quoted_list(&names)));
+        }
+    }
+    if !columns_removed.is_empty() {
+        let names: Vec<&str> = columns_removed.iter().map(|s| s.as_str()).collect();
+        if names.len() == 1 {
+            parts.push(format!("column removed: '{}'", names[0]));
+        } else {
+            parts.push(format!("columns removed: {}", fmt_quoted_list(&names)));
+        }
+    }
+    if order_changed {
+        parts.push("columns reordered".into());
+    }
+    if rows_added > 0 {
+        parts.push(format!(
+            "{rows_added} row{} added by key",
+            if rows_added == 1 { "" } else { "s" }
+        ));
+    }
+    if rows_removed > 0 {
+        parts.push(format!(
+            "{rows_removed} row{} removed by key",
+            if rows_removed == 1 { "" } else { "s" }
+        ));
+    }
+    if rows_modified > 0 {
+        parts.push(format!(
+            "{rows_modified} row{} modified by key",
+            if rows_modified == 1 { "" } else { "s" }
+        ));
+    } else if cells_changed > 0 {
+        parts.push(format!(
+            "{cells_changed} cell{} changed",
+            if cells_changed == 1 { "" } else { "s" }
+        ));
+    }
+
+    if parts.is_empty() {
+        "Table modified".into()
+    } else {
+        let mut s = parts.join("; ");
+        if let Some(first) = s.get_mut(..1) {
+            first.make_ascii_uppercase();
+        }
+        s
+    }
+}
+
+#[derive(Debug, Clone)]
+struct EffectiveRowIdentity {
+    columns: Vec<String>,
+    on_null_key: IdentityFailurePolicy,
+    on_duplicate_key: IdentityFailurePolicy,
+}
+
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+enum IdentityFailurePolicy {
+    #[default]
+    Diagnostic,
+    Error,
+    Ignore,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+struct DatasetSemanticsConfig {
+    #[serde(default)]
+    tables: TableConfig,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+struct TableConfig {
+    #[serde(default)]
+    defaults: TableDefaults,
+    #[serde(default)]
+    entries: BTreeMap<String, TableEntry>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+struct TableDefaults {
+    #[serde(default)]
+    row_identity: RowIdentityConfig,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+struct TableEntry {
+    #[serde(default, rename = "match")]
+    match_: TableSelector,
+    #[serde(default)]
+    row_identity: RowIdentityConfig,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+struct TableSelector {
+    #[serde(default)]
+    logical_name: Option<String>,
+    #[serde(default)]
+    source: Option<TableSourceSelector>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+struct TableSourceSelector {
+    #[serde(default)]
+    path: Option<String>,
+    #[serde(default)]
+    path_regex: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+struct RowIdentityConfig {
+    #[serde(default)]
+    columns: Vec<String>,
+    #[serde(default)]
+    on_null_key: Option<IdentityFailurePolicy>,
+    #[serde(default)]
+    on_duplicate_key: Option<IdentityFailurePolicy>,
+}
+
+fn row_identity_for_node(
+    node: &DiffNode,
+    config: &serde_json::Value,
+) -> Option<EffectiveRowIdentity> {
+    let dataset = config
+        .get("dataset")
+        .filter(|value| !value.is_null())
+        .unwrap_or(config);
+    let semantics: DatasetSemanticsConfig = serde_json::from_value(dataset.clone()).ok()?;
+    let defaults = semantics.tables.defaults.row_identity;
+
+    for (entry_name, entry) in &semantics.tables.entries {
+        if table_entry_matches(entry_name, entry, node) {
+            let columns = if entry.row_identity.columns.is_empty() {
+                defaults.columns.clone()
+            } else {
+                entry.row_identity.columns.clone()
+            };
+            if columns.is_empty() {
+                return None;
+            }
+            return Some(EffectiveRowIdentity {
+                columns,
+                on_null_key: entry
+                    .row_identity
+                    .on_null_key
+                    .unwrap_or(defaults.on_null_key.unwrap_or_default()),
+                on_duplicate_key: entry
+                    .row_identity
+                    .on_duplicate_key
+                    .unwrap_or(defaults.on_duplicate_key.unwrap_or_default()),
+            });
+        }
+    }
+
+    if defaults.columns.is_empty() {
+        None
+    } else {
+        Some(EffectiveRowIdentity {
+            columns: defaults.columns,
+            on_null_key: defaults.on_null_key.unwrap_or_default(),
+            on_duplicate_key: defaults.on_duplicate_key.unwrap_or_default(),
+        })
+    }
+}
+
+fn table_entry_matches(entry_name: &str, entry: &TableEntry, node: &DiffNode) -> bool {
+    if let Some(expected) = &entry.match_.logical_name {
+        return node_logical_name(node).is_some_and(|logical| logical == expected);
+    }
+
+    if let Some(source) = &entry.match_.source {
+        let paths = node_source_paths(node);
+        if let Some(expected) = &source.path {
+            if paths.iter().any(|path| path == expected) {
+                return true;
+            }
+        }
+        if let Some(pattern) = &source.path_regex {
+            if let Ok(regex) = regex::Regex::new(pattern) {
+                return paths.iter().any(|path| regex.is_match(path));
+            }
+        }
+        return false;
+    }
+
+    node_logical_name(node).is_some_and(|logical| logical == entry_name)
+        || node.path == entry_name
+        || std::path::Path::new(&node.path)
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .is_some_and(|stem| stem == entry_name)
+}
+
+fn node_logical_name(node: &DiffNode) -> Option<&str> {
+    node.details.get("logical_name")?.as_str()
+}
+
+fn node_source_paths(node: &DiffNode) -> Vec<&str> {
+    let mut paths = vec![node.path.as_str()];
+    if let Some(pair) = &node.source_items {
+        if let Some(left) = &pair.left {
+            paths.push(left.logical_path.as_str());
+        }
+        if let Some(right) = &pair.right {
+            paths.push(right.logical_path.as_str());
+        }
+    }
+    paths
+}
+
+#[derive(Debug, Clone)]
+struct MatchedRow {
+    left_index: usize,
+    right_index: usize,
+    key: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct UnmatchedRow {
+    row_index: usize,
+    key: Option<Vec<String>>,
+}
+
+#[derive(Debug, Default)]
+struct KeyDiagnostics {
+    null_left: usize,
+    null_right: usize,
+    duplicate_left: usize,
+    duplicate_right: usize,
+    ambiguous_keys: usize,
+    duplicate_examples: Vec<Vec<String>>,
+}
+
+#[derive(Debug)]
+struct KeyMatch {
+    matched: Vec<MatchedRow>,
+    unmatched_left: Vec<UnmatchedRow>,
+    unmatched_right: Vec<UnmatchedRow>,
+    diagnostics: KeyDiagnostics,
+}
+
+fn build_key_match(
+    left: &TabularData,
+    right: &TabularData,
+    identity: &EffectiveRowIdentity,
+) -> KeyMatch {
+    let left_index = index_rows_by_key(left, &identity.columns);
+    let right_index = index_rows_by_key(right, &identity.columns);
+
+    let mut matched = Vec::new();
+    let mut unmatched_left: Vec<UnmatchedRow> = left_index
+        .null_rows
+        .iter()
+        .map(|row_index| UnmatchedRow {
+            row_index: *row_index,
+            key: None,
+        })
+        .collect();
+    let mut unmatched_right: Vec<UnmatchedRow> = right_index
+        .null_rows
+        .iter()
+        .map(|row_index| UnmatchedRow {
+            row_index: *row_index,
+            key: None,
+        })
+        .collect();
+    let mut diagnostics = KeyDiagnostics {
+        null_left: left_index.null_rows.len(),
+        null_right: right_index.null_rows.len(),
+        ..Default::default()
+    };
+
+    let keys: BTreeSet<Vec<String>> = left_index
+        .rows_by_key
+        .keys()
+        .chain(right_index.rows_by_key.keys())
+        .cloned()
+        .collect();
+
+    for key in keys {
+        let left_rows = left_index
+            .rows_by_key
+            .get(&key)
+            .cloned()
+            .unwrap_or_default();
+        let right_rows = right_index
+            .rows_by_key
+            .get(&key)
+            .cloned()
+            .unwrap_or_default();
+
+        match (left_rows.len(), right_rows.len()) {
+            (1, 1) => matched.push(MatchedRow {
+                left_index: left_rows[0],
+                right_index: right_rows[0],
+                key,
+            }),
+            (1, 0) => unmatched_left.push(UnmatchedRow {
+                row_index: left_rows[0],
+                key: Some(key),
+            }),
+            (0, 1) => unmatched_right.push(UnmatchedRow {
+                row_index: right_rows[0],
+                key: Some(key),
+            }),
+            _ => {
+                if left_rows.len() > 1 {
+                    diagnostics.duplicate_left += left_rows.len();
+                }
+                if right_rows.len() > 1 {
+                    diagnostics.duplicate_right += right_rows.len();
+                }
+                if !left_rows.is_empty() && !right_rows.is_empty() {
+                    diagnostics.ambiguous_keys += 1;
+                }
+                if diagnostics.duplicate_examples.len() < MAX_CAPTURED_CELL_EXAMPLES {
+                    diagnostics.duplicate_examples.push(key.clone());
+                }
+                unmatched_left.extend(left_rows.into_iter().map(|row_index| UnmatchedRow {
+                    row_index,
+                    key: Some(key.clone()),
+                }));
+                unmatched_right.extend(right_rows.into_iter().map(|row_index| UnmatchedRow {
+                    row_index,
+                    key: Some(key.clone()),
+                }));
+            }
+        }
+    }
+
+    KeyMatch {
+        matched,
+        unmatched_left,
+        unmatched_right,
+        diagnostics,
+    }
+}
+
+#[derive(Debug)]
+struct RowKeyIndex {
+    rows_by_key: BTreeMap<Vec<String>, Vec<usize>>,
+    null_rows: Vec<usize>,
+}
+
+fn index_rows_by_key(table: &TabularData, key_columns: &[String]) -> RowKeyIndex {
+    let key_indices: Vec<usize> = key_columns
+        .iter()
+        .filter_map(|column| table.column_index(column))
+        .collect();
+    let mut rows_by_key: BTreeMap<Vec<String>, Vec<usize>> = BTreeMap::new();
+    let mut null_rows = Vec::new();
+
+    for (row_index, row) in table.rows.iter().enumerate() {
+        let mut key = Vec::with_capacity(key_indices.len());
+        let mut is_null = false;
+        for idx in &key_indices {
+            let value = row.get(*idx).map(|s| s.trim()).unwrap_or("");
+            if value.is_empty() {
+                is_null = true;
+            }
+            key.push(value.to_string());
+        }
+        if is_null {
+            null_rows.push(row_index);
+        } else {
+            rows_by_key.entry(key).or_default().push(row_index);
+        }
+    }
+
+    RowKeyIndex {
+        rows_by_key,
+        null_rows,
+    }
+}
+
+fn apply_key_diagnostics(node: &mut DiffNode, diagnostics: &KeyDiagnostics) {
+    let Some(row_identity) = node.details.get("row_identity").cloned() else {
+        return;
+    };
+    let policies = row_identity_policy_from_details(&row_identity);
+
+    if diagnostics.null_left + diagnostics.null_right > 0 {
+        node.tags.insert("binoc.identity-diagnostic".into());
+        node.tags.insert("binoc.null-key".into());
+        node.tags.insert("binoc.row-identity-ambiguous".into());
+        if let Some(diagnostic) = diagnostic_for_identity_policy(
+            policies.on_null_key,
+            "binoc.null-key",
+            format!(
+                "{} row{} had null configured key values",
+                diagnostics.null_left + diagnostics.null_right,
+                if diagnostics.null_left + diagnostics.null_right == 1 {
+                    ""
+                } else {
+                    "s"
+                }
+            ),
+        ) {
+            node.diagnostics
+                .push(diagnostic.with_location(node.path.clone()));
+        }
+    }
+
+    if diagnostics.duplicate_left + diagnostics.duplicate_right > 0 {
+        node.tags.insert("binoc.identity-diagnostic".into());
+        node.tags.insert("binoc.duplicate-key".into());
+        node.tags.insert("binoc.row-identity-ambiguous".into());
+        if diagnostics.ambiguous_keys > 0 {
+            node.tags.insert("binoc.ambiguous-key".into());
+        }
+        if let Some(diagnostic) = diagnostic_for_identity_policy(
+            policies.on_duplicate_key,
+            "binoc.duplicate-key",
+            format!(
+                "{} configured row key{} appeared more than once",
+                diagnostics
+                    .ambiguous_keys
+                    .max(diagnostics.duplicate_examples.len()),
+                if diagnostics
+                    .ambiguous_keys
+                    .max(diagnostics.duplicate_examples.len())
+                    == 1
+                {
+                    ""
+                } else {
+                    "s"
+                }
+            ),
+        ) {
+            node.diagnostics
+                .push(diagnostic.with_location(node.path.clone()));
+        }
+    }
+}
+
+fn diagnostic_for_identity_policy(
+    policy: IdentityFailurePolicy,
+    code: impl Into<String>,
+    message: impl Into<String>,
+) -> Option<Diagnostic> {
+    match policy {
+        IdentityFailurePolicy::Error => Some(Diagnostic::error(code, message)),
+        IdentityFailurePolicy::Diagnostic => Some(Diagnostic::warning(code, message)),
+        IdentityFailurePolicy::Ignore => None,
+    }
+}
+
+fn row_identity_policy_from_details(row_identity: &serde_json::Value) -> EffectiveRowIdentity {
+    let columns: Vec<String> = row_identity
+        .get("columns")
+        .and_then(|value| serde_json::from_value(value.clone()).ok())
+        .unwrap_or_default();
+    let on_null_key = row_identity
+        .get("on_null_key")
+        .and_then(|value| serde_json::from_value(value.clone()).ok())
+        .unwrap_or_default();
+    let on_duplicate_key = row_identity
+        .get("on_duplicate_key")
+        .and_then(|value| serde_json::from_value(value.clone()).ok())
+        .unwrap_or_default();
+    EffectiveRowIdentity {
+        columns,
+        on_null_key,
+        on_duplicate_key,
+    }
+}
+
+fn key_to_map(key_columns: &[String], key: &[String]) -> BTreeMap<String, String> {
+    key_columns
+        .iter()
+        .cloned()
+        .zip(key.iter().cloned())
+        .collect()
+}
+
+fn keyed_rows_for_detail(key_columns: &[String], rows: &[UnmatchedRow]) -> Vec<serde_json::Value> {
+    rows.iter()
+        .map(|row| {
+            let mut value = serde_json::Map::new();
+            value.insert("row".into(), serde_json::json!(row.row_index));
+            if let Some(key) = &row.key {
+                value.insert(
+                    "key".into(),
+                    serde_json::json!(key_to_map(key_columns, key)),
+                );
+            } else {
+                value.insert("key".into(), serde_json::Value::Null);
+            }
+            serde_json::Value::Object(value)
+        })
+        .collect()
+}
+
+fn keyed_tabular_extract(
+    pair: &TabularDataPair,
+    node: &DiffNode,
+    aspect: &str,
+) -> Option<ExtractResult> {
+    let row_identity = row_identity_from_node_details(node)?;
+    let left = pair.left.as_ref()?;
+    let right = pair.right.as_ref()?;
+    if !row_identity
+        .columns
+        .iter()
+        .all(|col| left.column_index(col).is_some() && right.column_index(col).is_some())
+    {
+        return None;
+    }
+    let key_match = build_key_match(left, right, &row_identity);
+
+    match aspect {
+        "cells_changed" => Some(ExtractResult::Text(keyed_cells_changed_csv(
+            left,
+            right,
+            &row_identity.columns,
+            &key_match.matched,
+        )?)),
+        "rows_added" => Some(ExtractResult::Text(keyed_rows_csv(
+            right,
+            &key_match.unmatched_right,
+            "No rows added.\n",
+        )?)),
+        "rows_removed" => Some(ExtractResult::Text(keyed_rows_csv(
+            left,
+            &key_match.unmatched_left,
+            "No rows removed.\n",
+        )?)),
+        _ => None,
+    }
+}
+
+fn row_identity_from_node_details(node: &DiffNode) -> Option<EffectiveRowIdentity> {
+    let value = node.details.get("row_identity")?;
+    let columns: Vec<String> = serde_json::from_value(value.get("columns")?.clone()).ok()?;
+    if columns.is_empty() {
+        return None;
+    }
+    Some(EffectiveRowIdentity {
+        columns,
+        on_null_key: value
+            .get("on_null_key")
+            .and_then(|value| serde_json::from_value(value.clone()).ok())
+            .unwrap_or_default(),
+        on_duplicate_key: value
+            .get("on_duplicate_key")
+            .and_then(|value| serde_json::from_value(value.clone()).ok())
+            .unwrap_or_default(),
+    })
+}
+
+fn keyed_cells_changed_csv(
+    left: &TabularData,
+    right: &TabularData,
+    key_columns: &[String],
+    matched_rows: &[MatchedRow],
+) -> Option<String> {
+    let common_cols = tabular_columns_in_common_local(left, right);
+    let mut writer = csv::Writer::from_writer(Vec::new());
+    let mut header = key_columns.to_vec();
+    header.push("column".into());
+    header.push("old_value".into());
+    header.push("new_value".into());
+    writer.write_record(&header).ok()?;
+
+    for matched in matched_rows {
+        let row_l = &left.rows[matched.left_index];
+        let row_r = &right.rows[matched.right_index];
+        for col in &common_cols {
+            let li = left.column_index(col)?;
+            let ri = right.column_index(col)?;
+            let lv = row_l.get(li).map(|s| s.as_str()).unwrap_or("");
+            let rv = row_r.get(ri).map(|s| s.as_str()).unwrap_or("");
+            if lv != rv {
+                let mut record = matched.key.clone();
+                record.push(col.clone());
+                record.push(lv.to_string());
+                record.push(rv.to_string());
+                writer.write_record(&record).ok()?;
+            }
+        }
+    }
+
+    String::from_utf8(writer.into_inner().ok()?).ok()
+}
+
+fn keyed_rows_csv(
+    table: &TabularData,
+    rows: &[UnmatchedRow],
+    empty_message: &str,
+) -> Option<String> {
+    if rows.is_empty() {
+        return Some(empty_message.into());
+    }
+    let mut writer = csv::Writer::from_writer(Vec::new());
+    writer.write_record(&table.headers).ok()?;
+    for row in rows {
+        writer.write_record(&table.rows[row.row_index]).ok()?;
+    }
+    String::from_utf8(writer.into_inner().ok()?).ok()
+}
+
+fn tabular_columns_in_common_local(left: &TabularData, right: &TabularData) -> Vec<String> {
+    let left_set: BTreeSet<&str> = left.headers.iter().map(|s| s.as_str()).collect();
+    right
+        .headers
+        .iter()
+        .filter(|h| left_set.contains(h.as_str()))
+        .cloned()
+        .collect()
 }

--- a/binoc-stdlib/tests/transformer_tests.rs
+++ b/binoc-stdlib/tests/transformer_tests.rs
@@ -1,3 +1,5 @@
+use binoc_core::config::DatasetConfig;
+use binoc_core::controller::Controller;
 use binoc_core::data_access::LocalDataAccess;
 use binoc_sdk::*;
 
@@ -12,6 +14,134 @@ fn da() -> LocalDataAccess {
 
 fn null_cfg() -> serde_json::Value {
     serde_json::Value::Null
+}
+
+fn controller_with_tabular_row_identity(on_null_key: &str, on_duplicate_key: &str) -> Controller {
+    let registry = binoc_stdlib::default_registry();
+    let mut config = DatasetConfig::default_config();
+    config.transformers = vec!["binoc.tabular_analyzer".into()];
+    config.dataset = serde_json::json!({
+        "tables": {
+            "defaults": {
+                "row_identity": {
+                    "columns": ["id"],
+                    "on_null_key": on_null_key,
+                    "on_duplicate_key": on_duplicate_key
+                }
+            }
+        }
+    });
+    let resolved = registry.resolve(&config).unwrap();
+    Controller::new(resolved.comparators, resolved.transformers)
+        .with_transformer_configs(config.transformer_config.as_map())
+        .with_dataset_config(config.dataset.clone())
+}
+
+fn write_file(path: &std::path::Path, contents: &str) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(path, contents).unwrap();
+}
+
+// ── Tabular row identity failures ─────────────────────────────────────
+
+#[test]
+fn tabular_row_identity_null_key_diagnostic_succeeds() {
+    let tmp = tempfile::tempdir().unwrap();
+    let snap_a = tmp.path().join("snapshot-a");
+    let snap_b = tmp.path().join("snapshot-b");
+    write_file(&snap_a.join("data.csv"), "id,name\n,Ada\n1,Bob\n");
+    write_file(&snap_b.join("data.csv"), "id,name\n,Ada Lovelace\n1,Bob\n");
+
+    let controller = controller_with_tabular_row_identity("diagnostic", "diagnostic");
+    let changeset = controller
+        .diff(
+            snap_a.to_string_lossy().as_ref(),
+            snap_b.to_string_lossy().as_ref(),
+        )
+        .unwrap();
+
+    assert!(changeset.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "binoc.null-key"
+            && diagnostic.severity == DiagnosticSeverity::Warning
+            && diagnostic.location.as_deref() == Some("data.csv")
+    }));
+}
+
+#[test]
+fn tabular_row_identity_null_key_error_is_reported() {
+    let tmp = tempfile::tempdir().unwrap();
+    let snap_a = tmp.path().join("snapshot-a");
+    let snap_b = tmp.path().join("snapshot-b");
+    write_file(&snap_a.join("data.csv"), "id,name\n,Ada\n1,Bob\n");
+    write_file(&snap_b.join("data.csv"), "id,name\n,Ada Lovelace\n1,Bob\n");
+
+    let controller = controller_with_tabular_row_identity("error", "diagnostic");
+    let changeset = controller
+        .diff(
+            snap_a.to_string_lossy().as_ref(),
+            snap_b.to_string_lossy().as_ref(),
+        )
+        .unwrap();
+
+    assert!(changeset.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "binoc.null-key"
+            && diagnostic.severity == DiagnosticSeverity::Error
+            && diagnostic.location.as_deref() == Some("data.csv")
+    }));
+}
+
+#[test]
+fn tabular_row_identity_duplicate_key_diagnostic_succeeds() {
+    let tmp = tempfile::tempdir().unwrap();
+    let snap_a = tmp.path().join("snapshot-a");
+    let snap_b = tmp.path().join("snapshot-b");
+    write_file(
+        &snap_a.join("data.csv"),
+        "id,name\n1,Ada\n1,Ada Duplicate\n2,Bob\n",
+    );
+    write_file(&snap_b.join("data.csv"), "id,name\n1,Ada Revised\n2,Bob\n");
+
+    let controller = controller_with_tabular_row_identity("diagnostic", "diagnostic");
+    let changeset = controller
+        .diff(
+            snap_a.to_string_lossy().as_ref(),
+            snap_b.to_string_lossy().as_ref(),
+        )
+        .unwrap();
+
+    assert!(changeset.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "binoc.duplicate-key"
+            && diagnostic.severity == DiagnosticSeverity::Warning
+            && diagnostic.location.as_deref() == Some("data.csv")
+    }));
+}
+
+#[test]
+fn tabular_row_identity_duplicate_key_error_is_reported() {
+    let tmp = tempfile::tempdir().unwrap();
+    let snap_a = tmp.path().join("snapshot-a");
+    let snap_b = tmp.path().join("snapshot-b");
+    write_file(
+        &snap_a.join("data.csv"),
+        "id,name\n1,Ada\n1,Ada Duplicate\n2,Bob\n",
+    );
+    write_file(&snap_b.join("data.csv"), "id,name\n1,Ada Revised\n2,Bob\n");
+
+    let controller = controller_with_tabular_row_identity("diagnostic", "error");
+    let changeset = controller
+        .diff(
+            snap_a.to_string_lossy().as_ref(),
+            snap_b.to_string_lossy().as_ref(),
+        )
+        .unwrap();
+
+    assert!(changeset.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "binoc.duplicate-key"
+            && diagnostic.severity == DiagnosticSeverity::Error
+            && diagnostic.location.as_deref() == Some("data.csv")
+    }));
 }
 
 // ── Correlation detector (leaf-level move + copy) ─────────────────────

--- a/binoc-stdlib/tests/transformer_tests.rs
+++ b/binoc-stdlib/tests/transformer_tests.rs
@@ -16,6 +16,27 @@ fn null_cfg() -> serde_json::Value {
     serde_json::Value::Null
 }
 
+fn controller_with_declared_correspondence(dataset: serde_json::Value) -> Controller {
+    let registry = binoc_stdlib::default_registry();
+    let mut config = DatasetConfig::default_config();
+    config.transformers = vec!["binoc.declared_correspondence".into()];
+    config.dataset = dataset;
+    let resolved = registry.resolve(&config).unwrap();
+    Controller::new(resolved.comparators, resolved.transformers)
+        .with_transformer_configs(config.transformer_config.as_map())
+        .with_dataset_config(config.dataset.clone())
+}
+
+fn controller_with_dataset(dataset: serde_json::Value) -> Controller {
+    let registry = binoc_stdlib::default_registry();
+    let mut config = DatasetConfig::default_config();
+    config.dataset = dataset;
+    let resolved = registry.resolve(&config).unwrap();
+    Controller::new(resolved.comparators, resolved.transformers)
+        .with_transformer_configs(config.transformer_config.as_map())
+        .with_dataset_config(config.dataset.clone())
+}
+
 fn controller_with_tabular_row_identity(on_null_key: &str, on_duplicate_key: &str) -> Controller {
     let registry = binoc_stdlib::default_registry();
     let mut config = DatasetConfig::default_config();
@@ -42,6 +63,222 @@ fn write_file(path: &std::path::Path, contents: &str) {
         std::fs::create_dir_all(parent).unwrap();
     }
     std::fs::write(path, contents).unwrap();
+}
+
+fn null_key_dataset(policy: &str) -> serde_json::Value {
+    serde_json::json!({
+        "files": {
+            "correspondences": [{
+                "name": "null-key-test",
+                "left": { "path_regex": "^(?P<list>running_list)_as_of_[0-9]{4}\\.csv$" },
+                "right": { "path_regex": "^(?P<list>running_list)_as_of_[0-9]{4}\\.csv$" },
+                "key": "${missing}",
+                "logical_path": "${list}.csv",
+                "on_null_key": policy,
+                "on_duplicate_key": "diagnostic"
+            }]
+        }
+    })
+}
+
+fn duplicate_key_dataset(policy: &str) -> serde_json::Value {
+    serde_json::json!({
+        "files": {
+            "correspondences": [{
+                "name": "duplicate-key-test",
+                "left": { "path_regex": "^state_(?P<state>[A-Z]{2})_old\\.csv$" },
+                "right": { "path_regex": "^by-state/(?P<state>[A-Z]{2})/records-[0-9]+\\.csv$" },
+                "key": "${state}",
+                "logical_path": "states/${state}.csv",
+                "on_null_key": "diagnostic",
+                "on_duplicate_key": policy
+            }]
+        }
+    })
+}
+
+// ── Declared file correspondence identity failures ───────────────────
+
+#[test]
+fn declared_correspondence_null_key_diagnostic_succeeds() {
+    let tmp = tempfile::tempdir().unwrap();
+    let snap_a = tmp.path().join("snapshot-a");
+    let snap_b = tmp.path().join("snapshot-b");
+    write_file(&snap_a.join("running_list_as_of_2022.csv"), "name\nAda\n");
+    write_file(
+        &snap_b.join("running_list_as_of_2023.csv"),
+        "name\nAda\nGrace\n",
+    );
+
+    let controller = controller_with_declared_correspondence(null_key_dataset("diagnostic"));
+    let changeset = controller
+        .diff(
+            snap_a.to_string_lossy().as_ref(),
+            snap_b.to_string_lossy().as_ref(),
+        )
+        .unwrap();
+
+    assert!(changeset.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "binoc.declared_correspondence.null_key"
+            && diagnostic.severity == DiagnosticSeverity::Warning
+    }));
+}
+
+#[test]
+fn declared_correspondence_null_key_error_is_reported() {
+    let tmp = tempfile::tempdir().unwrap();
+    let snap_a = tmp.path().join("snapshot-a");
+    let snap_b = tmp.path().join("snapshot-b");
+    write_file(&snap_a.join("running_list_as_of_2022.csv"), "name\nAda\n");
+    write_file(
+        &snap_b.join("running_list_as_of_2023.csv"),
+        "name\nAda\nGrace\n",
+    );
+
+    let controller = controller_with_declared_correspondence(null_key_dataset("error"));
+    let changeset = controller
+        .diff(
+            snap_a.to_string_lossy().as_ref(),
+            snap_b.to_string_lossy().as_ref(),
+        )
+        .unwrap();
+
+    assert!(changeset.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "binoc.declared_correspondence.null_key"
+            && diagnostic.severity == DiagnosticSeverity::Error
+    }));
+}
+
+#[test]
+fn declared_correspondence_duplicate_key_diagnostic_succeeds() {
+    let tmp = tempfile::tempdir().unwrap();
+    let snap_a = tmp.path().join("snapshot-a");
+    let snap_b = tmp.path().join("snapshot-b");
+    write_file(&snap_a.join("state_AL_old.csv"), "id\n1\n");
+    write_file(&snap_b.join("by-state/AL/records-1.csv"), "id\n1\n");
+    write_file(&snap_b.join("by-state/AL/records-2.csv"), "id\n2\n");
+
+    let controller = controller_with_declared_correspondence(duplicate_key_dataset("diagnostic"));
+    let changeset = controller
+        .diff(
+            snap_a.to_string_lossy().as_ref(),
+            snap_b.to_string_lossy().as_ref(),
+        )
+        .unwrap();
+
+    assert!(changeset.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "binoc.declared_correspondence.duplicate_key"
+            && diagnostic.severity == DiagnosticSeverity::Warning
+            && diagnostic.message.contains("duplicate right key 'AL'")
+    }));
+}
+
+#[test]
+fn declared_correspondence_duplicate_key_error_is_reported() {
+    let tmp = tempfile::tempdir().unwrap();
+    let snap_a = tmp.path().join("snapshot-a");
+    let snap_b = tmp.path().join("snapshot-b");
+    write_file(&snap_a.join("state_AL_old.csv"), "id\n1\n");
+    write_file(&snap_b.join("by-state/AL/records-1.csv"), "id\n1\n");
+    write_file(&snap_b.join("by-state/AL/records-2.csv"), "id\n2\n");
+
+    let controller = controller_with_declared_correspondence(duplicate_key_dataset("error"));
+    let changeset = controller
+        .diff(
+            snap_a.to_string_lossy().as_ref(),
+            snap_b.to_string_lossy().as_ref(),
+        )
+        .unwrap();
+
+    assert!(changeset.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "binoc.declared_correspondence.duplicate_key"
+            && diagnostic.severity == DiagnosticSeverity::Error
+    }));
+}
+
+#[test]
+fn declared_correspondence_identical_content_without_path_reporting_is_pruned() {
+    let tmp = tempfile::tempdir().unwrap();
+    let snap_a = tmp.path().join("snapshot-a");
+    let snap_b = tmp.path().join("snapshot-b");
+    write_file(
+        &snap_a.join("running_list_as_of_2022.csv"),
+        "id,name\n1,Ada\n",
+    );
+    write_file(
+        &snap_b.join("running_list_as_of_2023.csv"),
+        "id,name\n1,Ada\n",
+    );
+
+    let controller = controller_with_declared_correspondence(serde_json::json!({
+        "files": {
+            "correspondences": [{
+                "name": "running-list",
+                "left": { "path_regex": "^(?P<list>running_list)_as_of_[0-9]{4}\\.csv$" },
+                "right": { "path_regex": "^(?P<list>running_list)_as_of_[0-9]{4}\\.csv$" },
+                "key": "${list}",
+                "logical_path": "${list}.csv",
+                "report_path_change": false
+            }]
+        }
+    }));
+    let changeset = controller
+        .diff(
+            snap_a.to_string_lossy().as_ref(),
+            snap_b.to_string_lossy().as_ref(),
+        )
+        .unwrap();
+
+    assert!(changeset.root.is_none());
+}
+
+#[test]
+fn declared_correspondence_extract_replays_physical_paths() {
+    let tmp = tempfile::tempdir().unwrap();
+    let snap_a = tmp.path().join("snapshot-a");
+    let snap_b = tmp.path().join("snapshot-b");
+    write_file(&snap_a.join("data/state_AL.csv"), "id,city\n1,Mobile\n");
+    write_file(
+        &snap_b.join("by-state/AL/records.csv"),
+        "id,city\n1,Mobile\n2,Selma\n",
+    );
+
+    let dataset = serde_json::json!({
+        "files": {
+            "correspondences": [{
+                "name": "state-records",
+                "left": { "path_regex": "^data/state_(?P<state>[A-Z]{2})\\.csv$" },
+                "right": { "path_regex": "^by-state/(?P<state>[A-Z]{2})/records\\.csv$" },
+                "key": "${state}",
+                "logical_path": "states/${state}.csv"
+            }]
+        }
+    });
+    let controller = controller_with_dataset(dataset);
+    let changeset = controller
+        .diff(
+            snap_a.to_string_lossy().as_ref(),
+            snap_b.to_string_lossy().as_ref(),
+        )
+        .unwrap();
+
+    let extract = controller
+        .extract(
+            &changeset,
+            "states/AL.csv",
+            "rows_added",
+            snap_a.to_string_lossy().as_ref(),
+            snap_b.to_string_lossy().as_ref(),
+        )
+        .unwrap();
+
+    match extract {
+        ExtractResult::Text(text) => {
+            assert!(text.contains("id,city"));
+            assert!(text.contains("2,Selma"));
+        }
+        ExtractResult::Binary(_) => panic!("expected text extract"),
+    }
 }
 
 // ── Tabular row identity failures ─────────────────────────────────────

--- a/docs/adr/2026-06-01-diagnostics_channel.md
+++ b/docs/adr/2026-06-01-diagnostics_channel.md
@@ -6,7 +6,8 @@
 ## Context
 
 Binoc needs a lightweight way to tell callers about missing metadata,
-configuration opportunities, or fallback behavior without failing a diff.
+configuration opportunities, identity problems, or fallback behavior without
+failing a diff.
 Several follow-up issues will emit this kind of guidance, so the shape needs to
 be structured, durable in changeset JSON, and independent of any one renderer.
 
@@ -18,7 +19,7 @@ cannot flood output.
 
 Binoc adds a top-level `Changeset.diagnostics` list. Each record has:
 
-- `severity`: `warning` or `suggestion`
+- `severity`: `error`, `warning`, or `suggestion`
 - `code`: a stable, package-qualified string such as `binoc.binary-fallback`
 - `message`: human-facing advisory text
 - `location`: optional logical node path
@@ -30,9 +31,14 @@ list, and then strips node-local transient diagnostics before returning the
 changeset.
 
 Renderers consume `Changeset.diagnostics` directly. The Markdown renderer shows
-short `Warnings` and `Suggestions` sections. Renderer implementations may also
-add renderer-specific diagnostics during rendering via the renderer trait hook;
-those are merged into a cloned changeset rather than mutating stored JSON.
+short `Errors`, `Warnings`, and `Suggestions` sections. Renderer
+implementations may also add renderer-specific diagnostics during rendering via
+the renderer trait hook; those are merged into a cloned changeset rather than
+mutating stored JSON.
+
+Error-severity diagnostics are reportable findings in the completed changeset,
+not controller-level aborts; see
+[Error Diagnostics Are Reportable Findings](2026-06-03-error_diagnostics_are_reportable_findings.md).
 
 ## Conventions
 

--- a/docs/adr/2026-06-03-error_diagnostics_are_reportable_findings.md
+++ b/docs/adr/2026-06-03-error_diagnostics_are_reportable_findings.md
@@ -1,0 +1,39 @@
+# Error Diagnostics Are Reportable Findings
+
+**Date:** 2026-06-03
+**Status:** Implemented
+
+## Context
+
+Dataset identity policies can encounter bad observed data: null row keys,
+duplicate row keys, or ambiguous declared file correspondence keys. These
+conditions are important enough that users may want automation to treat them as
+errors.
+
+At the same time, binoc's primary job is to compare whole snapshots. Aborting
+the entire diff because one file has a duplicate key throws away useful results
+from the rest of the dataset.
+
+## Decision
+
+`DiagnosticSeverity::Error` is a reportable finding in the completed changeset,
+not a controller-level abort condition.
+
+Identity policy `error` settings emit error-severity diagnostics and keep the
+conservative matching behavior: unsafe ambiguous rows or files are left
+unmatched, and the comparison continues. Callers can decide whether a completed
+changeset containing error diagnostics should fail CI or another workflow.
+
+Hard `BinocError` failures remain appropriate for failures that prevent the
+comparison from being constructed at all, such as unreadable snapshots,
+unresolvable comparator dispatch, or invalid API use.
+
+## Alternatives Considered
+
+The controller could stop on the first error diagnostic. This makes plugin
+diagnostics too powerful: a local identity problem in one file prevents users
+from seeing unrelated changes elsewhere in the snapshot.
+
+Plugins could use warnings for all observed data problems and leave "error" to
+the CLI. That loses the user's configured severity in library output and makes
+embedded callers reimplement policy interpretation.

--- a/docs/adr/2026-06-03-transformer_initiated_recompare.md
+++ b/docs/adr/2026-06-03-transformer_initiated_recompare.md
@@ -1,0 +1,50 @@
+# Transformer-Initiated Recompare as a Correspondence Contract
+
+**Date:** 2026-06-03
+**Status:** Implemented
+
+## Context
+
+Some transformers discover that two existing diff leaves represent the same
+logical item even though ordinary path-based dispatch reported them as an
+unrelated remove and add. Fuzzy rename detection does this from content
+similarity. Declared file correspondence does this from dataset config.
+
+In both cases the transformer should not parse raw file formats itself. The
+controller already owns comparator dispatch, and comparators already publish the
+artifacts later transformers need.
+
+## Decision
+
+`DiffNode::pending_recompare` is the contract for a transformer-discovered
+correspondence to ask the controller to re-run comparator dispatch for an
+explicit `ItemPair` and merge the result into the transformer's semantic wrapper
+node.
+
+The transformer owns the semantic wrapper: action, logical path, source path,
+tags, summaries, and details such as correspondence rule names. The controller
+owns re-dispatch and merge behavior:
+
+- content artifacts, comparator name, source items, child nodes, tags, and
+  details from the recomparison are merged into the wrapper;
+- recomparison failures are diagnostics, not silent no-ops;
+- identical recomparisons convert plain `modify` wrappers to `identical` so
+  they can be pruned, while semantic wrappers such as moves remain reportable;
+- durable source/destination path details can be used to replay extraction when
+  a wrapper's logical path differs from the physical snapshot paths.
+
+`pending_recompare` remains transient session data and is stripped before
+changeset output.
+
+## Alternatives Considered
+
+Transformers could call comparators directly. That would duplicate controller
+dispatch logic inside plugins and make ordering harder to reason about.
+
+Declared correspondence could be implemented as a comparator. That would put
+dataset-level identity policy into a format-specific layer and would not compose
+with nested or plugin-produced leaves.
+
+The controller could ignore identical recomparisons. That worked for some fuzzy
+move cases, but it leaves phantom `modify` nodes for declared correspondences
+whose content is unchanged.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -6,6 +6,8 @@ Newer entries appear first. Each entry shows its date and current status. Create
 
 | Date | Title | Status |
 |---|---|---|
+| 2026-06-03 | [Transformer-Initiated Recompare as a Correspondence Contract](2026-06-03-transformer_initiated_recompare.md) | Implemented |
+| 2026-06-03 | [Error Diagnostics Are Reportable Findings](2026-06-03-error_diagnostics_are_reportable_findings.md) | Implemented |
 | 2026-06-02 | [Markdown Renderer Groups Replace Significance-Map Grouping](2026-06-02-renderer_groups.md) | Implemented |
 | 2026-06-01 | [Unified Dataset Config and Identity Policy](2026-06-01-unified_dataset_config_and_identity.md) | Accepted |
 | 2026-06-01 | [Tabular Collection Artifact Model](2026-06-01-tabular_collection_artifact_model.md) | Accepted |

--- a/docs/explanation/test-vectors-gallery.md
+++ b/docs/explanation/test-vectors-gallery.md
@@ -13,7 +13,7 @@ audience: new user, data steward, archivist
 
 These are runnable examples from binoc's test suite. Each example links to its source folder on GitHub, tells you whether it needs any extra setup, gives you the exact command to run, and shows the Markdown changelog binoc is expected to print.
 
-Binoc currently ships **33 shared examples** in this gallery.
+Binoc currently ships **37 shared examples** in this gallery.
 
 ## One-time setup
 
@@ -34,6 +34,8 @@ just materialize
 | [`csv-column-addition`](#csv-column-addition) | New column added | data.csv: Column added: 'email' | Default pipeline |
 | [`csv-column-removal`](#csv-column-removal) | Column removed | data.csv: Column removed: 'city' | Default pipeline |
 | [`csv-column-reorder`](#csv-column-reorder) | Columns shuffled, content identical | data.csv: Columns reordered (content unchanged) | Custom config |
+| [`csv-keyed-null-duplicate`](#csv-keyed-null-duplicate) | Configured CSV row keys surface null and duplicate key diagnostics | data.csv: 4 rows added by key; 4 rows removed by key; 1 row modified by key | Default pipeline |
+| [`csv-keyed-row-diff`](#csv-keyed-row-diff) | Configured CSV row keys match reordered rows and report keyed row/cell changes | data.csv: 1 row added by key; 1 row removed by key; 1 row modified by key | Default pipeline |
 | [`csv-mixed-changes`](#csv-mixed-changes) | Multiple change types | data.csv: Column added: 'email'; columns reordered; 1 row added | Default pipeline |
 | [`csv-rename-modify`](#csv-rename-modify) | CSV renamed and a column added: detected as a single move with content diff via fuzzy correlation | data_v2.csv: Moved from data.csv (modified) | Default pipeline |
 | [`csv-row-addition`](#csv-row-addition) | New rows appended | data.csv: 2 rows added | Default pipeline |
@@ -43,6 +45,8 @@ just materialize
 | [`directory-file-copy`](#directory-file-copy) | New file with same content as an existing unchanged file detected as a copy | duplicate.txt: Copied from original.txt | Default pipeline |
 | [`directory-nested`](#directory-nested) | Subdirectories with mixed changes | data/extra.csv: New table (2 columns, 1 row) | Default pipeline |
 | [`directory-nested-with-tar`](#directory-nested-with-tar) | Shows binoc diffing a tar archive and a plain directory that contain overlapping internal paths. | data/records.csv: 1 row added | Default pipeline |
+| [`file-correspondence-scheme`](#file-correspondence-scheme) | Config declares that a state CSV moved into a new directory scheme is the same logical file | states/AL.csv: 1 row added | Default pipeline |
+| [`file-correspondence-token`](#file-correspondence-token) | Config declares that year-stamped CSV filenames are the same logical file | running_list.csv: 1 row added | Default pipeline |
 | [`folder-move-nested`](#folder-move-nested) | Detects a whole-folder rename and rolls many file moves up into one folder-move entry. | documentation: Folder moved from docs | Default pipeline |
 | [`folder-move-partial`](#folder-move-partial) | Detects a mostly-moved folder rename and preserves only the added/removed/modified remainder entries beneath it. | FoodData_Central_csv_2026-04-30: Folder moved from FoodData_Central_csv_2,025-12-18 | Custom config |
 | [`gzip-inner-dispatch`](#gzip-inner-dispatch) | Gzipped CSV and text are decompressed and redispatched under their inner names | census.txt: 1 line added, 1 removed | Default pipeline |
@@ -186,6 +190,57 @@ Result:
 # Changelog: snapshot-a → snapshot-b
 
 - **data.csv**: Columns reordered (content unchanged)
+```
+
+## csv-keyed-null-duplicate
+
+Configured CSV row keys surface null and duplicate key diagnostics
+
+- **Browse source:** [csv-keyed-null-duplicate](https://github.com/harvard-lil/binoc/tree/main/test-vectors/csv-keyed-null-duplicate)
+- **Tags:** `csv`, `keyed`, `null-key`, `duplicate-key`
+- **Snapshots:** `snapshot-a` has 1 file — `data.csv`; `snapshot-b` has 1 file — `data.csv`
+
+Run it:
+```bash
+binoc diff \
+  ./test-vectors-materialized/csv-keyed-null-duplicate/snapshot-a \
+  ./test-vectors-materialized/csv-keyed-null-duplicate/snapshot-b
+```
+Result:
+```markdown
+# Changelog: snapshot-a → snapshot-b
+
+- **data.csv**: 4 rows added by key; 4 rows removed by key; 1 row modified by key
+  - Changed cells; use `binoc extract CHANGESET "data.csv" cells_changed` for all changed cells
+    - key id 'b', column 'score': '20' -> '21'
+
+## Warnings
+
+- 2 rows had null configured key values (`data.csv`) [binoc.null-key]
+- 1 configured row key appeared more than once (`data.csv`) [binoc.duplicate-key]
+```
+
+## csv-keyed-row-diff
+
+Configured CSV row keys match reordered rows and report keyed row/cell changes
+
+- **Browse source:** [csv-keyed-row-diff](https://github.com/harvard-lil/binoc/tree/main/test-vectors/csv-keyed-row-diff)
+- **Tags:** `csv`, `keyed`, `row-addition`, `row-removal`, `cell-change`
+- **Snapshots:** `snapshot-a` has 1 file — `data.csv`; `snapshot-b` has 1 file — `data.csv`
+
+Run it:
+```bash
+binoc diff \
+  ./test-vectors-materialized/csv-keyed-row-diff/snapshot-a \
+  ./test-vectors-materialized/csv-keyed-row-diff/snapshot-b
+```
+Result:
+```markdown
+# Changelog: snapshot-a → snapshot-b
+
+- **data.csv**: 1 row added by key; 1 row removed by key; 1 row modified by key
+  - Changed cells; use `binoc extract CHANGESET "data.csv" cells_changed` for all changed cells
+    - key id 'p2', column 'price': '20' -> '25'
 ```
 
 ## csv-mixed-changes
@@ -398,6 +453,48 @@ Result:
 - **data.tar.gz/records.csv**: 1 cell changed
   - Changed cells; use `binoc extract CHANGESET "data.tar.gz/records.csv" cells_changed` for all changed cells
     - row 2, column 'count': '20' -> '25'
+```
+
+## file-correspondence-scheme
+
+Config declares that a state CSV moved into a new directory scheme is the same logical file
+
+- **Browse source:** [file-correspondence-scheme](https://github.com/harvard-lil/binoc/tree/main/test-vectors/file-correspondence-scheme)
+- **Tags:** `csv`, `file-correspondence`, `scheme-change`
+- **Snapshots:** `snapshot-a` has 1 file — `data/state_AL.csv`; `snapshot-b` has 1 file — `by-state/AL/records.csv`
+
+Run it:
+```bash
+binoc diff \
+  ./test-vectors-materialized/file-correspondence-scheme/snapshot-a \
+  ./test-vectors-materialized/file-correspondence-scheme/snapshot-b
+```
+Result:
+```markdown
+# Changelog: snapshot-a → snapshot-b
+
+- **states/AL.csv**: 1 row added
+```
+
+## file-correspondence-token
+
+Config declares that year-stamped CSV filenames are the same logical file
+
+- **Browse source:** [file-correspondence-token](https://github.com/harvard-lil/binoc/tree/main/test-vectors/file-correspondence-token)
+- **Tags:** `csv`, `file-correspondence`, `declared-correspondence`
+- **Snapshots:** `snapshot-a` has 1 file — `running_list_as_of_2022.csv`; `snapshot-b` has 1 file — `running_list_as_of_2023.csv`
+
+Run it:
+```bash
+binoc diff \
+  ./test-vectors-materialized/file-correspondence-token/snapshot-a \
+  ./test-vectors-materialized/file-correspondence-token/snapshot-b
+```
+Result:
+```markdown
+# Changelog: snapshot-a → snapshot-b
+
+- **running_list.csv**: 1 row added
 ```
 
 ## folder-move-nested

--- a/docs/reference/changeset-schema.json
+++ b/docs/reference/changeset-schema.json
@@ -212,6 +212,7 @@
     "DiagnosticSeverity": {
       "type": "string",
       "enum": [
+        "error",
         "warning",
         "suggestion"
       ]
@@ -278,7 +279,7 @@
           "type": "string"
         },
         "pending_recompare": {
-          "description": "Request that the controller re-dispatch the given `ItemPair` through\nthe comparator pipeline and merge the result into this node before\nthe next transformer runs. Set by transformers (e.g. fuzzy\ncorrelation) that have decided two leaves represent the same logical\nitem but need a content diff under the new (move) node. Session-\nscoped working data: wire-visible so plugins can set it across the\nABI boundary, but cleared by [`DiffNode::strip_transient`] before\nchangeset output. The controller takes (clears) this field as it\nprocesses it; nodes in a finalized changeset never carry it.",
+          "description": "Request that the controller re-dispatch the given `ItemPair` through\nthe comparator pipeline and merge the result into this semantic wrapper\nnode before the next transformer runs. Set by transformers that have\ndiscovered a correspondence (for example, a rename-with-edits or a\nconfig-declared logical file pair) but still need normal comparators to\nparse the paired content. If the recomparison is identical, a plain\n`modify` wrapper is converted to `identical` so it can be pruned, while\nsemantic wrappers such as moves remain reportable. Session-scoped\nworking data: wire-visible so plugins can set it across the ABI\nboundary, but cleared by [`DiffNode::strip_transient`] before changeset\noutput. The controller takes (clears) this field as it processes it;\nnodes in a finalized changeset never carry it.",
           "anyOf": [
             {
               "$ref": "#/$defs/ItemPair"

--- a/docs/reference/changeset-schema.md
+++ b/docs/reference/changeset-schema.md
@@ -81,7 +81,7 @@ A node in the diff tree — the central data structure of the system. Every comp
 | `diagnostics` | array of [`Diagnostic`](#diagnostic) | no | Node-scoped diagnostics emitted during comparison or transform. Transient: the controller hoists them into [`Changeset::diagnostics`] at the end of the diff, then clears this field so the output shape stays as one durable top-level diagnostics list. |
 | `item_type` | string | yes | Open string: "directory", "file", "tabular", "zip_archive", etc. No built-in types — conventions, not enforcement. |
 | `path` | string | yes | Location within snapshot (logical path, including interior paths like "archive.zip/data/file.csv"). |
-| `pending_recompare` | [`ItemPair`](#itempair) \| null | no | Request that the controller re-dispatch the given `ItemPair` through the comparator pipeline and merge the result into this node before the next transformer runs. Set by transformers (e.g. fuzzy correlation) that have decided two leaves represent the same logical item but need a content diff under the new (move) node. Session- scoped working data: wire-visible so plugins can set it across the ABI boundary, but cleared by [`DiffNode::strip_transient`] before changeset output. The controller takes (clears) this field as it processes it; nodes in a finalized changeset never carry it. |
+| `pending_recompare` | [`ItemPair`](#itempair) \| null | no | Request that the controller re-dispatch the given `ItemPair` through the comparator pipeline and merge the result into this semantic wrapper node before the next transformer runs. Set by transformers that have discovered a correspondence (for example, a rename-with-edits or a config-declared logical file pair) but still need normal comparators to parse the paired content. If the recomparison is identical, a plain `modify` wrapper is converted to `identical` so it can be pruned, while semantic wrappers such as moves remain reportable. Session-scoped working data: wire-visible so plugins can set it across the ABI boundary, but cleared by [`DiffNode::strip_transient`] before changeset output. The controller takes (clears) this field as it processes it; nodes in a finalized changeset never carry it. |
 | `source_items` | [`ItemPair`](#itempair) \| null | no | The original item pair that produced this node. Session-scoped working data: available during a live diff/transform session for transformers and extractors that need to re-read source data, and carried across the plugin ABI wire so separately-compiled plugins can access it. Callers writing changeset output must strip this via [`DiffNode::strip_transient`] before serializing. |
 | `source_path` | string \| null | no | For moves/renames: the original path. |
 | `summary` | string \| null | no | Optional human-readable one-liner describing the change. Set by comparator or transformer; used by renderers for narrative rendering. |
@@ -179,6 +179,7 @@ One bounded example inside a detail block.
 
 String enum. One of:
 
+- `error`
 - `warning`
 - `suggestion`
 

--- a/docs/reference/dataset-config.md
+++ b/docs/reference/dataset-config.md
@@ -195,6 +195,48 @@ dataset:
 `on_duplicate_key` accept `diagnostic`, `error`, or `ignore`; plugins decide how
 to apply those policies for the semantics they implement.
 
+### `dataset.tables`
+
+Tabular row identity is optional. Without it, `binoc.tabular_analyzer`
+keeps the positional fallback: row additions/removals are counted by
+row count differences, and changed cells are compared at the same row
+offset. With `row_identity.columns`, the analyzer builds a table-local
+key and matches rows by that key before reporting row additions,
+removals, and modified cells.
+
+```yaml
+dataset:
+  tables:
+    defaults:
+      row_identity:
+        on_null_key: diagnostic
+        on_duplicate_key: diagnostic
+    entries:
+      applications:
+        match:
+          logical_name: applications
+        row_identity:
+          columns: ['ApplNo']
+      products:
+        match:
+          source:
+            path_regex: '^data/products\.csv$'
+        row_identity:
+          columns: ['BLA Number', 'Product Number']
+```
+
+`match.logical_name` targets logical table children produced by
+multi-table comparators or the CSV table splitter. `match.source.path`
+and `match.source.path_regex` target the tabular node path or its
+source item path, which is useful for single CSV files.
+
+Rows with blank key components are null-key rows. Keys that appear more
+than once on either side are duplicate-key rows. The default
+`diagnostic` policy emits warnings and leaves those rows unmatched so
+normal add/remove counts still reflect them. `error` emits an error-severity
+diagnostic without stopping the comparison. `ignore` suppresses the diagnostic
+while keeping the same conservative matching behavior.
+
 ## `output.<renderer>`
 
 Each renderer gets its own config section, keyed by the renderer's

--- a/docs/reference/dataset-config.md
+++ b/docs/reference/dataset-config.md
@@ -227,11 +227,16 @@ dataset:
       columns: ['id']
     - logical_name: products
       columns: ['BLA Number', 'Product Number']
+    - path: workbook.xlsx
+      logical_name: Products
+      columns: ['id']
 ```
 
 Use `logical_name` for logical table children produced by multi-table
 comparators or the CSV table splitter. Use `path` or `path_regex` for ordinary
-single-file CSVs.
+single-file CSVs. When an entry includes both a source selector and
+`logical_name`, both must match; for example, the `workbook.xlsx` entry above
+targets the `Products` logical table inside that source item.
 
 When several entries should share the same identity failure policy, expand
 `tables` to an object with `defaults` and `entries`:

--- a/docs/reference/dataset-config.md
+++ b/docs/reference/dataset-config.md
@@ -59,19 +59,8 @@ dataset:
         on_null_key: diagnostic
         on_duplicate_key: diagnostic
   tables:
-    defaults:
-      parse:
-        header: true
-        delimiter: ','
-      row_identity:
-        on_null_key: diagnostic
-        on_duplicate_key: diagnostic
-    entries:
-      products:
-        match:
-          logical_name: products
-        row_identity:
-          columns: ['BLA Number', 'Product Number']
+    - logical_name: products
+      columns: ['BLA Number', 'Product Number']
 
 output:
   markdown:
@@ -159,10 +148,8 @@ common dataset semantics:
 
 - `dataset.files.correspondences` declares that files with different snapshot
   paths are the same logical file.
-- `dataset.tables.defaults` declares table-wide defaults, such as parse options
-  and row identity failure policy.
-- `dataset.tables.entries` declares per-table selectors, parse options, and row
-  identity keys.
+- `dataset.tables` declares table row keys. It can be a list for the common
+  case, or an object with `defaults` and `entries` when shared policy is useful.
 
 ```yaml
 dataset:
@@ -181,19 +168,10 @@ dataset:
         report_path_change: false
 
   tables:
-    defaults:
-      row_identity:
-        on_null_key: diagnostic
-        on_duplicate_key: diagnostic
-    entries:
-      products:
-        match:
-          logical_name: products
-        parse:
-          header: true
-          delimiter: ','
-        row_identity:
-          columns: ['BLA Number', 'Product Number']
+    - logical_name: products
+      columns: ['BLA Number', 'Product Number']
+    - path: data.csv
+      columns: ['id']
 ```
 
 `cardinality` is currently `one-to-one`. `on_null_key` and
@@ -236,12 +214,27 @@ diagnostics do not stop the snapshot comparison.
 
 ### `dataset.tables`
 
-Tabular row identity is optional. Without it, `binoc.tabular_analyzer`
-keeps the positional fallback: row additions/removals are counted by
-row count differences, and changed cells are compared at the same row
-offset. With `row_identity.columns`, the analyzer builds a table-local
-key and matches rows by that key before reporting row additions,
-removals, and modified cells.
+Tabular row identity is optional. Without it, `binoc.tabular_analyzer` keeps
+the positional fallback: row additions/removals are counted by row count
+differences, and changed cells are compared at the same row offset. With
+`columns`, the analyzer builds a table-local key and matches rows by that key
+before reporting row additions, removals, and modified cells.
+
+```yaml
+dataset:
+  tables:
+    - path: data.csv
+      columns: ['id']
+    - logical_name: products
+      columns: ['BLA Number', 'Product Number']
+```
+
+Use `logical_name` for logical table children produced by multi-table
+comparators or the CSV table splitter. Use `path` or `path_regex` for ordinary
+single-file CSVs.
+
+When several entries should share the same identity failure policy, expand
+`tables` to an object with `defaults` and `entries`:
 
 ```yaml
 dataset:
@@ -249,25 +242,16 @@ dataset:
     defaults:
       row_identity:
         on_null_key: diagnostic
-        on_duplicate_key: diagnostic
+        on_duplicate_key: error
     entries:
-      applications:
-        match:
-          logical_name: applications
-        row_identity:
-          columns: ['ApplNo']
-      products:
-        match:
-          source:
-            path_regex: '^data/products\.csv$'
-        row_identity:
-          columns: ['BLA Number', 'Product Number']
+      - logical_name: applications
+        columns: ['ApplNo']
+      - path_regex: '^data/products\.csv$'
+        columns: ['BLA Number', 'Product Number']
 ```
 
-`match.logical_name` targets logical table children produced by
-multi-table comparators or the CSV table splitter. `match.source.path`
-and `match.source.path_regex` target the tabular node path or its
-source item path, which is useful for single CSV files.
+For unusual cases, entries also accept explicit `match` and `row_identity`
+blocks, but the flat selector and `columns` form above is preferred.
 
 Rows with blank key components are null-key rows. Keys that appear more
 than once on either side are duplicate-key rows. The default

--- a/docs/reference/dataset-config.md
+++ b/docs/reference/dataset-config.md
@@ -37,25 +37,27 @@ comparators:
   - binoc.binary
 
 transformers:
+  - binoc.declared_correspondence
   - binoc.correlation_detector
+  - binoc.fuzzy_correlation_detector
   - binoc.folder_move_detector
+  - binoc.table_splitter
   - binoc.tabular_analyzer
   - binoc.column_reorder_detector
+  - binoc.table_collection_analyzer
 
 dataset:
   files:
     correspondences:
-      - name: quarterly-csvs
+      - name: running-list
         left:
-          path_regex: '^raw/(?P<table>[^/]+)/(?P<year>[0-9]{4})\.csv$'
+          path_regex: '^(?P<list>running_list)_as_of_[0-9]{4}\.csv$'
         right:
-          path_regex: '^normalized/(?P<year>[0-9]{4})/(?P<table>[^/]+)\.csv$'
-        key: '${table}:${year}'
-        logical_path: 'tables/${table}-${year}.csv'
-        cardinality: one-to-one
+          path_regex: '^(?P<list>running_list)_as_of_[0-9]{4}\.csv$'
+        key: '${list}'
+        logical_path: '${list}.csv'
         on_null_key: diagnostic
         on_duplicate_key: diagnostic
-
   tables:
     defaults:
       parse:
@@ -119,13 +121,16 @@ A list of transformer names, in the order they should run.
 Transformers rewrite the already-built IR tree; later transformers
 see the output of earlier ones.
 
-The default order is shown above. `binoc.correlation_detector` and
-`binoc.folder_move_detector` run first so that per-file moves and
-folder renames collapse before the tabular pipeline adds cell-level
-details. `binoc.tabular_analyzer` reads `tabular_v1` artifacts and
-attaches tags and summaries; `binoc.column_reorder_detector`
-downgrades pure column reorders to `action: "reorder"` after the
-analyzer has labeled them.
+The default order is shown above. `binoc.declared_correspondence` runs before
+heuristic correlation so user-declared file identity consumes matching
+add/remove leaves first. `binoc.correlation_detector`,
+`binoc.fuzzy_correlation_detector`, and `binoc.folder_move_detector` then
+collapse inferred per-file moves, rename-and-modify cases, and folder renames
+before the tabular pipeline adds cell-level details. `binoc.table_splitter`
+separates stacked logical tables before `binoc.tabular_analyzer` reads
+`tabular_v1` artifacts and attaches tags and summaries;
+`binoc.column_reorder_detector` downgrades pure column reorders to
+`action: "reorder"` after the analyzer has labeled them.
 
 See [Artifacts and composition](../explanation/artifacts-and-composition.md)
 for why the order matters and how to slot a third-party transformer
@@ -194,6 +199,40 @@ dataset:
 `cardinality` is currently `one-to-one`. `on_null_key` and
 `on_duplicate_key` accept `diagnostic`, `error`, or `ignore`; plugins decide how
 to apply those policies for the semantics they implement.
+
+### `dataset.files.correspondences`
+
+Declared correspondence rules tell binoc that an unmatched removed file and an
+unmatched added file are the same logical file even though their paths differ.
+When a rule produces one unambiguous left match and one unambiguous right match
+for the same key, binoc emits one logical correspondence node and re-runs the
+normal comparator pipeline on that pair. If `report_path_change` is false and
+the content is identical, the node is pruned like any other identical change.
+If `report_path_change` is true, binoc keeps a move-style path change node even
+when the content is identical.
+
+```yaml
+dataset:
+  files:
+    correspondences:
+      - name: state-records
+        left:
+          path_regex: '^data/state_(?P<state>[A-Z]{2})\.csv$'
+        right:
+          path_regex: '^by-state/(?P<state>[A-Z]{2})/records\.csv$'
+        key: '${state}'
+        logical_path: 'states/${state}.csv'
+        on_null_key: diagnostic
+        on_duplicate_key: diagnostic
+        report_path_change: false
+```
+
+`path_regex` uses named capture groups. `key` and `logical_path` are templates
+that substitute captures as `${name}`. If `logical_path` is omitted, the right
+path is used. Null keys, duplicate keys, one-to-many, and many-to-one matches
+are skipped by default with warning diagnostics; use `error` to emit an
+error-severity diagnostic or `ignore` to silence those diagnostics. Error
+diagnostics do not stop the snapshot comparison.
 
 ### `dataset.tables`
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -161,6 +161,8 @@ nav:
       - Architectural decisions:
           # BEGIN-ADR-NAV
           - adr/README.md
+          - 'Transformer-Initiated Recompare as a Correspondence Contract': adr/2026-06-03-transformer_initiated_recompare.md
+          - 'Error Diagnostics Are Reportable Findings': adr/2026-06-03-error_diagnostics_are_reportable_findings.md
           - 'Markdown Renderer Groups Replace Significance-Map Grouping': adr/2026-06-02-renderer_groups.md
           - 'Unified Dataset Config and Identity Policy': adr/2026-06-01-unified_dataset_config_and_identity.md
           - 'Tabular Collection Artifact Model': adr/2026-06-01-tabular_collection_artifact_model.md

--- a/test-vectors/binary-fallback-diagnostic/expected-output/abi-log.snap
+++ b/test-vectors/binary-fallback-diagnostic/expected-output/abi-log.snap
@@ -42,6 +42,11 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.declared_correspondence",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.correlation_detector",
     "data_ops": []
   },

--- a/test-vectors/csv-cell-changes/expected-output/abi-log.snap
+++ b/test-vectors/csv-cell-changes/expected-output/abi-log.snap
@@ -73,6 +73,11 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.declared_correspondence",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.correlation_detector",
     "data_ops": []
   },

--- a/test-vectors/csv-column-addition/expected-output/abi-log.snap
+++ b/test-vectors/csv-column-addition/expected-output/abi-log.snap
@@ -73,6 +73,11 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.declared_correspondence",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.correlation_detector",
     "data_ops": []
   },

--- a/test-vectors/csv-column-removal/expected-output/abi-log.snap
+++ b/test-vectors/csv-column-removal/expected-output/abi-log.snap
@@ -73,6 +73,11 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.declared_correspondence",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.correlation_detector",
     "data_ops": []
   },

--- a/test-vectors/csv-keyed-null-duplicate/expected-output/abi-log.snap
+++ b/test-vectors/csv-keyed-null-duplicate/expected-output/abi-log.snap
@@ -73,6 +73,11 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.declared_correspondence",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.correlation_detector",
     "data_ops": []
   },

--- a/test-vectors/csv-keyed-null-duplicate/expected-output/abi-log.snap
+++ b/test-vectors/csv-keyed-null-duplicate/expected-output/abi-log.snap
@@ -1,0 +1,137 @@
+---
+source: binoc-stdlib/src/test_vectors.rs
+expression: "&abi_log"
+---
+[
+  {
+    "method": "compare",
+    "plugin": "binoc.directory",
+    "data_ops": [
+      {
+        "op": "local_path",
+        "handle": ""
+      },
+      {
+        "op": "local_path",
+        "handle": ""
+      },
+      {
+        "op": "register_local",
+        "logical": "data.csv"
+      },
+      {
+        "op": "read_bytes",
+        "handle": "data.csv",
+        "result_size": 71
+      },
+      {
+        "op": "register_local",
+        "logical": "data.csv"
+      },
+      {
+        "op": "read_bytes",
+        "handle": "data.csv",
+        "result_size": 85
+      }
+    ]
+  },
+  {
+    "method": "compare",
+    "plugin": "binoc.csv",
+    "data_ops": [
+      {
+        "op": "local_path",
+        "handle": "data.csv"
+      },
+      {
+        "op": "local_path",
+        "handle": "data.csv"
+      },
+      {
+        "op": "publish_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "subject": "Left",
+        "producer": "binoc.csv",
+        "size": 139
+      },
+      {
+        "op": "publish_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "subject": "Right",
+        "producer": "binoc.csv",
+        "size": 153
+      }
+    ]
+  },
+  {
+    "method": "transform",
+    "plugin": "binoc.correlation_detector",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
+    "plugin": "binoc.fuzzy_correlation_detector",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
+    "plugin": "binoc.folder_move_detector",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
+    "plugin": "binoc.table_splitter",
+    "data_ops": [
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      },
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      }
+    ]
+  },
+  {
+    "method": "transform",
+    "plugin": "binoc.tabular_analyzer",
+    "data_ops": [
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      },
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      }
+    ]
+  }
+]

--- a/test-vectors/csv-keyed-null-duplicate/expected-output/changelog.snap
+++ b/test-vectors/csv-keyed-null-duplicate/expected-output/changelog.snap
@@ -1,0 +1,14 @@
+---
+source: binoc-stdlib/src/test_vectors.rs
+expression: "&md"
+---
+# Changelog: snapshot-a → snapshot-b
+
+- **data.csv**: 4 rows added by key; 4 rows removed by key; 1 row modified by key
+  - Changed cells; use `binoc extract CHANGESET "data.csv" cells_changed` for all changed cells
+    - key id 'b', column 'score': '20' -> '21'
+
+## Warnings
+
+- 2 rows had null configured key values (`data.csv`) [binoc.null-key]
+- 1 configured row key appeared more than once (`data.csv`) [binoc.duplicate-key]

--- a/test-vectors/csv-keyed-null-duplicate/expected-output/changeset.snap
+++ b/test-vectors/csv-keyed-null-duplicate/expected-output/changeset.snap
@@ -1,0 +1,161 @@
+---
+source: binoc-stdlib/src/test_vectors.rs
+expression: "&stable_changeset"
+---
+{
+  "from_snapshot": "snapshot-a",
+  "to_snapshot": "snapshot-b",
+  "root": {
+    "action": "modify",
+    "item_type": "directory",
+    "path": "",
+    "children": [
+      {
+        "action": "modify",
+        "item_type": "tabular",
+        "path": "data.csv",
+        "summary": "4 rows added by key; 4 rows removed by key; 1 row modified by key",
+        "tags": [
+          "binoc.ambiguous-key",
+          "binoc.cell-change",
+          "binoc.duplicate-key",
+          "binoc.identity-diagnostic",
+          "binoc.null-key",
+          "binoc.row-addition",
+          "binoc.row-identity-ambiguous",
+          "binoc.row-removal"
+        ],
+        "details": {
+          "cells_changed": 1,
+          "columns_added": [],
+          "columns_left": [
+            "id",
+            "name",
+            "score"
+          ],
+          "columns_removed": [],
+          "columns_right": [
+            "id",
+            "name",
+            "score"
+          ],
+          "hash_left": "a173bd43f55adf4e02c1a6e699cc47012df16ec03877484353b33b02e920a3fc",
+          "hash_right": "2fb4ebc136d454b2da8e6fb5bc09f286b003078e604b18e642c50f795e2b7fc4",
+          "row_identity": {
+            "columns": [
+              "id"
+            ],
+            "matched_rows": 1,
+            "mode": "keyed",
+            "on_duplicate_key": "diagnostic",
+            "on_null_key": "diagnostic"
+          },
+          "rows_added": 4,
+          "rows_added_keys": [
+            {
+              "key": null,
+              "row": 3
+            },
+            {
+              "key": {
+                "id": "c"
+              },
+              "row": 4
+            },
+            {
+              "key": {
+                "id": "dup"
+              },
+              "row": 1
+            },
+            {
+              "key": {
+                "id": "dup"
+              },
+              "row": 2
+            }
+          ],
+          "rows_left": 5,
+          "rows_modified": 1,
+          "rows_removed": 4,
+          "rows_removed_keys": [
+            {
+              "key": null,
+              "row": 1
+            },
+            {
+              "key": {
+                "id": "a"
+              },
+              "row": 0
+            },
+            {
+              "key": {
+                "id": "dup"
+              },
+              "row": 2
+            },
+            {
+              "key": {
+                "id": "dup"
+              },
+              "row": 3
+            }
+          ],
+          "rows_right": 5
+        },
+        "detail_blocks": [
+          {
+            "id": "cells_changed",
+            "kind": "binoc.tabular.cell_changes.v1",
+            "label": "Changed cells",
+            "total_count": 1,
+            "examples": [
+              {
+                "locator": {
+                  "column": "score",
+                  "key": {
+                    "id": "b"
+                  }
+                },
+                "before": {
+                  "value": "20",
+                  "media_type": "text/plain"
+                },
+                "after": {
+                  "value": "21",
+                  "media_type": "text/plain"
+                }
+              }
+            ],
+            "extract": [
+              {
+                "aspect": "cells_changed",
+                "label": "All changed cells"
+              }
+            ]
+          }
+        ],
+        "comparator": "binoc.csv",
+        "transformed_by": [
+          "binoc.tabular_analyzer"
+        ]
+      }
+    ],
+    "comparator": "binoc.directory"
+  },
+  "diagnostics": [
+    {
+      "severity": "warning",
+      "code": "binoc.null-key",
+      "message": "2 rows had null configured key values",
+      "location": "data.csv"
+    },
+    {
+      "severity": "warning",
+      "code": "binoc.duplicate-key",
+      "message": "1 configured row key appeared more than once",
+      "location": "data.csv"
+    }
+  ]
+}

--- a/test-vectors/csv-keyed-null-duplicate/manifest.toml
+++ b/test-vectors/csv-keyed-null-duplicate/manifest.toml
@@ -7,10 +7,8 @@ tags = ["csv", "keyed", "null-key", "duplicate-key"]
 on_null_key = "diagnostic"
 on_duplicate_key = "diagnostic"
 
-[config.dataset.tables.entries.people.match.source]
+[[config.dataset.tables.entries]]
 path_regex = '^data\.csv$'
-
-[config.dataset.tables.entries.people.row_identity]
 columns = ["id"]
 
 [expected]

--- a/test-vectors/csv-keyed-null-duplicate/manifest.toml
+++ b/test-vectors/csv-keyed-null-duplicate/manifest.toml
@@ -1,0 +1,26 @@
+[vector]
+name = "csv-keyed-null-duplicate"
+description = "Configured CSV row keys surface null and duplicate key diagnostics"
+tags = ["csv", "keyed", "null-key", "duplicate-key"]
+
+[config.dataset.tables.defaults.row_identity]
+on_null_key = "diagnostic"
+on_duplicate_key = "diagnostic"
+
+[config.dataset.tables.entries.people.match.source]
+path_regex = '^data\.csv$'
+
+[config.dataset.tables.entries.people.row_identity]
+columns = ["id"]
+
+[expected]
+root_action = "modify"
+has_tags = [
+  "binoc.row-addition",
+  "binoc.row-removal",
+  "binoc.cell-change",
+  "binoc.identity-diagnostic",
+  "binoc.null-key",
+  "binoc.duplicate-key",
+  "binoc.row-identity-ambiguous",
+]

--- a/test-vectors/csv-keyed-null-duplicate/snapshot-a/data.csv
+++ b/test-vectors/csv-keyed-null-duplicate/snapshot-a/data.csv
@@ -1,0 +1,6 @@
+id,name,score
+a,Alice,10
+,BadLeft,99
+dup,First,1
+dup,Second,2
+b,Bob,20

--- a/test-vectors/csv-keyed-null-duplicate/snapshot-b/data.csv
+++ b/test-vectors/csv-keyed-null-duplicate/snapshot-b/data.csv
@@ -1,0 +1,6 @@
+id,name,score
+b,Bob,21
+dup,First,1
+dup,Second changed,3
+,MissingRight,100
+c,Carol,30

--- a/test-vectors/csv-keyed-row-diff/expected-output/abi-log.snap
+++ b/test-vectors/csv-keyed-row-diff/expected-output/abi-log.snap
@@ -73,6 +73,11 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.declared_correspondence",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.correlation_detector",
     "data_ops": []
   },

--- a/test-vectors/csv-keyed-row-diff/expected-output/abi-log.snap
+++ b/test-vectors/csv-keyed-row-diff/expected-output/abi-log.snap
@@ -1,0 +1,137 @@
+---
+source: binoc-stdlib/src/test_vectors.rs
+expression: "&abi_log"
+---
+[
+  {
+    "method": "compare",
+    "plugin": "binoc.directory",
+    "data_ops": [
+      {
+        "op": "local_path",
+        "handle": ""
+      },
+      {
+        "op": "local_path",
+        "handle": ""
+      },
+      {
+        "op": "register_local",
+        "logical": "data.csv"
+      },
+      {
+        "op": "read_bytes",
+        "handle": "data.csv",
+        "result_size": 78
+      },
+      {
+        "op": "register_local",
+        "logical": "data.csv"
+      },
+      {
+        "op": "read_bytes",
+        "handle": "data.csv",
+        "result_size": 77
+      }
+    ]
+  },
+  {
+    "method": "compare",
+    "plugin": "binoc.csv",
+    "data_ops": [
+      {
+        "op": "local_path",
+        "handle": "data.csv"
+      },
+      {
+        "op": "local_path",
+        "handle": "data.csv"
+      },
+      {
+        "op": "publish_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "subject": "Left",
+        "producer": "binoc.csv",
+        "size": 138
+      },
+      {
+        "op": "publish_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "subject": "Right",
+        "producer": "binoc.csv",
+        "size": 137
+      }
+    ]
+  },
+  {
+    "method": "transform",
+    "plugin": "binoc.correlation_detector",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
+    "plugin": "binoc.fuzzy_correlation_detector",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
+    "plugin": "binoc.folder_move_detector",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
+    "plugin": "binoc.table_splitter",
+    "data_ops": [
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      },
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      }
+    ]
+  },
+  {
+    "method": "transform",
+    "plugin": "binoc.tabular_analyzer",
+    "data_ops": [
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      },
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      }
+    ]
+  }
+]

--- a/test-vectors/csv-keyed-row-diff/expected-output/changelog.snap
+++ b/test-vectors/csv-keyed-row-diff/expected-output/changelog.snap
@@ -1,0 +1,9 @@
+---
+source: binoc-stdlib/src/test_vectors.rs
+expression: "&md"
+---
+# Changelog: snapshot-a → snapshot-b
+
+- **data.csv**: 1 row added by key; 1 row removed by key; 1 row modified by key
+  - Changed cells; use `binoc extract CHANGESET "data.csv" cells_changed` for all changed cells
+    - key id 'p2', column 'price': '20' -> '25'

--- a/test-vectors/csv-keyed-row-diff/expected-output/changeset.snap
+++ b/test-vectors/csv-keyed-row-diff/expected-output/changeset.snap
@@ -1,0 +1,112 @@
+---
+source: binoc-stdlib/src/test_vectors.rs
+expression: "&stable_changeset"
+---
+{
+  "from_snapshot": "snapshot-a",
+  "to_snapshot": "snapshot-b",
+  "root": {
+    "action": "modify",
+    "item_type": "directory",
+    "path": "",
+    "children": [
+      {
+        "action": "modify",
+        "item_type": "tabular",
+        "path": "data.csv",
+        "summary": "1 row added by key; 1 row removed by key; 1 row modified by key",
+        "tags": [
+          "binoc.cell-change",
+          "binoc.row-addition",
+          "binoc.row-removal"
+        ],
+        "details": {
+          "cells_changed": 1,
+          "columns_added": [],
+          "columns_left": [
+            "id",
+            "name",
+            "price",
+            "status"
+          ],
+          "columns_removed": [],
+          "columns_right": [
+            "id",
+            "name",
+            "price",
+            "status"
+          ],
+          "hash_left": "6235797724098915a0a1aceb382bd1b91b206b0d403937299adce5c798dac5ad",
+          "hash_right": "a71e03436c2dd8c967acfa5a190b4fc35ed7b77d7e6260ccaf2dfaba0a4906b8",
+          "row_identity": {
+            "columns": [
+              "id"
+            ],
+            "matched_rows": 2,
+            "mode": "keyed",
+            "on_duplicate_key": "diagnostic",
+            "on_null_key": "diagnostic"
+          },
+          "rows_added": 1,
+          "rows_added_keys": [
+            {
+              "key": {
+                "id": "p4"
+              },
+              "row": 1
+            }
+          ],
+          "rows_left": 3,
+          "rows_modified": 1,
+          "rows_removed": 1,
+          "rows_removed_keys": [
+            {
+              "key": {
+                "id": "p3"
+              },
+              "row": 2
+            }
+          ],
+          "rows_right": 3
+        },
+        "detail_blocks": [
+          {
+            "id": "cells_changed",
+            "kind": "binoc.tabular.cell_changes.v1",
+            "label": "Changed cells",
+            "total_count": 1,
+            "examples": [
+              {
+                "locator": {
+                  "column": "price",
+                  "key": {
+                    "id": "p2"
+                  }
+                },
+                "before": {
+                  "value": "20",
+                  "media_type": "text/plain"
+                },
+                "after": {
+                  "value": "25",
+                  "media_type": "text/plain"
+                }
+              }
+            ],
+            "extract": [
+              {
+                "aspect": "cells_changed",
+                "label": "All changed cells"
+              }
+            ]
+          }
+        ],
+        "comparator": "binoc.csv",
+        "transformed_by": [
+          "binoc.tabular_analyzer"
+        ]
+      }
+    ],
+    "comparator": "binoc.directory"
+  }
+}

--- a/test-vectors/csv-keyed-row-diff/manifest.toml
+++ b/test-vectors/csv-keyed-row-diff/manifest.toml
@@ -1,0 +1,14 @@
+[vector]
+name = "csv-keyed-row-diff"
+description = "Configured CSV row keys match reordered rows and report keyed row/cell changes"
+tags = ["csv", "keyed", "row-addition", "row-removal", "cell-change"]
+
+[config.dataset.tables.entries.products.match.source]
+path_regex = '^data\.csv$'
+
+[config.dataset.tables.entries.products.row_identity]
+columns = ["id"]
+
+[expected]
+root_action = "modify"
+has_tags = ["binoc.row-addition", "binoc.row-removal", "binoc.cell-change"]

--- a/test-vectors/csv-keyed-row-diff/manifest.toml
+++ b/test-vectors/csv-keyed-row-diff/manifest.toml
@@ -3,10 +3,8 @@ name = "csv-keyed-row-diff"
 description = "Configured CSV row keys match reordered rows and report keyed row/cell changes"
 tags = ["csv", "keyed", "row-addition", "row-removal", "cell-change"]
 
-[config.dataset.tables.entries.products.match.source]
+[[config.dataset.tables]]
 path_regex = '^data\.csv$'
-
-[config.dataset.tables.entries.products.row_identity]
 columns = ["id"]
 
 [expected]

--- a/test-vectors/csv-keyed-row-diff/snapshot-a/data.csv
+++ b/test-vectors/csv-keyed-row-diff/snapshot-a/data.csv
@@ -1,0 +1,4 @@
+id,name,price,status
+p1,Alpha,10,active
+p2,Beta,20,active
+p3,Gamma,30,retired

--- a/test-vectors/csv-keyed-row-diff/snapshot-b/data.csv
+++ b/test-vectors/csv-keyed-row-diff/snapshot-b/data.csv
@@ -1,0 +1,4 @@
+id,name,price,status
+p2,Beta,25,active
+p4,Delta,40,active
+p1,Alpha,10,active

--- a/test-vectors/csv-mixed-changes/expected-output/abi-log.snap
+++ b/test-vectors/csv-mixed-changes/expected-output/abi-log.snap
@@ -73,6 +73,11 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.declared_correspondence",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.correlation_detector",
     "data_ops": []
   },

--- a/test-vectors/csv-rename-modify/expected-output/abi-log.snap
+++ b/test-vectors/csv-rename-modify/expected-output/abi-log.snap
@@ -79,6 +79,11 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.declared_correspondence",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.correlation_detector",
     "data_ops": []
   },

--- a/test-vectors/csv-row-addition/expected-output/abi-log.snap
+++ b/test-vectors/csv-row-addition/expected-output/abi-log.snap
@@ -73,6 +73,11 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.declared_correspondence",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.correlation_detector",
     "data_ops": []
   },

--- a/test-vectors/csv-row-removal/expected-output/abi-log.snap
+++ b/test-vectors/csv-row-removal/expected-output/abi-log.snap
@@ -73,6 +73,11 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.declared_correspondence",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.correlation_detector",
     "data_ops": []
   },

--- a/test-vectors/csv-stacked-tables/expected-output/abi-log.snap
+++ b/test-vectors/csv-stacked-tables/expected-output/abi-log.snap
@@ -73,6 +73,11 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.declared_correspondence",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.correlation_detector",
     "data_ops": []
   },

--- a/test-vectors/csv-verbosity-full/expected-output/abi-log.snap
+++ b/test-vectors/csv-verbosity-full/expected-output/abi-log.snap
@@ -73,6 +73,11 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.declared_correspondence",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.correlation_detector",
     "data_ops": []
   },

--- a/test-vectors/directory-file-copy/expected-output/abi-log.snap
+++ b/test-vectors/directory-file-copy/expected-output/abi-log.snap
@@ -57,6 +57,11 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.declared_correspondence",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.correlation_detector",
     "data_ops": []
   },

--- a/test-vectors/directory-nested-with-tar/expected-output/abi-log.snap
+++ b/test-vectors/directory-nested-with-tar/expected-output/abi-log.snap
@@ -209,6 +209,11 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.declared_correspondence",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.correlation_detector",
     "data_ops": []
   },

--- a/test-vectors/directory-nested/expected-output/abi-log.snap
+++ b/test-vectors/directory-nested/expected-output/abi-log.snap
@@ -181,6 +181,11 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.declared_correspondence",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.correlation_detector",
     "data_ops": []
   },

--- a/test-vectors/file-correspondence-scheme/expected-output/abi-log.snap
+++ b/test-vectors/file-correspondence-scheme/expected-output/abi-log.snap
@@ -1,0 +1,226 @@
+---
+source: binoc-stdlib/src/test_vectors.rs
+expression: "&abi_log"
+---
+[
+  {
+    "method": "compare",
+    "plugin": "binoc.directory",
+    "data_ops": [
+      {
+        "op": "local_path",
+        "handle": ""
+      },
+      {
+        "op": "local_path",
+        "handle": ""
+      },
+      {
+        "op": "register_local",
+        "logical": "by-state"
+      },
+      {
+        "op": "register_local",
+        "logical": "data"
+      }
+    ]
+  },
+  {
+    "method": "compare",
+    "plugin": "binoc.directory",
+    "data_ops": [
+      {
+        "op": "local_path",
+        "handle": "by-state"
+      },
+      {
+        "op": "register_local",
+        "logical": "by-state/AL"
+      }
+    ]
+  },
+  {
+    "method": "compare",
+    "plugin": "binoc.directory",
+    "data_ops": [
+      {
+        "op": "local_path",
+        "handle": "by-state/AL"
+      },
+      {
+        "op": "register_local",
+        "logical": "by-state/AL/records.csv"
+      },
+      {
+        "op": "read_bytes",
+        "handle": "by-state/AL/records.csv",
+        "result_size": 34
+      }
+    ]
+  },
+  {
+    "method": "compare",
+    "plugin": "binoc.csv",
+    "data_ops": [
+      {
+        "op": "local_path",
+        "handle": "by-state/AL/records.csv"
+      },
+      {
+        "op": "publish_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "subject": "Right",
+        "producer": "binoc.csv",
+        "size": 72
+      }
+    ]
+  },
+  {
+    "method": "compare",
+    "plugin": "binoc.directory",
+    "data_ops": [
+      {
+        "op": "local_path",
+        "handle": "data"
+      },
+      {
+        "op": "register_local",
+        "logical": "data/state_AL.csv"
+      },
+      {
+        "op": "read_bytes",
+        "handle": "data/state_AL.csv",
+        "result_size": 21
+      }
+    ]
+  },
+  {
+    "method": "compare",
+    "plugin": "binoc.csv",
+    "data_ops": [
+      {
+        "op": "local_path",
+        "handle": "data/state_AL.csv"
+      },
+      {
+        "op": "publish_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "subject": "Left",
+        "producer": "binoc.csv",
+        "size": 53
+      }
+    ]
+  },
+  {
+    "method": "transform",
+    "plugin": "binoc.declared_correspondence",
+    "data_ops": []
+  },
+  {
+    "method": "compare",
+    "plugin": "binoc.csv",
+    "data_ops": [
+      {
+        "op": "local_path",
+        "handle": "states/AL.csv"
+      },
+      {
+        "op": "local_path",
+        "handle": "states/AL.csv"
+      },
+      {
+        "op": "publish_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "subject": "Left",
+        "producer": "binoc.csv",
+        "size": 53
+      },
+      {
+        "op": "publish_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "subject": "Right",
+        "producer": "binoc.csv",
+        "size": 72
+      }
+    ]
+  },
+  {
+    "method": "transform",
+    "plugin": "binoc.correlation_detector",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
+    "plugin": "binoc.fuzzy_correlation_detector",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
+    "plugin": "binoc.folder_move_detector",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
+    "plugin": "binoc.table_splitter",
+    "data_ops": [
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      },
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      }
+    ]
+  },
+  {
+    "method": "transform",
+    "plugin": "binoc.tabular_analyzer",
+    "data_ops": [
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      },
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      }
+    ]
+  }
+]

--- a/test-vectors/file-correspondence-scheme/expected-output/changelog.snap
+++ b/test-vectors/file-correspondence-scheme/expected-output/changelog.snap
@@ -1,0 +1,7 @@
+---
+source: binoc-stdlib/src/test_vectors.rs
+expression: "&md"
+---
+# Changelog: snapshot-a → snapshot-b
+
+- **states/AL.csv**: 1 row added

--- a/test-vectors/file-correspondence-scheme/expected-output/changeset.snap
+++ b/test-vectors/file-correspondence-scheme/expected-output/changeset.snap
@@ -1,0 +1,56 @@
+---
+source: binoc-stdlib/src/test_vectors.rs
+expression: "&stable_changeset"
+---
+{
+  "from_snapshot": "snapshot-a",
+  "to_snapshot": "snapshot-b",
+  "root": {
+    "action": "modify",
+    "item_type": "directory",
+    "path": "",
+    "children": [
+      {
+        "action": "modify",
+        "item_type": "tabular",
+        "path": "states/AL.csv",
+        "summary": "1 row added",
+        "tags": [
+          "binoc.declared-correspondence",
+          "binoc.row-addition"
+        ],
+        "details": {
+          "cells_changed": 0,
+          "columns_added": [],
+          "columns_left": [
+            "id",
+            "city"
+          ],
+          "columns_removed": [],
+          "columns_right": [
+            "id",
+            "city"
+          ],
+          "correspondence_key": "AL",
+          "correspondence_rule": "state-records",
+          "destination_path": "by-state/AL/records.csv",
+          "hash_left": "eff803d89835b196a34290b8962335829020b8b8977420dd33f3e1cf00e1a311",
+          "hash_right": "393887ee3fd7d1a896bd16c503c9701699129a12467fb4b0595243b3494d0cd4",
+          "rows_added": 1,
+          "rows_left": 1,
+          "rows_removed": 0,
+          "rows_right": 2,
+          "source_path": "data/state_AL.csv"
+        },
+        "comparator": "binoc.csv",
+        "transformed_by": [
+          "binoc.tabular_analyzer"
+        ]
+      }
+    ],
+    "comparator": "binoc.directory",
+    "transformed_by": [
+      "binoc.declared_correspondence"
+    ]
+  }
+}

--- a/test-vectors/file-correspondence-scheme/manifest.toml
+++ b/test-vectors/file-correspondence-scheme/manifest.toml
@@ -1,0 +1,22 @@
+[vector]
+name = "file-correspondence-scheme"
+description = "Config declares that a state CSV moved into a new directory scheme is the same logical file"
+tags = ["csv", "file-correspondence", "scheme-change"]
+
+[config.dataset.files]
+[[config.dataset.files.correspondences]]
+name = "state-records"
+key = "${state}"
+logical_path = "states/${state}.csv"
+on_null_key = "diagnostic"
+on_duplicate_key = "diagnostic"
+
+[config.dataset.files.correspondences.left]
+path_regex = "^data/state_(?P<state>[A-Z]{2})\\.csv$"
+
+[config.dataset.files.correspondences.right]
+path_regex = "^by-state/(?P<state>[A-Z]{2})/records\\.csv$"
+
+[expected]
+child_count = 1
+has_tags = ["binoc.declared-correspondence", "binoc.row-addition"]

--- a/test-vectors/file-correspondence-scheme/snapshot-a/data/state_AL.csv
+++ b/test-vectors/file-correspondence-scheme/snapshot-a/data/state_AL.csv
@@ -1,0 +1,2 @@
+id,city
+1,Montgomery

--- a/test-vectors/file-correspondence-scheme/snapshot-b/by-state/AL/records.csv
+++ b/test-vectors/file-correspondence-scheme/snapshot-b/by-state/AL/records.csv
@@ -1,0 +1,3 @@
+id,city
+1,Montgomery
+2,Birmingham

--- a/test-vectors/file-correspondence-token/expected-output/abi-log.snap
+++ b/test-vectors/file-correspondence-token/expected-output/abi-log.snap
@@ -1,0 +1,184 @@
+---
+source: binoc-stdlib/src/test_vectors.rs
+expression: "&abi_log"
+---
+[
+  {
+    "method": "compare",
+    "plugin": "binoc.directory",
+    "data_ops": [
+      {
+        "op": "local_path",
+        "handle": ""
+      },
+      {
+        "op": "local_path",
+        "handle": ""
+      },
+      {
+        "op": "register_local",
+        "logical": "running_list_as_of_2023.csv"
+      },
+      {
+        "op": "read_bytes",
+        "handle": "running_list_as_of_2023.csv",
+        "result_size": 25
+      },
+      {
+        "op": "register_local",
+        "logical": "running_list_as_of_2022.csv"
+      },
+      {
+        "op": "read_bytes",
+        "handle": "running_list_as_of_2022.csv",
+        "result_size": 20
+      }
+    ]
+  },
+  {
+    "method": "compare",
+    "plugin": "binoc.csv",
+    "data_ops": [
+      {
+        "op": "local_path",
+        "handle": "running_list_as_of_2023.csv"
+      },
+      {
+        "op": "publish_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "subject": "Right",
+        "producer": "binoc.csv",
+        "size": 69
+      }
+    ]
+  },
+  {
+    "method": "compare",
+    "plugin": "binoc.csv",
+    "data_ops": [
+      {
+        "op": "local_path",
+        "handle": "running_list_as_of_2022.csv"
+      },
+      {
+        "op": "publish_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "subject": "Left",
+        "producer": "binoc.csv",
+        "size": 58
+      }
+    ]
+  },
+  {
+    "method": "transform",
+    "plugin": "binoc.declared_correspondence",
+    "data_ops": []
+  },
+  {
+    "method": "compare",
+    "plugin": "binoc.csv",
+    "data_ops": [
+      {
+        "op": "local_path",
+        "handle": "running_list.csv"
+      },
+      {
+        "op": "local_path",
+        "handle": "running_list.csv"
+      },
+      {
+        "op": "publish_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "subject": "Left",
+        "producer": "binoc.csv",
+        "size": 58
+      },
+      {
+        "op": "publish_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "subject": "Right",
+        "producer": "binoc.csv",
+        "size": 69
+      }
+    ]
+  },
+  {
+    "method": "transform",
+    "plugin": "binoc.correlation_detector",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
+    "plugin": "binoc.fuzzy_correlation_detector",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
+    "plugin": "binoc.folder_move_detector",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
+    "plugin": "binoc.table_splitter",
+    "data_ops": [
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      },
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      }
+    ]
+  },
+  {
+    "method": "transform",
+    "plugin": "binoc.tabular_analyzer",
+    "data_ops": [
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      },
+      {
+        "op": "get_artifact",
+        "format": {
+          "package": "binoc",
+          "name": "tabular",
+          "version": 1
+        },
+        "found": true
+      }
+    ]
+  }
+]

--- a/test-vectors/file-correspondence-token/expected-output/changelog.snap
+++ b/test-vectors/file-correspondence-token/expected-output/changelog.snap
@@ -1,0 +1,7 @@
+---
+source: binoc-stdlib/src/test_vectors.rs
+expression: "&md"
+---
+# Changelog: snapshot-a → snapshot-b
+
+- **running_list.csv**: 1 row added

--- a/test-vectors/file-correspondence-token/expected-output/changeset.snap
+++ b/test-vectors/file-correspondence-token/expected-output/changeset.snap
@@ -1,0 +1,56 @@
+---
+source: binoc-stdlib/src/test_vectors.rs
+expression: "&stable_changeset"
+---
+{
+  "from_snapshot": "snapshot-a",
+  "to_snapshot": "snapshot-b",
+  "root": {
+    "action": "modify",
+    "item_type": "directory",
+    "path": "",
+    "children": [
+      {
+        "action": "modify",
+        "item_type": "tabular",
+        "path": "running_list.csv",
+        "summary": "1 row added",
+        "tags": [
+          "binoc.declared-correspondence",
+          "binoc.row-addition"
+        ],
+        "details": {
+          "cells_changed": 0,
+          "columns_added": [],
+          "columns_left": [
+            "id",
+            "name"
+          ],
+          "columns_removed": [],
+          "columns_right": [
+            "id",
+            "name"
+          ],
+          "correspondence_key": "running_list",
+          "correspondence_rule": "running-list",
+          "destination_path": "running_list_as_of_2023.csv",
+          "hash_left": "962813cd557c5c6641908d7cb6e6df7ece7224b661726f7f73a68f291d7fabd5",
+          "hash_right": "986fc8e7e20e252afd58def4e2901fd8de66b0f1792f6f2885c7a0d2e4fe1e51",
+          "rows_added": 1,
+          "rows_left": 2,
+          "rows_removed": 0,
+          "rows_right": 3,
+          "source_path": "running_list_as_of_2022.csv"
+        },
+        "comparator": "binoc.csv",
+        "transformed_by": [
+          "binoc.tabular_analyzer"
+        ]
+      }
+    ],
+    "comparator": "binoc.directory",
+    "transformed_by": [
+      "binoc.declared_correspondence"
+    ]
+  }
+}

--- a/test-vectors/file-correspondence-token/manifest.toml
+++ b/test-vectors/file-correspondence-token/manifest.toml
@@ -1,0 +1,22 @@
+[vector]
+name = "file-correspondence-token"
+description = "Config declares that year-stamped CSV filenames are the same logical file"
+tags = ["csv", "file-correspondence", "declared-correspondence"]
+
+[config.dataset.files]
+[[config.dataset.files.correspondences]]
+name = "running-list"
+key = "${list}"
+logical_path = "${list}.csv"
+on_null_key = "diagnostic"
+on_duplicate_key = "diagnostic"
+
+[config.dataset.files.correspondences.left]
+path_regex = "^(?P<list>running_list)_as_of_[0-9]{4}\\.csv$"
+
+[config.dataset.files.correspondences.right]
+path_regex = "^(?P<list>running_list)_as_of_[0-9]{4}\\.csv$"
+
+[expected]
+child_count = 1
+has_tags = ["binoc.declared-correspondence", "binoc.row-addition"]

--- a/test-vectors/file-correspondence-token/snapshot-a/running_list_as_of_2022.csv
+++ b/test-vectors/file-correspondence-token/snapshot-a/running_list_as_of_2022.csv
@@ -1,0 +1,3 @@
+id,name
+1,Ada
+2,Ben

--- a/test-vectors/file-correspondence-token/snapshot-b/running_list_as_of_2023.csv
+++ b/test-vectors/file-correspondence-token/snapshot-b/running_list_as_of_2023.csv
@@ -1,0 +1,4 @@
+id,name
+1,Ada
+2,Ben
+3,Cy

--- a/test-vectors/folder-move-nested/expected-output/abi-log.snap
+++ b/test-vectors/folder-move-nested/expected-output/abi-log.snap
@@ -263,6 +263,11 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.declared_correspondence",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.correlation_detector",
     "data_ops": []
   },

--- a/test-vectors/folder-move-partial/expected-output/abi-log.snap
+++ b/test-vectors/folder-move-partial/expected-output/abi-log.snap
@@ -593,6 +593,11 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.declared_correspondence",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.correlation_detector",
     "data_ops": []
   },

--- a/test-vectors/gzip-inner-dispatch/expected-output/abi-log.snap
+++ b/test-vectors/gzip-inner-dispatch/expected-output/abi-log.snap
@@ -163,6 +163,11 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.declared_correspondence",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.correlation_detector",
     "data_ops": []
   },

--- a/test-vectors/kitchen-sink/expected-output/abi-log.snap
+++ b/test-vectors/kitchen-sink/expected-output/abi-log.snap
@@ -532,6 +532,11 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.declared_correspondence",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.correlation_detector",
     "data_ops": []
   },

--- a/test-vectors/single-file-add/expected-output/abi-log.snap
+++ b/test-vectors/single-file-add/expected-output/abi-log.snap
@@ -39,6 +39,11 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.declared_correspondence",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.correlation_detector",
     "data_ops": []
   },

--- a/test-vectors/single-file-modify-binary/expected-output/abi-log.snap
+++ b/test-vectors/single-file-modify-binary/expected-output/abi-log.snap
@@ -42,6 +42,11 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.declared_correspondence",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.correlation_detector",
     "data_ops": []
   },

--- a/test-vectors/single-file-modify-csv/expected-output/abi-log.snap
+++ b/test-vectors/single-file-modify-csv/expected-output/abi-log.snap
@@ -41,6 +41,11 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.declared_correspondence",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.correlation_detector",
     "data_ops": []
   },

--- a/test-vectors/single-file-modify-text-root/expected-output/abi-log.snap
+++ b/test-vectors/single-file-modify-text-root/expected-output/abi-log.snap
@@ -21,6 +21,11 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.declared_correspondence",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.correlation_detector",
     "data_ops": []
   },

--- a/test-vectors/single-file-modify-text/expected-output/abi-log.snap
+++ b/test-vectors/single-file-modify-text/expected-output/abi-log.snap
@@ -53,6 +53,11 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.declared_correspondence",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.correlation_detector",
     "data_ops": []
   },

--- a/test-vectors/single-file-remove/expected-output/abi-log.snap
+++ b/test-vectors/single-file-remove/expected-output/abi-log.snap
@@ -39,6 +39,11 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.declared_correspondence",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.correlation_detector",
     "data_ops": []
   },

--- a/test-vectors/tar-nested/expected-output/abi-log.snap
+++ b/test-vectors/tar-nested/expected-output/abi-log.snap
@@ -193,6 +193,11 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.declared_correspondence",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.correlation_detector",
     "data_ops": []
   },

--- a/test-vectors/tar-simple/expected-output/abi-log.snap
+++ b/test-vectors/tar-simple/expected-output/abi-log.snap
@@ -167,6 +167,11 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.declared_correspondence",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.correlation_detector",
     "data_ops": []
   },

--- a/test-vectors/text-rename-modify/expected-output/abi-log.snap
+++ b/test-vectors/text-rename-modify/expected-output/abi-log.snap
@@ -59,6 +59,11 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.declared_correspondence",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.correlation_detector",
     "data_ops": []
   },

--- a/test-vectors/tree-wide-correlation/expected-output/abi-log.snap
+++ b/test-vectors/tree-wide-correlation/expected-output/abi-log.snap
@@ -359,6 +359,11 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.declared_correspondence",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.correlation_detector",
     "data_ops": []
   },

--- a/test-vectors/trivial-identical-csv/expected-output/abi-log.snap
+++ b/test-vectors/trivial-identical-csv/expected-output/abi-log.snap
@@ -37,6 +37,11 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.declared_correspondence",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.correlation_detector",
     "data_ops": []
   },

--- a/test-vectors/trivial-identical/expected-output/abi-log.snap
+++ b/test-vectors/trivial-identical/expected-output/abi-log.snap
@@ -37,6 +37,11 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.declared_correspondence",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.correlation_detector",
     "data_ops": []
   },

--- a/test-vectors/tsv-cell-changes/expected-output/abi-log.snap
+++ b/test-vectors/tsv-cell-changes/expected-output/abi-log.snap
@@ -73,6 +73,11 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.declared_correspondence",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.correlation_detector",
     "data_ops": []
   },

--- a/test-vectors/zip-nested/expected-output/abi-log.snap
+++ b/test-vectors/zip-nested/expected-output/abi-log.snap
@@ -193,6 +193,11 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.declared_correspondence",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.correlation_detector",
     "data_ops": []
   },

--- a/test-vectors/zip-simple/expected-output/abi-log.snap
+++ b/test-vectors/zip-simple/expected-output/abi-log.snap
@@ -133,6 +133,11 @@ expression: "&abi_log"
   },
   {
     "method": "transform",
+    "plugin": "binoc.declared_correspondence",
+    "data_ops": []
+  },
+  {
+    "method": "transform",
     "plugin": "binoc.correlation_detector",
     "data_ops": []
   },


### PR DESCRIPTION
## Summary

Adds dataset-configured identity semantics for tabular rows and file correspondence.

- keyed tabular diffs match rows by configured key columns before reporting row additions, removals, modified rows, and changed cells
- declared file correspondence pairs removed/added files by configured selectors and key templates, then re-runs normal comparator dispatch on the logical pair
- identity failures can emit warning or error diagnostics without aborting the snapshot comparison
- `pending_recompare` is now the controller contract for correspondence wrappers that need normal comparator parsing

## Config examples

Common keyed CSV case:

```yaml
dataset:
  tables:
    - path: data.csv
      columns: ['id']
```

Logical table children can be selected by producer-assigned name, or by source path plus logical name. When both are present, both must match:

```yaml
dataset:
  tables:
    - logical_name: products
      columns: ['BLA Number', 'Product Number']
    - path: workbook.xlsx
      logical_name: Products
      columns: ['id']
    - path_regex: '^data/products\\.csv$'
      columns: ['id']
```

Shared row identity policy:

```yaml
dataset:
  tables:
    defaults:
      row_identity:
        on_null_key: diagnostic
        on_duplicate_key: error
    entries:
      - logical_name: applications
        columns: ['ApplNo']
```

Declared file correspondence:

```yaml
dataset:
  files:
    correspondences:
      - name: state-files
        left:
          path_regex: '^data/state_(?P<state>[A-Z]{2})\\.csv$'
        right:
          path_regex: '^by-state/(?P<state>[A-Z]{2})/records\\.csv$'
        key: '${state}'
        logical_path: 'states/${state}.csv'
        report_path_change: true
```

## Design notes

This keeps the core type-ignorant: file correspondence and row identity live in dataset config and stdlib transformers, while the controller only owns re-dispatch and merge mechanics. Error diagnostics are reportable findings in the completed changeset rather than hard aborts; callers can decide whether those diagnostics should fail CI.

Two ADRs record the cross-cutting pieces:

- Transformer-Initiated Recompare as a Correspondence Contract
- Error Diagnostics Are Reportable Findings
