### PR TITLE
Constrain markdown count humanization

### DIFF
--- a/binoc-stdlib/src/renderers/markdown.rs
+++ b/binoc-stdlib/src/renderers/markdown.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use serde::{Deserialize, Serialize};
 
@@ -179,7 +179,7 @@ fn format_diagnostics_section(
     out.push_str(&format!("## {title}\n\n"));
     for diagnostic in matching {
         out.push_str("- ");
-        out.push_str(&humanize_numbers(&diagnostic.message));
+        out.push_str(&diagnostic.message);
         if let Some(location) = &diagnostic.location {
             out.push_str(&format!(" (`{location}`)"));
         }
@@ -275,11 +275,7 @@ fn format_node(
 
     out.push_str(&format!("- **{path}**: "));
 
-    if let Some(summary) = &node.summary {
-        out.push_str(&humanize_numbers(summary));
-    } else {
-        out.push_str(&humanize_numbers(&fallback_description(node)));
-    }
+    out.push_str(&format_summary_text(node));
     out.push('\n');
 
     // For a move with content detail, emit the detail as a second
@@ -289,11 +285,34 @@ fn format_node(
     // inline punctuation or capitalization fixups.
     if should_group_move_children(node) {
         if let Some(detail) = move_trailer(node) {
-            out.push_str(&format!("- **{path}**: {}\n", humanize_numbers(&detail)));
+            out.push_str(&format!(
+                "- **{path}**: {}\n",
+                format_known_quantities(&detail, node)
+            ));
         }
     }
 
     render_detail_blocks(out, node, path, config, detail_budget);
+}
+
+fn format_summary_text(node: &DiffNode) -> String {
+    let text = node
+        .summary
+        .clone()
+        .unwrap_or_else(|| fallback_description(node));
+
+    if summary_is_path_statement(node, &text) {
+        text
+    } else {
+        format_known_quantities(&text, node)
+    }
+}
+
+fn summary_is_path_statement(node: &DiffNode, text: &str) -> bool {
+    matches!(node.action.as_str(), "move" | "copy")
+        && (text.starts_with("Moved from ")
+            || text.starts_with("Folder moved from ")
+            || text.starts_with("Copied from "))
 }
 
 fn should_group_move_children(node: &DiffNode) -> bool {
@@ -321,7 +340,7 @@ fn move_trailer(node: &DiffNode) -> Option<String> {
             .children
             .iter()
             .filter(|c| c.action != "identical")
-            .map(|c| c.summary.clone().unwrap_or_else(|| fallback_description(c)))
+            .map(format_summary_text)
             .collect();
         if !parts.is_empty() {
             return Some(parts.join("; "));
@@ -336,6 +355,11 @@ fn annotation_str(node: &DiffNode, key: &str) -> Option<String> {
         .and_then(|v| v.as_str())
         .filter(|s| !s.is_empty())
         .map(|s| s.to_string())
+}
+
+fn format_count(value: u64) -> String {
+    let digits = value.to_string();
+    group_digits(&digits)
 }
 
 fn fallback_description(node: &DiffNode) -> String {
@@ -407,11 +431,15 @@ fn render_detail_blocks(
         let mut header = block.label.clone().unwrap_or_else(|| block.id.clone());
         if truncated {
             if shown == 0 && block.examples.is_empty() && total > 0 {
-                header.push_str(&format!(" ({total} total)"));
+                header.push_str(&format!(" ({} total)", format_count(total)));
             } else if total > 0 {
-                header.push_str(&format!(" (showing {shown} of {total})"));
+                header.push_str(&format!(
+                    " (showing {} of {})",
+                    format_count(shown),
+                    format_count(total)
+                ));
             } else {
-                header.push_str(&format!(" (showing {shown})"));
+                header.push_str(&format!(" (showing {})", format_count(shown)));
             }
         }
         if let Some(extract) = block.extract.first() {
@@ -601,45 +629,162 @@ fn capitalize(s: &str) -> String {
     }
 }
 
-fn humanize_numbers(input: &str) -> String {
-    // Locale-aware formatting is intentionally out of scope for now; this is US-style grouping.
+fn format_known_quantities(input: &str, node: &DiffNode) -> String {
+    let counts = known_count_values(node);
+    if counts.is_empty() {
+        return input.to_string();
+    }
+
     let mut out = String::with_capacity(input.len() + input.len() / 3);
-    let mut digits = String::new();
+    let mut cursor = 0;
+    let mut chars = input.char_indices().peekable();
 
-    let flush_digits = |out: &mut String, digits: &mut String| {
-        if digits.len() > 3 {
-            let first_group = digits.len() % 3;
-            let mut idx = 0;
-            if first_group != 0 {
-                out.push_str(&digits[..first_group]);
-                idx = first_group;
-                if idx < digits.len() {
-                    out.push(',');
-                }
-            }
-            while idx < digits.len() {
-                let end = (idx + 3).min(digits.len());
-                out.push_str(&digits[idx..end]);
-                idx = end;
-                if idx < digits.len() {
-                    out.push(',');
-                }
-            }
-        } else {
-            out.push_str(digits);
+    while let Some((start, ch)) = chars.next() {
+        if !ch.is_ascii_digit() {
+            continue;
         }
-        digits.clear();
-    };
 
-    for ch in input.chars() {
-        if ch.is_ascii_digit() {
-            digits.push(ch);
-        } else {
-            flush_digits(&mut out, &mut digits);
-            out.push(ch);
+        let mut end = start + ch.len_utf8();
+        while let Some((next_idx, next_ch)) = chars.peek().copied() {
+            if !next_ch.is_ascii_digit() {
+                break;
+            }
+            chars.next();
+            end = next_idx + next_ch.len_utf8();
+        }
+
+        out.push_str(&input[cursor..start]);
+        let digits = &input[start..end];
+        let formatted = digits
+            .parse::<u64>()
+            .ok()
+            .filter(|value| *value > 999)
+            .filter(|value| counts.contains(value))
+            .filter(|_| is_quantity_context(input, start, end))
+            .map(format_count)
+            .unwrap_or_else(|| digits.to_string());
+        out.push_str(&formatted);
+        cursor = end;
+    }
+
+    out.push_str(&input[cursor..]);
+    out
+}
+
+fn known_count_values(node: &DiffNode) -> BTreeSet<u64> {
+    let mut counts = BTreeSet::new();
+    for key in [
+        "rows_added",
+        "rows_removed",
+        "rows_modified",
+        "rows_left",
+        "rows_right",
+        "cells_changed",
+        "lines",
+        "lines_added",
+        "lines_removed",
+        "lines_unchanged",
+        "row_count",
+        "total_rows",
+    ] {
+        if let Some(value) = node.details.get(key).and_then(|value| value.as_u64()) {
+            counts.insert(value);
         }
     }
-    flush_digits(&mut out, &mut digits);
+    for key in [
+        "columns",
+        "columns_left",
+        "columns_right",
+        "columns_added",
+        "columns_removed",
+        "columns_type_changed",
+        "tables",
+    ] {
+        if let Some(len) = node
+            .details
+            .get(key)
+            .and_then(|value| value.as_array())
+            .map(|values| values.len() as u64)
+        {
+            counts.insert(len);
+        }
+    }
+    for block in &node.detail_blocks {
+        if let Some(total_count) = block.total_count {
+            counts.insert(total_count);
+        }
+    }
+    counts
+}
+
+fn is_quantity_context(input: &str, start: usize, end: usize) -> bool {
+    if path_or_identifier_adjacent(input, start, end) {
+        return false;
+    }
+
+    let Some(unit) = next_word(input, end) else {
+        return false;
+    };
+    matches!(
+        unit,
+        "row"
+            | "rows"
+            | "cell"
+            | "cells"
+            | "line"
+            | "lines"
+            | "column"
+            | "columns"
+            | "table"
+            | "tables"
+            | "null"
+            | "nulls"
+            | "added"
+            | "removed"
+            | "changed"
+            | "modified"
+    )
+}
+
+fn path_or_identifier_adjacent(input: &str, start: usize, end: usize) -> bool {
+    let prev = input[..start].chars().next_back();
+    let next = input[end..].chars().next();
+    prev.is_some_and(is_path_or_identifier_char) || next.is_some_and(is_path_or_identifier_char)
+}
+
+fn is_path_or_identifier_char(ch: char) -> bool {
+    ch.is_ascii_alphabetic() || matches!(ch, '_' | '/' | '\\' | '.' | '-' | ':')
+}
+
+fn next_word(input: &str, start: usize) -> Option<&str> {
+    let trimmed = input[start..].trim_start();
+    let word_len = trimmed
+        .char_indices()
+        .take_while(|(_, ch)| ch.is_ascii_alphabetic())
+        .last()
+        .map(|(idx, ch)| idx + ch.len_utf8())?;
+    Some(&trimmed[..word_len])
+}
+
+fn group_digits(digits: &str) -> String {
+    let mut out = String::with_capacity(digits.len() + digits.len() / 3);
+    let first_group = digits.len() % 3;
+    let mut idx = 0;
+    if first_group != 0 {
+        out.push_str(&digits[..first_group]);
+        idx = first_group;
+        if idx < digits.len() {
+            out.push(',');
+        }
+    }
+    while idx < digits.len() {
+        let end = (idx + 3).min(digits.len());
+        out.push_str(&digits[idx..end]);
+        idx = end;
+        if idx < digits.len() {
+            out.push(',');
+        }
+    }
     out
 }
 
@@ -956,18 +1101,30 @@ mod tests {
     }
 
     #[test]
-    fn humanizes_large_numbers_in_summaries() {
+    fn formats_known_counts_but_not_years_in_paths() {
         let changeset = Changeset::new(
             "v1",
             "v2",
-            Some(
-                DiffNode::new("modify", "csv", "data.csv")
-                    .with_summary("5975 rows added; 18133333 cells changed"),
-            ),
+            Some(DiffNode::new("modify", "directory", "").with_children(vec![
+                    DiffNode::new("move", "directory", "FoodData_Central_csv_2026-04-30")
+                        .with_source_path("FoodData_Central_csv_2025-12-18")
+                        .with_summary("Folder moved from FoodData_Central_csv_2025-12-18"),
+                    DiffNode::new("modify", "csv", "data.csv")
+                        .with_summary("5975 rows added; 18133333 cells changed")
+                        .with_detail("rows_added", serde_json::json!(5975_u64))
+                        .with_detail("cells_changed", serde_json::json!(18133333_u64)),
+                    DiffNode::new("modify", "text", "notes.txt")
+                        .with_summary("5975 lines added, 18133333 removed")
+                        .with_detail("lines_added", serde_json::json!(5975_u64))
+                        .with_detail("lines_removed", serde_json::json!(18133333_u64)),
+                ])),
         );
         let config = MarkdownRendererConfig::default();
         let md = render_markdown(&[changeset], &config);
         assert!(md.contains("5,975 rows added; 18,133,333 cells changed"));
+        assert!(md.contains("5,975 lines added, 18,133,333 removed"));
+        assert!(md.contains("Folder moved from FoodData_Central_csv_2025-12-18"));
+        assert!(!md.contains("FoodData_Central_csv_2,025-12-18"));
     }
 
     #[test]

--- a/binoc-stdlib/src/renderers/markdown.rs
+++ b/binoc-stdlib/src/renderers/markdown.rs
@@ -631,9 +631,6 @@ fn capitalize(s: &str) -> String {
 
 fn format_known_quantities(input: &str, node: &DiffNode) -> String {
     let counts = known_count_values(node);
-    if counts.is_empty() {
-        return input.to_string();
-    }
 
     let mut out = String::with_capacity(input.len() + input.len() / 3);
     let mut cursor = 0;
@@ -659,8 +656,8 @@ fn format_known_quantities(input: &str, node: &DiffNode) -> String {
             .parse::<u64>()
             .ok()
             .filter(|value| *value > 999)
-            .filter(|value| counts.contains(value))
-            .filter(|_| is_quantity_context(input, start, end))
+            .filter(|_| !digits.starts_with('0'))
+            .filter(|value| is_quantity_context(input, start, end, counts.contains(value)))
             .map(format_count)
             .unwrap_or_else(|| digits.to_string());
         out.push_str(&formatted);
@@ -717,7 +714,7 @@ fn known_count_values(node: &DiffNode) -> BTreeSet<u64> {
     counts
 }
 
-fn is_quantity_context(input: &str, start: usize, end: usize) -> bool {
+fn is_quantity_context(input: &str, start: usize, end: usize, is_known_count: bool) -> bool {
     if path_or_identifier_adjacent(input, start, end) {
         return false;
     }
@@ -725,8 +722,17 @@ fn is_quantity_context(input: &str, start: usize, end: usize) -> bool {
     let Some(unit) = next_word(input, end) else {
         return false;
     };
+
+    if is_quantity_unit(unit) {
+        return true;
+    }
+
+    is_quantity_action(unit) && (is_known_count || recent_quantity_unit_before(input, start))
+}
+
+fn is_quantity_unit(word: &str) -> bool {
     matches!(
-        unit,
+        word.to_ascii_lowercase().as_str(),
         "row"
             | "rows"
             | "cell"
@@ -739,11 +745,29 @@ fn is_quantity_context(input: &str, start: usize, end: usize) -> bool {
             | "tables"
             | "null"
             | "nulls"
-            | "added"
-            | "removed"
-            | "changed"
-            | "modified"
     )
+}
+
+fn is_quantity_action(word: &str) -> bool {
+    matches!(
+        word.to_ascii_lowercase().as_str(),
+        "added" | "removed" | "changed" | "modified"
+    )
+}
+
+fn recent_quantity_unit_before(input: &str, start: usize) -> bool {
+    let prefix = &input[..start];
+    let window_start = prefix
+        .rfind([';', '.', '(', ')', '\n'])
+        .map(|idx| idx + 1)
+        .unwrap_or(0);
+
+    prefix[window_start..]
+        .split(|ch: char| !ch.is_ascii_alphabetic())
+        .rev()
+        .filter(|word| !word.is_empty())
+        .take(4)
+        .any(is_quantity_unit)
 }
 
 fn path_or_identifier_adjacent(input: &str, start: usize, end: usize) -> bool {
@@ -1125,6 +1149,41 @@ mod tests {
         assert!(md.contains("5,975 lines added, 18,133,333 removed"));
         assert!(md.contains("Folder moved from FoodData_Central_csv_2025-12-18"));
         assert!(!md.contains("FoodData_Central_csv_2,025-12-18"));
+    }
+
+    #[test]
+    fn formats_aggregate_counts_but_not_dates_in_summary_text() {
+        let changeset = Changeset::new(
+            "v1",
+            "v2",
+            Some(
+                DiffNode::new("modify", "tabular_collection", "")
+                    .with_summary(
+                        "Table FoodData_Central_csv_2025-12-18 changed: 5975 rows added; \
+                         18133333 cells changed",
+                    )
+                    .with_tag("binoc.tabular-collection-change")
+                    .with_children(vec![DiffNode::new(
+                        "modify",
+                        "tabular",
+                        "FoodData_Central_csv_2026-04-30/data.csv",
+                    )
+                    .with_summary("5975 rows added; 18133333 cells changed")
+                    .with_detail("rows_added", serde_json::json!(5975_u64))
+                    .with_detail("cells_changed", serde_json::json!(18133333_u64))]),
+            ),
+        );
+        let config = MarkdownRendererConfig::default();
+        let md = render_markdown(&[changeset], &config);
+
+        assert!(md.contains(
+            "- **(root)**: Table FoodData_Central_csv_2025-12-18 changed: 5,975 rows added; 18,133,333 cells changed"
+        ));
+        assert!(md.contains(
+            "- **FoodData_Central_csv_2026-04-30/data.csv**: 5,975 rows added; 18,133,333 cells changed"
+        ));
+        assert!(!md.contains("FoodData_Central_csv_2,025-12-18"));
+        assert!(!md.contains("FoodData_Central_csv_2,026-04-30"));
     }
 
     #[test]

--- a/docs/adr/2026-03-18-terminology.md
+++ b/docs/adr/2026-03-18-terminology.md
@@ -57,7 +57,9 @@ Superseded in part by [2026-06-02-renderer_groups.md](2026-06-02-renderer_groups
 | **Clerical** | Changes that are mechanically necessary but semantically unimportant: column reordering, whitespace normalization, encoding changes. Chosen over *ministerial* (precise in records management but unfamiliar to most developers), *minor*/*trivial* (judgmental), *cosmetic* (implies visual concerns). |
 | **Substantive** | Changes that alter the information content: added columns, removed rows, schema changes. |
 
-Note: these were the original category names used in the Markdown renderer design. They are not baked into the IR. Current renderer config uses explicit ordered groups with literal headings. 
+Note: these were the original category names used in the Markdown renderer
+design. They are not baked into the IR. Current renderer config uses explicit
+ordered groups with literal headings.
 
 ### Testing
 

--- a/docs/explanation/test-vectors-gallery.md
+++ b/docs/explanation/test-vectors-gallery.md
@@ -48,7 +48,7 @@ just materialize
 | [`file-correspondence-scheme`](#file-correspondence-scheme) | Config declares that a state CSV moved into a new directory scheme is the same logical file | states/AL.csv: 1 row added | Default pipeline |
 | [`file-correspondence-token`](#file-correspondence-token) | Config declares that year-stamped CSV filenames are the same logical file | running_list.csv: 1 row added | Default pipeline |
 | [`folder-move-nested`](#folder-move-nested) | Detects a whole-folder rename and rolls many file moves up into one folder-move entry. | documentation: Folder moved from docs | Default pipeline |
-| [`folder-move-partial`](#folder-move-partial) | Detects a mostly-moved folder rename and preserves only the added/removed/modified remainder entries beneath it. | FoodData_Central_csv_2026-04-30: Folder moved from FoodData_Central_csv_2,025-12-18 | Custom config |
+| [`folder-move-partial`](#folder-move-partial) | Detects a mostly-moved folder rename and preserves only the added/removed/modified remainder entries beneath it. | FoodData_Central_csv_2026-04-30: Folder moved from FoodData_Central_csv_2025-12-18 | Custom config |
 | [`gzip-inner-dispatch`](#gzip-inner-dispatch) | Gzipped CSV and text are decompressed and redispatched under their inner names | census.txt: 1 line added, 1 removed | Default pipeline |
 | [`kitchen-sink`](#kitchen-sink) | Runs text, CSV, archive, move, and copy detection together in one end-to-end example. | archive.tar.gz/inventory.csv: 1 row added | Default pipeline |
 | [`single-file-add`](#single-file-add) | File present in B but not A | new_file.txt: New file (1 line) | Default pipeline |
@@ -546,7 +546,7 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-- **FoodData_Central_csv_2026-04-30**: Folder moved from FoodData_Central_csv_2,025-12-18
+- **FoodData_Central_csv_2026-04-30**: Folder moved from FoodData_Central_csv_2025-12-18
 - **FoodData_Central_csv_2026-04-30/data/new-table.csv**: New table (2 columns, 1 row)
 - **FoodData_Central_csv_2026-04-30/docs/modified.txt**: Text modified
 - **FoodData_Central_csv_2026-04-30/docs/old-table.txt**: File removed (1 line)

--- a/test-vectors/folder-move-partial/expected-output/changelog.snap
+++ b/test-vectors/folder-move-partial/expected-output/changelog.snap
@@ -4,7 +4,7 @@ expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
 
-- **FoodData_Central_csv_2026-04-30**: Folder moved from FoodData_Central_csv_2,025-12-18
+- **FoodData_Central_csv_2026-04-30**: Folder moved from FoodData_Central_csv_2025-12-18
 - **FoodData_Central_csv_2026-04-30/data/new-table.csv**: New table (2 columns, 1 row)
 - **FoodData_Central_csv_2026-04-30/docs/modified.txt**: Text modified
 - **FoodData_Central_csv_2026-04-30/docs/old-table.txt**: File removed (1 line)


### PR DESCRIPTION
## Summary
- only humanize numbers in structured quantity contexts instead of arbitrary IDs, dates, and paths
- preserve grouping for aggregate count summaries
- update the vector gallery output for the corrected folder-move date rendering

## Verification
- just docs
- just fmt
- just check
- just test