### PR TITLE
Harden CSV encoding handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,6 +233,8 @@ dependencies = [
  "binoc-sdk",
  "blake3",
  "csv",
+ "encoding_rs",
+ "encoding_rs_io",
  "flate2",
  "infer",
  "insta",
@@ -521,6 +523,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
 ]
 
 [[package]]

--- a/binoc-stdlib/Cargo.toml
+++ b/binoc-stdlib/Cargo.toml
@@ -25,6 +25,8 @@ binoc-sdk = { workspace = true }
 binoc-core = { workspace = true }
 blake3 = "1.8.5"
 csv = "1.4.0"
+encoding_rs = "0.8.35"
+encoding_rs_io = "0.1.7"
 infer = "0.19"
 mime_guess = "2.0.5"
 regex = "1.12.2"

--- a/binoc-stdlib/src/comparators/csv_compare.rs
+++ b/binoc-stdlib/src/comparators/csv_compare.rs
@@ -1,7 +1,10 @@
-use std::io::BufReader;
+use std::borrow::Cow;
+use std::io::{BufRead, BufReader, Read};
 use std::path::Path;
 
 use binoc_sdk::*;
+use encoding_rs::{Encoding, UTF_8, WINDOWS_1252};
+use encoding_rs_io::DecodeReaderBytesBuilder;
 
 /// Thin CSV comparator: parses CSV into [`TabularData`], publishes
 /// [`tabular_v1`] artifacts, and checks logical identity. All semantic
@@ -28,25 +31,67 @@ impl CsvParseOptions {
     }
 }
 
+type DynRead = Box<dyn Read + Send>;
+
+fn sniff_encoding(reader: &mut BufReader<DynRead>) -> BinocResult<Option<&'static Encoding>> {
+    let sample = reader.fill_buf().map_err(BinocError::Io)?;
+    if sample.starts_with(&[0xEF, 0xBB, 0xBF]) {
+        return Ok(None);
+    }
+    if std::str::from_utf8(sample).is_ok() {
+        return Ok(Some(UTF_8));
+    }
+    Ok(Some(WINDOWS_1252))
+}
+
+pub(crate) fn csv_reader_from_read(
+    reader: DynRead,
+    delimiter: u8,
+) -> BinocResult<csv::Reader<DynRead>> {
+    let mut buffered = BufReader::new(reader);
+    let encoding = sniff_encoding(&mut buffered)?;
+    let decoded: DynRead = Box::new(
+        DecodeReaderBytesBuilder::new()
+            .encoding(encoding)
+            .build(buffered),
+    );
+
+    Ok(csv::ReaderBuilder::new()
+        .delimiter(delimiter)
+        .flexible(true)
+        .from_reader(decoded))
+}
+
+pub(crate) fn lossy_field(record: &csv::ByteRecord, index: usize) -> Cow<'_, str> {
+    String::from_utf8_lossy(record.get(index).unwrap_or(b""))
+}
+
+pub(crate) fn lossy_record(record: &csv::ByteRecord) -> Vec<String> {
+    record
+        .iter()
+        .map(|field| String::from_utf8_lossy(field).into_owned())
+        .collect()
+}
+
+pub(crate) fn csv_headers<R: Read>(rdr: &mut csv::Reader<R>) -> BinocResult<Vec<String>> {
+    let headers = rdr
+        .byte_headers()
+        .map_err(|e| BinocError::Csv(e.to_string()))?;
+    Ok(lossy_record(headers))
+}
+
 fn parse_csv(path: &Path, options: CsvParseOptions) -> BinocResult<TabularData> {
     let file = std::fs::File::open(path).map_err(BinocError::Io)?;
-    let reader = BufReader::new(file);
-    let mut rdr = csv::ReaderBuilder::new()
-        .delimiter(options.delimiter)
-        .flexible(true)
-        .from_reader(reader);
-
-    let headers: Vec<String> = rdr
-        .headers()
-        .map_err(|e| BinocError::Csv(e.to_string()))?
-        .iter()
-        .map(|s| s.to_string())
-        .collect();
+    let mut rdr = csv_reader_from_read(Box::new(file), options.delimiter)?;
+    let headers = csv_headers(&mut rdr)?;
 
     let mut rows = Vec::new();
-    for result in rdr.records() {
-        let record = result.map_err(|e| BinocError::Csv(e.to_string()))?;
-        rows.push(record.iter().map(|s| s.to_string()).collect());
+    let mut record = csv::ByteRecord::new();
+    while rdr
+        .read_byte_record(&mut record)
+        .map_err(|e| BinocError::Csv(e.to_string()))?
+    {
+        rows.push(lossy_record(&record));
     }
 
     Ok(TabularData { headers, rows })
@@ -153,5 +198,43 @@ mod tests {
             CsvParseOptions::for_item(&item("table.unknown")),
             CsvParseOptions { delimiter: b',' }
         );
+    }
+    #[test]
+    fn parse_csv_strips_utf8_bom_from_headers() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("bom.csv");
+        std::fs::write(&path, b"\xEF\xBB\xBFid,name\n1,Alice\n").unwrap();
+
+        let parsed = parse_csv(&path, CsvParseOptions { delimiter: b',' }).unwrap();
+
+        assert_eq!(parsed.headers, vec!["id", "name"]);
+        assert_eq!(
+            parsed.rows,
+            vec![vec!["1".to_string(), "Alice".to_string()]]
+        );
+    }
+
+    #[test]
+    fn parse_csv_transcodes_windows_1252() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("cp1252.csv");
+        std::fs::write(&path, b"id,name\n1,Jos\xe9\n").unwrap();
+
+        let parsed = parse_csv(&path, CsvParseOptions { delimiter: b',' }).unwrap();
+
+        assert_eq!(parsed.rows[0][1], "José");
+    }
+
+    #[test]
+    fn parse_csv_tolerates_invalid_bytes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("invalid.csv");
+        std::fs::write(&path, b"id,name\n1,Alice\n2,bad\xffvalue\n3,Carol\n").unwrap();
+
+        let parsed = parse_csv(&path, CsvParseOptions { delimiter: b',' }).unwrap();
+
+        assert_eq!(parsed.rows.len(), 3);
+        assert_eq!(parsed.rows[0][1], "Alice");
+        assert_eq!(parsed.rows[2][1], "Carol");
     }
 }

