### PR TITLE
Fix partial folder move remainder containers

### DIFF
--- a/binoc-stdlib/src/transformers/folder_move_detector.rs
+++ b/binoc-stdlib/src/transformers/folder_move_detector.rs
@@ -283,7 +283,7 @@ fn apply_rollups(
                 format!("Folder copied from {}", display_name(&rollup.source_path)),
             ),
         };
-        let mut children = rewrite_destination_children(node.children, rollup);
+        let mut children = rewrite_destination_children(node.children, rollup, source_index);
         if let Some(source_node) = source_index.get(&rollup.source_path) {
             children.extend(relocate_source_remainders(source_node, rollup));
         }
@@ -315,35 +315,48 @@ fn apply_rollups(
     }
 }
 
-fn rewrite_destination_children(children: Vec<DiffNode>, rollup: &Rollup) -> Vec<DiffNode> {
+fn rewrite_destination_children(
+    children: Vec<DiffNode>,
+    rollup: &Rollup,
+    source_index: &BTreeMap<String, DiffNode>,
+) -> Vec<DiffNode> {
     merge_same_path_nodes(
         children
             .into_iter()
-            .filter_map(|child| rewrite_destination_node(child, rollup))
+            .filter_map(|child| rewrite_destination_node(child, rollup, source_index))
             .collect(),
     )
 }
 
-fn rewrite_destination_node(node: DiffNode, rollup: &Rollup) -> Option<DiffNode> {
-    let rel = strip_prefix_as_child(&node.path, &rollup.dst_path)?;
+fn rewrite_destination_node(
+    node: DiffNode,
+    rollup: &Rollup,
+    source_index: &BTreeMap<String, DiffNode>,
+) -> Option<DiffNode> {
+    let rel = strip_prefix_as_child(&node.path, &rollup.dst_path)?.to_string();
     if node.children.is_empty() {
-        if is_clean_matched_leaf(&node, rel, rollup) {
+        if is_clean_matched_leaf(&node, &rel, rollup) {
             return None;
         }
         return Some(normalize_rollup_remainder_leaf(node, rollup));
     }
 
-    let mut new_children = rewrite_destination_children(node.children, rollup);
+    let mut new_children = rewrite_destination_children(node.children, rollup, source_index);
     new_children = merge_same_path_nodes(new_children);
 
     if new_children.is_empty() && node.summary.is_none() && node.tags.is_empty() {
         return None;
     }
 
-    Some(DiffNode {
-        children: new_children,
-        ..node
-    })
+    Some(normalize_rollup_remainder_container(
+        DiffNode {
+            children: new_children,
+            ..node
+        },
+        &rel,
+        rollup,
+        source_index,
+    ))
 }
 
 fn is_clean_matched_leaf(node: &DiffNode, rel: &str, rollup: &Rollup) -> bool {
@@ -362,6 +375,39 @@ fn normalize_rollup_remainder_leaf(node: DiffNode, rollup: &Rollup) -> DiffNode 
     }
 
     maybe_demote_move_like_remainder(node)
+}
+
+fn normalize_rollup_remainder_container(
+    mut node: DiffNode,
+    rel: &str,
+    rollup: &Rollup,
+    source_index: &BTreeMap<String, DiffNode>,
+) -> DiffNode {
+    if node.action != "add" {
+        return node;
+    }
+
+    let source_path = if rollup.source_path.is_empty() {
+        rel.to_string()
+    } else if rel.is_empty() {
+        rollup.source_path.clone()
+    } else {
+        format!("{}/{}", rollup.source_path, rel)
+    };
+
+    let has_source_container = source_index
+        .get(&source_path)
+        .is_some_and(|source| source.item_type == node.item_type);
+    let has_matched_descendant = rollup
+        .matched_rel_paths
+        .iter()
+        .any(|matched| matched == rel || matched.starts_with(&format!("{rel}/")));
+
+    if has_source_container || has_matched_descendant {
+        node.action = "modify".to_string();
+    }
+
+    node
 }
 
 fn maybe_demote_move_like_remainder(mut node: DiffNode) -> DiffNode {

--- a/binoc-stdlib/tests/transformer_tests.rs
+++ b/binoc-stdlib/tests/transformer_tests.rs
@@ -826,6 +826,49 @@ fn folder_move_rolls_up_partial_rename_and_keeps_remainders() {
 }
 
 #[test]
+fn folder_move_marks_persisting_remainder_container_as_modify() {
+    let dst = DiffNode::new("add", "directory", "newdir").with_children(vec![
+        DiffNode::new("add", "directory", "newdir/data").with_children(vec![
+            DiffNode::new("move", "file", "newdir/data/kept.txt")
+                .with_source_path("olddir/data/kept.txt")
+                .with_tag("binoc.move"),
+            DiffNode::new("add", "file", "newdir/data/new.txt")
+                .with_summary("New file")
+                .with_tag("binoc.content-changed"),
+        ]),
+        DiffNode::new("move", "file", "newdir/readme.txt")
+            .with_source_path("olddir/readme.txt")
+            .with_tag("binoc.move"),
+    ]);
+    let src = DiffNode::new("remove", "directory", "olddir").with_children(vec![
+        DiffNode::new("remove", "directory", "olddir/data").with_children(vec![DiffNode::new(
+            "remove",
+            "file",
+            "olddir/data/kept.txt",
+        )]),
+        DiffNode::new("remove", "file", "olddir/readme.txt"),
+    ]);
+    let root = DiffNode::new("modify", "directory", "").with_children(vec![src, dst]);
+
+    let cfg = serde_json::json!({ "threshold": 0.5 });
+    let TransformResult::Replace(root) = FolderMoveDetector.transform(root, &da(), &cfg) else {
+        panic!("Expected Replace");
+    };
+
+    let folded = &root.children[0];
+    let data = folded
+        .children
+        .iter()
+        .find(|c| c.path == "newdir/data")
+        .expect("data remainder container");
+    assert_eq!(data.action, "modify");
+    assert_eq!(data.item_type, "directory");
+    assert_eq!(data.children.len(), 1);
+    assert_eq!(data.children[0].path, "newdir/data/new.txt");
+    assert_eq!(data.children[0].action, "add");
+}
+
+#[test]
 fn folder_move_descriptor() {
     let desc = FolderMoveDetector.descriptor();
     assert_eq!(desc.name, "binoc.folder_move_detector");

--- a/test-vectors/folder-move-partial/expected-output/changeset.snap
+++ b/test-vectors/folder-move-partial/expected-output/changeset.snap
@@ -22,7 +22,7 @@ expression: "&stable_changeset"
         ],
         "children": [
           {
-            "action": "add",
+            "action": "modify",
             "item_type": "directory",
             "path": "FoodData_Central_csv_2026-04-30/data",
             "children": [


### PR DESCRIPTION
## Summary
- mark persisted destination-side remainder directories as modified rather than added during folder move rollup
- keep genuinely new remainder leaves as additions
- add transformer coverage and update the partial folder move changeset snapshot