--- a/binoc-stdlib/src/comparators/csv_compare.rs
+++ b/binoc-stdlib/src/comparators/csv_compare.rs
@@ -33,12 +33,99 @@ impl CsvParseOptions {
 
 type DynRead = Box<dyn Read + Send>;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Utf8SampleStats {
+    valid_multibyte_sequences: usize,
+    valid_multibyte_bytes: usize,
+    invalid_bytes: usize,
+}
+
+fn utf8_sample_stats(sample: &[u8]) -> Utf8SampleStats {
+    let mut stats = Utf8SampleStats {
+        valid_multibyte_sequences: 0,
+        valid_multibyte_bytes: 0,
+        invalid_bytes: 0,
+    };
+    let mut i = 0;
+    while i < sample.len() {
+        let byte = sample[i];
+        if byte <= 0x7F {
+            i += 1;
+            continue;
+        }
+
+        let width = if (0xC2..=0xDF).contains(&byte) {
+            2
+        } else if (0xE0..=0xEF).contains(&byte) {
+            3
+        } else if (0xF0..=0xF4).contains(&byte) {
+            4
+        } else {
+            stats.invalid_bytes += 1;
+            i += 1;
+            continue;
+        };
+
+        if i + width > sample.len() {
+            stats.invalid_bytes += sample.len() - i;
+            break;
+        }
+
+        let seq = &sample[i..i + width];
+        let valid = match width {
+            2 => (0x80..=0xBF).contains(&seq[1]),
+            3 => match seq[0] {
+                0xE0 => (0xA0..=0xBF).contains(&seq[1]) && (0x80..=0xBF).contains(&seq[2]),
+                0xED => (0x80..=0x9F).contains(&seq[1]) && (0x80..=0xBF).contains(&seq[2]),
+                _ => (0x80..=0xBF).contains(&seq[1]) && (0x80..=0xBF).contains(&seq[2]),
+            },
+            4 => match seq[0] {
+                0xF0 => {
+                    (0x90..=0xBF).contains(&seq[1])
+                        && (0x80..=0xBF).contains(&seq[2])
+                        && (0x80..=0xBF).contains(&seq[3])
+                }
+                0xF4 => {
+                    (0x80..=0x8F).contains(&seq[1])
+                        && (0x80..=0xBF).contains(&seq[2])
+                        && (0x80..=0xBF).contains(&seq[3])
+                }
+                _ => {
+                    (0x80..=0xBF).contains(&seq[1])
+                        && (0x80..=0xBF).contains(&seq[2])
+                        && (0x80..=0xBF).contains(&seq[3])
+                }
+            },
+            _ => unreachable!(),
+        };
+
+        if valid {
+            stats.valid_multibyte_sequences += 1;
+            stats.valid_multibyte_bytes += width;
+            i += width;
+        } else {
+            stats.invalid_bytes += 1;
+            i += 1;
+        }
+    }
+
+    stats
+}
+
+fn should_prefer_utf8_despite_invalid_bytes(sample: &[u8]) -> bool {
+    let stats = utf8_sample_stats(sample);
+    stats.valid_multibyte_sequences > 0 && stats.valid_multibyte_bytes >= stats.invalid_bytes * 2
+}
+
 fn sniff_encoding(reader: &mut BufReader<DynRead>) -> BinocResult<Option<&'static Encoding>> {
     let sample = reader.fill_buf().map_err(BinocError::Io)?;
     if sample.starts_with(&[0xEF, 0xBB, 0xBF]) {
         return Ok(None);
     }
     if std::str::from_utf8(sample).is_ok() {
+        return Ok(Some(UTF_8));
+    }
+    if should_prefer_utf8_despite_invalid_bytes(sample) {
         return Ok(Some(UTF_8));
     }
     Ok(Some(WINDOWS_1252))
@@ -236,5 +323,30 @@ mod tests {
         assert_eq!(parsed.rows.len(), 3);
         assert_eq!(parsed.rows[0][1], "Alice");
         assert_eq!(parsed.rows[2][1], "Carol");
+    }
+
+    #[test]
+    fn parse_csv_prefers_utf8_when_corruption_follows_valid_utf8() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("mostly-utf8.csv");
+        std::fs::write(&path, b"id,name\n1,Jos\xc3\xa9\n2,bad\xffvalue\n").unwrap();
+
+        let parsed = parse_csv(&path, CsvParseOptions { delimiter: b',' }).unwrap();
+
+        assert_eq!(parsed.rows[0][1], "José");
+        assert_eq!(parsed.rows[1][1], "bad�value");
+    }
+
+    #[test]
+    fn utf8_sample_stats_counts_valid_and_invalid_non_ascii_bytes() {
+        let stats = utf8_sample_stats(b"Jos\xc3\xa9\xff");
+        assert_eq!(
+            stats,
+            Utf8SampleStats {
+                valid_multibyte_sequences: 1,
+                valid_multibyte_bytes: 2,
+                invalid_bytes: 1,
+            }
+        );
     }
 }

--- a/binoc-stdlib/src/comparators/csv_compare.rs
+++ b/binoc-stdlib/src/comparators/csv_compare.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::io::{BufRead, BufReader, Read};
 use std::path::Path;
 
@@ -147,10 +146,6 @@ pub(crate) fn csv_reader_from_read(
         .delimiter(delimiter)
         .flexible(true)
         .from_reader(decoded))
-}
-
-pub(crate) fn lossy_field(record: &csv::ByteRecord, index: usize) -> Cow<'_, str> {
-    String::from_utf8_lossy(record.get(index).unwrap_or(b""))
 }
 
 pub(crate) fn lossy_record(record: &csv::ByteRecord) -> Vec<String> {


### PR DESCRIPTION
## Summary
- decode CSV input through encoding_rs so UTF-8 BOMs are stripped and Windows-1252 legacy input is handled
- prefer UTF-8 for mostly-valid UTF-8 samples with isolated corrupt bytes
- add parser coverage for BOMs, Windows-1252, invalid bytes, and mixed valid/corrupt UTF-8