### PR TITLE
Structured summary segments

### DIFF
--- a/binoc-core/src/controller.rs
+++ b/binoc-core/src/controller.rs
@@ -643,7 +643,13 @@ impl Controller {
                     node.summary = Some(summary.clone());
                 }
                 if node.binoc_annotation("content_summary").is_none() {
-                    node.annotate_from("binoc", "content_summary", serde_json::json!(summary));
+                    // Stash as plain text: the trailer annotation is read with
+                    // `.as_str()` by the folder-move detector and the renderer.
+                    node.annotate_from(
+                        "binoc",
+                        "content_summary",
+                        serde_json::json!(summary.plain_text()),
+                    );
                 }
             }
         }

--- a/binoc-python/src/lib.rs
+++ b/binoc-python/src/lib.rs
@@ -611,7 +611,7 @@ impl PyDiffNode {
     ) -> PyResult<Self> {
         let mut node = DiffNode::new(action, item_type, path);
         node.source_path = source_path;
-        node.summary = summary;
+        node.summary = summary.map(Into::into);
         if let Some(tags_obj) = tags {
             if let Ok(tag_list) = tags_obj.extract::<Vec<String>>() {
                 node.tags = tag_list.into_iter().collect();
@@ -657,10 +657,10 @@ impl PyDiffNode {
     fn source_path(&self) -> Option<&str> {
         self.inner.source_path.as_deref()
     }
-    /// Optional one-line human summary of the change.
+    /// Optional one-line human summary of the change, as plain text.
     #[getter]
-    fn summary(&self) -> Option<&str> {
-        self.inner.summary.as_deref()
+    fn summary(&self) -> Option<String> {
+        self.inner.summary.as_ref().map(|s| s.plain_text())
     }
     /// Open-string tags attached to this node (used for renderer significance
     /// classification and transformer dispatch).
@@ -705,7 +705,10 @@ impl PyDiffNode {
         dict.set_item("item_type", &self.inner.item_type)?;
         dict.set_item("path", &self.inner.path)?;
         dict.set_item("source_path", self.inner.source_path.as_deref())?;
-        dict.set_item("summary", self.inner.summary.as_deref())?;
+        dict.set_item(
+            "summary",
+            self.inner.summary.as_ref().map(|s| s.plain_text()),
+        )?;
         dict.set_item("tags", self.tags())?;
         let children: PyResult<Vec<Bound<'py, PyDict>>> = self
             .inner

--- a/binoc-sdk/src/ir.rs
+++ b/binoc-sdk/src/ir.rs
@@ -1,7 +1,192 @@
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
 
 use crate::types::{ArtifactDescriptor, ItemPair};
+
+/// Which snapshot a [`Segment::Path`] resolves in.
+///
+/// Lets a renderer that can dereference a path — hyperlink it, shorten it
+/// against a tree, show an icon — target the correct side of the diff
+/// without understanding *why* the path appears (rename, copy,
+/// cross-reference, ...). It is a property of the value, not an encoding of
+/// any one concept. See ADR 2026-06-03-structured-summary-segments.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum Side {
+    /// The "before" snapshot (a source/original path).
+    From,
+    /// The "after" snapshot (a destination/current path).
+    To,
+}
+
+/// One piece of a [`Summary`].
+///
+/// Each variant carries a value *and*, implicitly, the render-time policy
+/// for it: group an integer, format a float, leave text alone, dereference
+/// a path. Renderers format by variant; they never parse prose to recover
+/// the type of a value, because the producer never threw it away. Variants
+/// track *render behavior*, not semantics — a currency or percent is `Text`
+/// plus a number, never its own variant. See ADR
+/// 2026-06-03-structured-summary-segments.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum Segment {
+    /// Verbatim text: connective wording, units, punctuation, and any
+    /// value the renderer must not reinterpret. Embedded digits are never
+    /// reformatted — a number that should be grouped is a [`Segment::Uint`],
+    /// and a path that could be linked is a [`Segment::Path`].
+    Text(String),
+    /// A path or locator. Renderers may shorten or hyperlink it; `snapshot`
+    /// says which side of the diff it resolves in.
+    Path { value: String, snapshot: Side },
+    /// A non-negative count. Renderers apply digit grouping / locale.
+    Uint(u64),
+    /// A real-valued quantity. Renderers apply decimal / precision policy.
+    Float(f64),
+}
+
+/// A structured, render-ready one-line summary: an ordered list of typed
+/// [`Segment`]s.
+///
+/// Producers (comparators, transformers, plugins) build it; renderers format
+/// each segment by its type. This replaces free-text summaries so that
+/// number and path formatting is a render-time decision the renderer makes
+/// from typed values, rather than a fragile reparse of prose. A producer
+/// that owns a concept (a rename detector) owns the *wording* — it emits the
+/// connective `Text` and the `Path`s — while the renderer owns the
+/// *typography*. See ADR 2026-06-03-structured-summary-segments.
+///
+/// The ergonomic shortcut for the common case is `impl Into<Summary>`:
+/// `with_summary("plain text")` still works and produces a single
+/// [`Segment::Text`].
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(transparent)]
+pub struct Summary(pub Vec<Segment>);
+
+impl Summary {
+    pub fn new() -> Self {
+        Summary(Vec::new())
+    }
+
+    /// Append verbatim text, coalescing into a trailing text segment if the
+    /// summary already ends in one. Keeps the serialized form canonical so
+    /// that helpers like [`Summary::count`] which emit a count followed by
+    /// text don't leave redundant adjacent text segments on the wire.
+    pub fn text(mut self, value: impl Into<String>) -> Self {
+        let value = value.into();
+        if let Some(Segment::Text(last)) = self.0.last_mut() {
+            last.push_str(&value);
+        } else {
+            self.0.push(Segment::Text(value));
+        }
+        self
+    }
+
+    /// Append a non-negative count (renderer applies digit grouping).
+    pub fn uint(mut self, value: u64) -> Self {
+        self.0.push(Segment::Uint(value));
+        self
+    }
+
+    /// Append a counted noun: `"{n} {noun}"`, with the count as a
+    /// [`Segment::Uint`] (grouped by the renderer) and the noun pluralized
+    /// with a trailing `s` unless `n == 1`. For irregular plurals, build the
+    /// segments by hand. Example: `.count(5, "row")` -> `5 rows`.
+    pub fn count(self, n: u64, noun: &str) -> Self {
+        let suffix = if n == 1 { "" } else { "s" };
+        self.uint(n).text(format!(" {noun}{suffix}"))
+    }
+
+    /// Append a real-valued quantity (renderer applies decimal policy).
+    pub fn float(mut self, value: f64) -> Self {
+        self.0.push(Segment::Float(value));
+        self
+    }
+
+    /// Append a path/locator that resolves in `snapshot`.
+    pub fn path(mut self, value: impl Into<String>, snapshot: Side) -> Self {
+        self.0.push(Segment::Path {
+            value: value.into(),
+            snapshot,
+        });
+        self
+    }
+
+    /// Append a single segment.
+    pub fn push(&mut self, segment: Segment) {
+        self.0.push(segment);
+    }
+
+    /// Append all segments of another summary (e.g. when joining child
+    /// summaries into a trailer).
+    pub fn extend(&mut self, other: Summary) {
+        self.0.extend(other.0);
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn segments(&self) -> &[Segment] {
+        &self.0
+    }
+
+    /// Plain-text rendering with no formatting policy applied: text and path
+    /// values verbatim, numbers in bare decimal form. For consumers without a
+    /// renderer (Python bindings, machine sinks, provenance) and for internal
+    /// bookkeeping such as path-statement detection.
+    pub fn plain_text(&self) -> String {
+        self.to_string()
+    }
+
+    /// Uppercase the first character of the leading text segment, if the
+    /// summary begins with text. No-op when it begins with a number or path.
+    /// Mirrors sentence-casing of prose without scanning a built string.
+    pub fn capitalize_first(mut self) -> Self {
+        if let Some(Segment::Text(text)) = self.0.first_mut() {
+            if let Some(first) = text.get_mut(..1) {
+                first.make_ascii_uppercase();
+            }
+        }
+        self
+    }
+}
+
+impl fmt::Display for Summary {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for segment in &self.0 {
+            match segment {
+                Segment::Text(text) => f.write_str(text)?,
+                Segment::Path { value, .. } => f.write_str(value)?,
+                Segment::Uint(value) => write!(f, "{value}")?,
+                Segment::Float(value) => write!(f, "{value}")?,
+            }
+        }
+        Ok(())
+    }
+}
+
+impl From<&str> for Summary {
+    fn from(value: &str) -> Self {
+        Summary(vec![Segment::Text(value.to_string())])
+    }
+}
+
+impl From<String> for Summary {
+    fn from(value: String) -> Self {
+        Summary(vec![Segment::Text(value)])
+    }
+}
+
+impl From<Vec<Segment>> for Summary {
+    fn from(value: Vec<Segment>) -> Self {
+        Summary(value)
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -116,10 +301,12 @@ pub struct DiffNode {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_path: Option<String>,
 
-    /// Optional human-readable one-liner describing the change.
-    /// Set by comparator or transformer; used by renderers for narrative rendering.
+    /// Optional structured one-liner describing the change. Set by a
+    /// comparator or transformer; renderers format each [`Segment`] by its
+    /// type. Build it with [`Summary`]'s builder, or pass a plain string —
+    /// `impl Into<Summary>` wraps it as a single [`Segment::Text`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub summary: Option<String>,
+    pub summary: Option<Summary>,
 
     /// Open bag of semantic tags, namespaced by convention.
     /// e.g. "binoc.column-reorder", "biobinoc.gap-change"
@@ -218,7 +405,7 @@ impl DiffNode {
         }
     }
 
-    pub fn with_summary(mut self, summary: impl Into<String>) -> Self {
+    pub fn with_summary(mut self, summary: impl Into<Summary>) -> Self {
         self.summary = Some(summary.into());
         self
     }

--- a/binoc-sdk/src/lib.rs
+++ b/binoc-sdk/src/lib.rs
@@ -10,7 +10,7 @@ pub mod test_support;
 pub use data_access::LocalDataAccess;
 pub use ir::{
     Annotation, Changeset, DetailBlock, DetailExample, Diagnostic, DiagnosticSeverity, DiffNode,
-    ExtractHint, ValuePreview,
+    ExtractHint, Segment, Side, Summary, ValuePreview,
 };
 pub use traits::*;
 pub use types::*;

--- a/binoc-stdlib/src/comparators/text.rs
+++ b/binoc-stdlib/src/comparators/text.rs
@@ -79,10 +79,12 @@ impl Comparator for TextComparator {
                 let lines = text.lines().count() as u64;
 
                 let node = DiffNode::new("add", "text", &right.logical_path)
-                    .with_summary(format!(
-                        "New file ({lines} line{})",
-                        if lines == 1 { "" } else { "s" }
-                    ))
+                    .with_summary(
+                        Summary::new()
+                            .text("New file (")
+                            .count(lines, "line")
+                            .text(")"),
+                    )
                     .with_tag("binoc.content-changed")
                     .with_detail("lines", serde_json::json!(lines));
 
@@ -97,10 +99,12 @@ impl Comparator for TextComparator {
                 let lines = text.lines().count() as u64;
 
                 let node = DiffNode::new("remove", "text", &left.logical_path)
-                    .with_summary(format!(
-                        "File removed ({lines} line{})",
-                        if lines == 1 { "" } else { "s" }
-                    ))
+                    .with_summary(
+                        Summary::new()
+                            .text("File removed (")
+                            .count(lines, "line")
+                            .text(")"),
+                    )
                     .with_tag("binoc.content-changed")
                     .with_detail("lines", serde_json::json!(lines));
 
@@ -111,14 +115,15 @@ impl Comparator for TextComparator {
     }
 }
 
-fn text_modify_summary(lines_added: u64, lines_removed: u64) -> String {
+fn text_modify_summary(lines_added: u64, lines_removed: u64) -> Summary {
     match (lines_added, lines_removed) {
         (0, 0) => "Whitespace changes only".into(),
-        (a, 0) => format!("{a} line{} added", if a == 1 { "" } else { "s" }),
-        (0, r) => format!("{r} line{} removed", if r == 1 { "" } else { "s" }),
-        (a, r) => format!(
-            "{a} line{} added, {r} removed",
-            if a == 1 { "" } else { "s" },
-        ),
+        (a, 0) => Summary::new().count(a, "line").text(" added"),
+        (0, r) => Summary::new().count(r, "line").text(" removed"),
+        (a, r) => Summary::new()
+            .count(a, "line")
+            .text(" added, ")
+            .uint(r)
+            .text(" removed"),
     }
 }

--- a/binoc-stdlib/src/renderers/markdown.rs
+++ b/binoc-stdlib/src/renderers/markdown.rs
@@ -275,11 +275,7 @@ fn format_node(
 
     out.push_str(&format!("- **{path}**: "));
 
-    if let Some(summary) = &node.summary {
-        out.push_str(&humanize_numbers(summary));
-    } else {
-        out.push_str(&humanize_numbers(&fallback_description(node)));
-    }
+    out.push_str(&render_summary(&node_summary(node)));
     out.push('\n');
 
     // For a move with content detail, emit the detail as a second
@@ -289,7 +285,7 @@ fn format_node(
     // inline punctuation or capitalization fixups.
     if should_group_move_children(node) {
         if let Some(detail) = move_trailer(node) {
-            out.push_str(&format!("- **{path}**: {}\n", humanize_numbers(&detail)));
+            out.push_str(&format!("- **{path}**: {}\n", render_summary(&detail)));
         }
     }
 
@@ -310,22 +306,28 @@ fn should_group_move_children(node: &DiffNode) -> bool {
 /// 2. `annotations.content_summary` — generic, captured during the
 ///    controller's re-dispatch merge.
 /// 3. A join of non-identical child summaries.
-fn move_trailer(node: &DiffNode) -> Option<String> {
+fn move_trailer(node: &DiffNode) -> Option<Summary> {
+    // The annotation trailers are carried as plain strings (so transformers
+    // like the folder-move detector can read them with `.as_str()`); they
+    // render verbatim as a single text segment.
     if let Some(s) = annotation_str(node, "tabular_summary") {
-        return Some(s);
+        return Some(s.into());
     }
     if let Some(s) = annotation_str(node, "content_summary") {
-        return Some(s);
+        return Some(s.into());
     }
     if !node.children.is_empty() {
-        let parts: Vec<String> = node
-            .children
-            .iter()
-            .filter(|c| c.action != "identical")
-            .map(|c| c.summary.clone().unwrap_or_else(|| fallback_description(c)))
-            .collect();
-        if !parts.is_empty() {
-            return Some(parts.join("; "));
+        let mut trailer = Summary::new();
+        let mut any = false;
+        for child in node.children.iter().filter(|c| c.action != "identical") {
+            if any {
+                trailer = trailer.text("; ");
+            }
+            trailer.extend(node_summary(child));
+            any = true;
+        }
+        if any {
+            return Some(trailer);
         }
     }
     None
@@ -465,34 +467,77 @@ fn humanize_annotation_key(key: &str) -> String {
     capitalize(&text)
 }
 
-fn fallback_description(node: &DiffNode) -> String {
-    let action = &node.action;
+/// This node's summary, or a generic fallback when the producer supplied none.
+fn node_summary(node: &DiffNode) -> Summary {
+    node.summary
+        .clone()
+        .unwrap_or_else(|| fallback_summary(node))
+}
+
+/// Render a structured summary by formatting each segment according to its
+/// type. The renderer never parses prose: a `Uint` is digit-grouped, a `Float`
+/// gets decimal policy, `Text` is verbatim, and a `Path` is emitted as-is (a
+/// richer renderer could hyperlink it, using `Segment::Path`'s snapshot side to
+/// resolve against the correct tree). See ADR
+/// 2026-06-03-structured-summary-segments.
+fn render_summary(summary: &Summary) -> String {
+    let mut out = String::new();
+    for segment in summary.segments() {
+        match segment {
+            Segment::Text(text) => out.push_str(text),
+            Segment::Path { value, .. } => out.push_str(value),
+            // Reuse the prose grouper on the bare decimal form: a `Uint` is
+            // always a count, so it is always grouped — no context guessing.
+            Segment::Uint(value) => out.push_str(&humanize_numbers(&value.to_string())),
+            Segment::Float(value) => out.push_str(&format_float(*value)),
+        }
+    }
+    out
+}
+
+/// Format a real-valued quantity: trimmed fixed/scientific notation, with the
+/// integer part digit-grouped. (No producer emits `Float` yet; this keeps the
+/// segment type renderable for plugins that do.)
+fn format_float(value: f64) -> String {
+    let raw = if value.abs() < 1_000_000.0 {
+        format!("{value:.3}")
+    } else {
+        format!("{value:.6e}")
+    };
+    let trimmed = raw.trim_end_matches('0').trim_end_matches('.');
+    match trimmed.split_once('.') {
+        Some((int_part, frac)) => format!("{}.{frac}", humanize_numbers(int_part)),
+        None => humanize_numbers(trimmed),
+    }
+}
+
+/// Generic last-resort summary for a node whose producer supplied none.
+///
+/// Producers own the wording of their concepts; this fallback only covers the
+/// built-in actions so a summary-less node still renders something. The
+/// move/copy cases emit a [`Segment::Path`] for the source so the path is typed
+/// (linkable, never digit-grouped) even on this degraded path.
+fn fallback_summary(node: &DiffNode) -> Summary {
     let item_type = if node.item_type.is_empty() {
         "item"
     } else {
         &node.item_type
     };
 
-    match action.as_str() {
-        "add" => format!("New {item_type}"),
-        "remove" => format!("{} removed", capitalize(item_type)),
-        "modify" => format!("{} modified", capitalize(item_type)),
-        "move" => {
-            if let Some(src) = &node.source_path {
-                format!("Moved from {src}")
-            } else {
-                format!("{} moved", capitalize(item_type))
-            }
-        }
-        "copy" => {
-            if let Some(src) = &node.source_path {
-                format!("Copied from {src}")
-            } else {
-                format!("{} copied", capitalize(item_type))
-            }
-        }
-        "reorder" => format!("{} reordered", capitalize(item_type)),
-        _ => format!("{action} ({item_type})"),
+    match node.action.as_str() {
+        "add" => format!("New {item_type}").into(),
+        "remove" => format!("{} removed", capitalize(item_type)).into(),
+        "modify" => format!("{} modified", capitalize(item_type)).into(),
+        "move" => match &node.source_path {
+            Some(src) => Summary::new().text("Moved from ").path(src, Side::From),
+            None => format!("{} moved", capitalize(item_type)).into(),
+        },
+        "copy" => match &node.source_path {
+            Some(src) => Summary::new().text("Copied from ").path(src, Side::From),
+            None => format!("{} copied", capitalize(item_type)).into(),
+        },
+        "reorder" => format!("{} reordered", capitalize(item_type)).into(),
+        action => format!("{action} ({item_type})").into(),
     }
 }
 
@@ -1089,18 +1134,34 @@ mod tests {
     }
 
     #[test]
-    fn humanizes_large_numbers_in_summaries() {
+    fn groups_uint_segments_but_leaves_text_and_paths_verbatim() {
+        // Grouping is a property of the `Uint` segment, not a prose scan: a
+        // `Uint` is always grouped, while digits inside `Text`/`Path` (a year
+        // in a folder name) are never touched.
         let changeset = Changeset::new(
             "v1",
             "v2",
-            Some(
-                DiffNode::new("modify", "csv", "data.csv")
-                    .with_summary("5975 rows added; 18133333 cells changed"),
-            ),
+            Some(DiffNode::new("modify", "directory", "").with_children(vec![
+                DiffNode::new("move", "directory", "FoodData_Central_csv_2026-04-30")
+                    .with_source_path("FoodData_Central_csv_2025-12-18")
+                    .with_summary(
+                        Summary::new()
+                            .text("Folder moved from ")
+                            .path("FoodData_Central_csv_2025-12-18", Side::From),
+                    ),
+                DiffNode::new("modify", "csv", "data.csv").with_summary(
+                    Summary::new()
+                        .uint(5975)
+                        .text(" rows added; ")
+                        .uint(18133333)
+                        .text(" cells changed"),
+                ),
+            ])),
         );
-        let config = MarkdownRendererConfig::default();
-        let md = render_markdown(&[changeset], &config);
+        let md = render_markdown(&[changeset], &MarkdownRendererConfig::default());
         assert!(md.contains("5,975 rows added; 18,133,333 cells changed"));
+        assert!(md.contains("Folder moved from FoodData_Central_csv_2025-12-18"));
+        assert!(!md.contains("FoodData_Central_csv_2,025-12-18"));
     }
 
     #[test]

--- a/binoc-stdlib/src/transformers/correlation_detector.rs
+++ b/binoc-stdlib/src/transformers/correlation_detector.rs
@@ -136,7 +136,7 @@ fn emit_move(group: &HashGroup, aggregate: bool, plan: &mut RewritePlan) {
             .with_tag("binoc.move");
 
         let summary = aggregated_move_summary(&sorted_removes, &sorted_adds);
-        node.summary = Some(summary);
+        node.summary = Some(summary.into());
 
         if sorted_removes.len() > 1 {
             let sources: Vec<String> = sorted_removes.iter().map(|e| e.path.clone()).collect();
@@ -171,10 +171,11 @@ fn emit_move(group: &HashGroup, aggregate: bool, plan: &mut RewritePlan) {
         let add = sorted_adds[i];
         let rm = sorted_removes[i];
         let node = DiffNode::new("move", &add.item_type, &add.path)
-            .with_summary(format!(
-                "Moved from {}",
-                source_label_for_move(&rm.path, &add.path)
-            ))
+            .with_summary(
+                Summary::new()
+                    .text("Moved from ")
+                    .path(source_label_for_move(&rm.path, &add.path), Side::From),
+            )
             .with_source_path(&rm.path)
             .with_tag("binoc.move");
         plan.schedule_remove(&add.path);
@@ -200,7 +201,7 @@ fn emit_copy(group: &HashGroup, aggregate: bool, plan: &mut RewritePlan) {
             .with_source_path(&source.path)
             .with_tag("binoc.copy");
         let destinations: Vec<String> = sorted_adds.iter().map(|e| e.path.clone()).collect();
-        node.summary = Some(aggregated_copy_summary(&source.path, &sorted_adds));
+        node.summary = Some(aggregated_copy_summary(&source.path, &sorted_adds).into());
         node.details
             .insert("destinations".into(), serde_json::json!(destinations));
         for a in &sorted_adds {
@@ -212,7 +213,11 @@ fn emit_copy(group: &HashGroup, aggregate: bool, plan: &mut RewritePlan) {
 
     for add in sorted_adds {
         let node = DiffNode::new("copy", &add.item_type, &add.path)
-            .with_summary(format!("Copied from {}", file_name_of(&source.path)))
+            .with_summary(
+                Summary::new()
+                    .text("Copied from ")
+                    .path(file_name_of(&source.path), Side::From),
+            )
             .with_source_path(&source.path)
             .with_tag("binoc.copy");
         plan.schedule_remove(&add.path);

--- a/binoc-stdlib/src/transformers/declared_correspondence.rs
+++ b/binoc-stdlib/src/transformers/declared_correspondence.rs
@@ -461,7 +461,11 @@ fn build_correspondence_node(
         .with_detail("destination_path", serde_json::json!(add.path));
     if rule.report_path_change {
         node.source_path = Some(remove.path.clone());
-        node.summary = Some(format!("Moved from {}", remove.path));
+        node.summary = Some(
+            Summary::new()
+                .text("Moved from ")
+                .path(&remove.path, binoc_sdk::Side::From),
+        );
         node.tags.insert("binoc.path-change".into());
     }
     node.pending_recompare = Some(ItemPair::both(left, right));

--- a/binoc-stdlib/src/transformers/folder_move_detector.rs
+++ b/binoc-stdlib/src/transformers/folder_move_detector.rs
@@ -275,12 +275,16 @@ fn apply_rollups(
             RollupKind::Move => (
                 "move",
                 "binoc.move",
-                format!("Folder moved from {}", display_name(&rollup.source_path)),
+                Summary::new()
+                    .text("Folder moved from ")
+                    .path(display_name(&rollup.source_path), Side::From),
             ),
             RollupKind::Copy => (
                 "copy",
                 "binoc.copy",
-                format!("Folder copied from {}", display_name(&rollup.source_path)),
+                Summary::new()
+                    .text("Folder copied from ")
+                    .path(display_name(&rollup.source_path), Side::From),
             ),
         };
         let mut children = rewrite_destination_children(node.children, rollup, source_index);
@@ -412,14 +416,14 @@ fn normalize_rollup_remainder_container(
 
 fn maybe_demote_move_like_remainder(mut node: DiffNode) -> DiffNode {
     if matches!(node.action.as_str(), "move" | "copy") {
-        let detail = node
+        let detail: Option<Summary> = node
             .binoc_annotation("tabular_summary")
             .and_then(Annotation::as_str)
             .or_else(|| {
                 node.binoc_annotation("content_summary")
                     .and_then(Annotation::as_str)
             })
-            .map(str::to_string);
+            .map(Summary::from);
         node.action = "modify".to_string();
         node.source_path = None;
         node.tags.remove("binoc.move");
@@ -427,15 +431,13 @@ fn maybe_demote_move_like_remainder(mut node: DiffNode) -> DiffNode {
         node.tags.remove("binoc.move.modified");
         node.tags.remove("binoc.copy.modified");
         node.summary = detail.or_else(|| {
-            if node
-                .summary
-                .as_deref()
-                .is_some_and(|s| s.starts_with("Moved from "))
-                || node
-                    .summary
-                    .as_deref()
-                    .is_some_and(|s| s.starts_with("Copied from "))
-            {
+            // Drop a bare "Moved from .../Copied from ..." headline (now
+            // demoted to a plain modify); keep any other prior summary.
+            let is_path_statement = node.summary.as_ref().is_some_and(|s| {
+                let text = s.plain_text();
+                text.starts_with("Moved from ") || text.starts_with("Copied from ")
+            });
+            if is_path_statement {
                 None
             } else {
                 node.summary.clone()

--- a/binoc-stdlib/src/transformers/fuzzy_correlation_detector.rs
+++ b/binoc-stdlib/src/transformers/fuzzy_correlation_detector.rs
@@ -299,7 +299,12 @@ fn greedy_assign(mut pairs: Vec<ScoredPair>, threshold: f64) -> Vec<(usize, usiz
 fn build_move_node(rm: &FuzzyLeaf, add: &FuzzyLeaf) -> DiffNode {
     let source_name = source_label_for_move(&rm.path, &add.path);
     let mut node = DiffNode::new("move", &add.item_type, &add.path)
-        .with_summary(format!("Moved from {source_name} (modified)"))
+        .with_summary(
+            Summary::new()
+                .text("Moved from ")
+                .path(source_name, Side::From)
+                .text(" (modified)"),
+        )
         .with_source_path(&rm.path)
         .with_tag("binoc.move")
         .with_tag("binoc.move.modified");

--- a/binoc-stdlib/src/transformers/table_collection_analyzer.rs
+++ b/binoc-stdlib/src/transformers/table_collection_analyzer.rs
@@ -189,8 +189,8 @@ fn collection_summary(
     children: &[DiffNode],
     left: &BTreeMap<String, &TableMember>,
     right: &BTreeMap<String, &TableMember>,
-) -> String {
-    let mut parts = Vec::new();
+) -> Summary {
+    let mut parts: Vec<Summary> = Vec::new();
     for child in children {
         let Some(logical_name) = logical_name_for_child(child, left, right) else {
             continue;
@@ -200,14 +200,24 @@ fn collection_summary(
             .summary
             .clone()
             .unwrap_or_else(|| fallback_table_summary(child, left, right, &logical_name));
-        parts.push(format!("{label}: {}", lower_first(&detail)));
+        // Compose the per-table clause structurally so the child's typed
+        // counts keep their grouping policy through to the renderer.
+        let mut part = Summary::new().text(format!("{label}: "));
+        part.extend(lower_first_summary(detail));
+        parts.push(part);
     }
 
     if parts.is_empty() {
-        "Table collection changed".into()
-    } else {
-        parts.join("; ")
+        return "Table collection changed".into();
     }
+    let mut out = Summary::new();
+    for (index, part) in parts.into_iter().enumerate() {
+        if index > 0 {
+            out = out.text("; ");
+        }
+        out.extend(part);
+    }
+    out
 }
 
 fn table_label(logical_name: &str, action: &str) -> String {
@@ -223,7 +233,7 @@ fn fallback_table_summary(
     left: &BTreeMap<String, &TableMember>,
     right: &BTreeMap<String, &TableMember>,
     logical_name: &str,
-) -> String {
+) -> Summary {
     let member = match child.action.as_str() {
         "remove" => left.get(logical_name).copied(),
         _ => right
@@ -232,15 +242,12 @@ fn fallback_table_summary(
             .or_else(|| left.get(logical_name).copied()),
     };
     if let Some(member) = member {
-        let columns = member.shape.columns.len();
+        let columns = member.shape.columns.len() as u64;
         let rows = member.shape.row_count.unwrap_or(0);
-        return format!(
-            "{} column{}, {} row{}",
-            columns,
-            if columns == 1 { "" } else { "s" },
-            rows,
-            if rows == 1 { "" } else { "s" }
-        );
+        return Summary::new()
+            .count(columns, "column")
+            .text(", ")
+            .count(rows, "row");
     }
     match child.action.as_str() {
         "add" => "table added".into(),
@@ -249,12 +256,17 @@ fn fallback_table_summary(
     }
 }
 
-fn lower_first(s: &str) -> String {
-    let mut chars = s.chars();
-    match chars.next() {
-        None => String::new(),
-        Some(first) => first.to_lowercase().to_string() + chars.as_str(),
+/// Lowercase the first character of a summary's leading text segment (the
+/// inverse of [`Summary::capitalize_first`]), so a child clause reads
+/// naturally after `Table X changed: `.
+fn lower_first_summary(mut summary: Summary) -> Summary {
+    if let Some(Segment::Text(text)) = summary.0.first_mut() {
+        let mut chars = text.chars();
+        if let Some(first) = chars.next() {
+            *text = first.to_lowercase().to_string() + chars.as_str();
+        }
     }
+    summary
 }
 
 #[cfg(test)]
@@ -327,7 +339,7 @@ mod tests {
         assert!(node.tags.contains("binoc.table-addition"));
         assert!(node.tags.contains("binoc.table-change"));
         assert_eq!(
-            node.summary.as_deref(),
+            node.summary.as_ref().map(|s| s.plain_text()).as_deref(),
             Some("Table users changed: 1 row added; Table posts added: new table (1 columns, 1 rows)")
         );
         assert!(node.children[0].tags.contains("binoc.table-change"));

--- a/binoc-stdlib/src/transformers/tabular_analyzer.rs
+++ b/binoc-stdlib/src/transformers/tabular_analyzer.rs
@@ -60,12 +60,10 @@ fn transform_add(mut node: DiffNode, pair: &TabularDataPair) -> TransformResult 
     let Some(right) = &pair.right else {
         return TransformResult::Unchanged;
     };
-    node.summary = Some(format!(
-        "New table ({} column{}, {} row{})",
-        right.headers.len(),
-        if right.headers.len() == 1 { "" } else { "s" },
-        right.rows.len(),
-        if right.rows.len() == 1 { "" } else { "s" }
+    node.summary = Some(table_shape_summary(
+        "New table",
+        right.headers.len() as u64,
+        right.rows.len() as u64,
     ));
     node.tags.insert("binoc.content-changed".into());
     node.details
@@ -79,12 +77,10 @@ fn transform_remove(mut node: DiffNode, pair: &TabularDataPair) -> TransformResu
     let Some(left) = &pair.left else {
         return TransformResult::Unchanged;
     };
-    node.summary = Some(format!(
-        "Table removed ({} column{}, {} row{})",
-        left.headers.len(),
-        if left.headers.len() == 1 { "" } else { "s" },
-        left.rows.len(),
-        if left.rows.len() == 1 { "" } else { "s" }
+    node.summary = Some(table_shape_summary(
+        "Table removed",
+        left.headers.len() as u64,
+        left.rows.len() as u64,
     ));
     node.tags.insert("binoc.content-changed".into());
     node.details
@@ -278,11 +274,13 @@ fn transform_modify(
     // stash the tabular description as an annotation so renderers can
     // surface it if they want without overwriting "Moved from ...".
     if node.action == "move" {
-        node.annotate_from("binoc", "tabular_summary", serde_json::json!(tabular_desc));
-    } else {
-        if tabular_desc != "Table modified" || node.summary.is_none() {
-            node.summary = Some(tabular_desc);
-        }
+        node.annotate_from(
+            "binoc",
+            "tabular_summary",
+            serde_json::json!(tabular_desc.plain_text()),
+        );
+    } else if tabular_desc.plain_text() != "Table modified" || node.summary.is_none() {
+        node.summary = Some(tabular_desc);
     }
 
     TransformResult::Replace(Box::new(node))
@@ -436,12 +434,41 @@ fn transform_modify_keyed(
     );
 
     if node.action == "move" {
-        node.annotate_from("binoc", "tabular_summary", serde_json::json!(tabular_desc));
-    } else if tabular_desc != "Table modified" || node.summary.is_none() {
+        node.annotate_from(
+            "binoc",
+            "tabular_summary",
+            serde_json::json!(tabular_desc.plain_text()),
+        );
+    } else if tabular_desc.plain_text() != "Table modified" || node.summary.is_none() {
         node.summary = Some(tabular_desc);
     }
 
     TransformResult::Replace(Box::new(node))
+}
+
+/// `New table (N columns, M rows)` / `Table removed (...)` with grouped counts.
+fn table_shape_summary(lead: &str, columns: u64, rows: u64) -> Summary {
+    Summary::new()
+        .text(format!("{lead} ("))
+        .count(columns, "column")
+        .text(", ")
+        .count(rows, "row")
+        .text(")")
+}
+
+/// Join count/clause parts with `; ` into one [`Summary`], sentence-cased.
+fn join_clauses(parts: Vec<Summary>) -> Summary {
+    if parts.is_empty() {
+        return "Table modified".into();
+    }
+    let mut out = Summary::new();
+    for (index, part) in parts.into_iter().enumerate() {
+        if index > 0 {
+            out = out.text("; ");
+        }
+        out.extend(part);
+    }
+    out.capitalize_first()
 }
 
 fn tabular_summary(
@@ -451,56 +478,44 @@ fn tabular_summary(
     rows_added: u64,
     rows_removed: u64,
     cells_changed: u64,
-) -> String {
-    let mut parts = Vec::new();
+) -> Summary {
+    let mut parts: Vec<Summary> = Vec::new();
 
-    if !columns_added.is_empty() {
-        let names: Vec<&str> = columns_added.iter().map(|s| s.as_str()).collect();
-        if names.len() == 1 {
-            parts.push(format!("column added: '{}'", names[0]));
-        } else {
-            parts.push(format!("columns added: {}", fmt_quoted_list(&names)));
-        }
+    if let Some(part) = column_clause("added", columns_added) {
+        parts.push(part);
     }
-    if !columns_removed.is_empty() {
-        let names: Vec<&str> = columns_removed.iter().map(|s| s.as_str()).collect();
-        if names.len() == 1 {
-            parts.push(format!("column removed: '{}'", names[0]));
-        } else {
-            parts.push(format!("columns removed: {}", fmt_quoted_list(&names)));
-        }
+    if let Some(part) = column_clause("removed", columns_removed) {
+        parts.push(part);
     }
     if order_changed {
         parts.push("columns reordered".into());
     }
     if rows_added > 0 {
-        parts.push(format!(
-            "{rows_added} row{} added",
-            if rows_added == 1 { "" } else { "s" }
-        ));
+        parts.push(Summary::new().count(rows_added, "row").text(" added"));
     }
     if rows_removed > 0 {
-        parts.push(format!(
-            "{rows_removed} row{} removed",
-            if rows_removed == 1 { "" } else { "s" }
-        ));
+        parts.push(Summary::new().count(rows_removed, "row").text(" removed"));
     }
     if cells_changed > 0 {
-        parts.push(format!(
-            "{cells_changed} cell{} changed",
-            if cells_changed == 1 { "" } else { "s" }
-        ));
+        parts.push(Summary::new().count(cells_changed, "cell").text(" changed"));
     }
 
-    if parts.is_empty() {
-        "Table modified".into()
-    } else {
-        let mut s = parts.join("; ");
-        if let Some(first) = s.get_mut(..1) {
-            first.make_ascii_uppercase();
-        }
-        s
+    join_clauses(parts)
+}
+
+/// `column added: 'x'` / `columns added: 'x', 'y'` — pure text (column names
+/// are identifiers, never grouped).
+fn column_clause(verb: &str, names: &[String]) -> Option<Summary> {
+    if names.is_empty() {
+        return None;
     }
+    let names: Vec<&str> = names.iter().map(|s| s.as_str()).collect();
+    let text = if names.len() == 1 {
+        format!("column {verb}: '{}'", names[0])
+    } else {
+        format!("columns {verb}: {}", fmt_quoted_list(&names))
+    };
+    Some(text.into())
 }
 
 fn fmt_quoted_list(items: &[&str]) -> String {
@@ -599,61 +614,43 @@ fn keyed_tabular_summary(
     rows_removed: u64,
     rows_modified: u64,
     cells_changed: u64,
-) -> String {
-    let mut parts = Vec::new();
+) -> Summary {
+    let mut parts: Vec<Summary> = Vec::new();
 
-    if !columns_added.is_empty() {
-        let names: Vec<&str> = columns_added.iter().map(|s| s.as_str()).collect();
-        if names.len() == 1 {
-            parts.push(format!("column added: '{}'", names[0]));
-        } else {
-            parts.push(format!("columns added: {}", fmt_quoted_list(&names)));
-        }
+    if let Some(part) = column_clause("added", columns_added) {
+        parts.push(part);
     }
-    if !columns_removed.is_empty() {
-        let names: Vec<&str> = columns_removed.iter().map(|s| s.as_str()).collect();
-        if names.len() == 1 {
-            parts.push(format!("column removed: '{}'", names[0]));
-        } else {
-            parts.push(format!("columns removed: {}", fmt_quoted_list(&names)));
-        }
+    if let Some(part) = column_clause("removed", columns_removed) {
+        parts.push(part);
     }
     if order_changed {
         parts.push("columns reordered".into());
     }
     if rows_added > 0 {
-        parts.push(format!(
-            "{rows_added} row{} added by key",
-            if rows_added == 1 { "" } else { "s" }
-        ));
+        parts.push(
+            Summary::new()
+                .count(rows_added, "row")
+                .text(" added by key"),
+        );
     }
     if rows_removed > 0 {
-        parts.push(format!(
-            "{rows_removed} row{} removed by key",
-            if rows_removed == 1 { "" } else { "s" }
-        ));
+        parts.push(
+            Summary::new()
+                .count(rows_removed, "row")
+                .text(" removed by key"),
+        );
     }
     if rows_modified > 0 {
-        parts.push(format!(
-            "{rows_modified} row{} modified by key",
-            if rows_modified == 1 { "" } else { "s" }
-        ));
+        parts.push(
+            Summary::new()
+                .count(rows_modified, "row")
+                .text(" modified by key"),
+        );
     } else if cells_changed > 0 {
-        parts.push(format!(
-            "{cells_changed} cell{} changed",
-            if cells_changed == 1 { "" } else { "s" }
-        ));
+        parts.push(Summary::new().count(cells_changed, "cell").text(" changed"));
     }
 
-    if parts.is_empty() {
-        "Table modified".into()
-    } else {
-        let mut s = parts.join("; ");
-        if let Some(first) = s.get_mut(..1) {
-            first.make_ascii_uppercase();
-        }
-        s
-    }
+    join_clauses(parts)
 }
 
 #[derive(Debug, Clone)]

--- a/binoc-stdlib/tests/transformer_tests.rs
+++ b/binoc-stdlib/tests/transformer_tests.rs
@@ -544,7 +544,12 @@ fn correlation_detector_aggregates_one_to_many_copy() {
                 .get("destinations")
                 .expect("destinations present");
             assert_eq!(dests.as_array().unwrap().len(), 2);
-            assert!(copy.summary.as_deref().unwrap().contains("copy_a.bin"));
+            assert!(copy
+                .summary
+                .as_ref()
+                .unwrap()
+                .plain_text()
+                .contains("copy_a.bin"));
         }
         _ => panic!("Expected Replace"),
     }
@@ -808,7 +813,10 @@ fn folder_move_rolls_up_partial_rename_and_keeps_remainders() {
         .expect("modified remainder");
     assert_eq!(modified.action, "modify");
     assert_eq!(modified.source_path, None);
-    assert_eq!(modified.summary.as_deref(), Some("2 lines added"));
+    assert_eq!(
+        modified.summary.as_ref().map(|s| s.plain_text()).as_deref(),
+        Some("2 lines added")
+    );
     assert!(!modified.tags.contains("binoc.move"));
 
     let removed = folded
@@ -949,7 +957,12 @@ fn tabular_analyzer_detects_cell_changes() {
         TransformResult::Replace(n) => {
             assert!(n.tags.contains("binoc.cell-change"));
             assert_eq!(n.details["cells_changed"], 2);
-            assert!(n.summary.as_ref().unwrap().contains("2 cells changed"));
+            assert!(n
+                .summary
+                .as_ref()
+                .unwrap()
+                .plain_text()
+                .contains("2 cells changed"));
             assert_eq!(n.detail_blocks.len(), 1);
             let block = &n.detail_blocks[0];
             assert_eq!(block.id, "cells_changed");
@@ -1041,8 +1054,13 @@ fn tabular_analyzer_handles_add_action() {
     match TabularAnalyzer.transform(node, &data, &null_cfg()) {
         TransformResult::Replace(n) => {
             assert!(n.tags.contains("binoc.content-changed"));
-            assert!(n.summary.as_ref().unwrap().contains("2 columns"));
-            assert!(n.summary.as_ref().unwrap().contains("2 rows"));
+            assert!(n
+                .summary
+                .as_ref()
+                .unwrap()
+                .plain_text()
+                .contains("2 columns"));
+            assert!(n.summary.as_ref().unwrap().plain_text().contains("2 rows"));
         }
         _ => panic!("Expected Replace"),
     }
@@ -1065,8 +1083,13 @@ fn tabular_analyzer_handles_remove_action() {
     match TabularAnalyzer.transform(node, &data, &null_cfg()) {
         TransformResult::Replace(n) => {
             assert!(n.tags.contains("binoc.content-changed"));
-            assert!(n.summary.as_ref().unwrap().contains("3 columns"));
-            assert!(n.summary.as_ref().unwrap().contains("1 row"));
+            assert!(n
+                .summary
+                .as_ref()
+                .unwrap()
+                .plain_text()
+                .contains("3 columns"));
+            assert!(n.summary.as_ref().unwrap().plain_text().contains("1 row"));
         }
         _ => panic!("Expected Replace"),
     }

--- a/docs/adr/2026-06-03-structured-summary-segments.md
+++ b/docs/adr/2026-06-03-structured-summary-segments.md
@@ -1,0 +1,112 @@
+# Structured Summary Segments
+
+**Date:** 2026-06-03
+**Status:** Implemented
+
+## Context
+
+`DiffNode::summary` was a free-text string built by whichever comparator or
+transformer produced the node (for example `format!("{a} lines added, {r}
+removed")`). By the time a renderer saw it, the *type* of every value in it was
+gone — it was just characters. To present numbers well (thousands grouping) the
+markdown renderer had to reverse-engineer structure the producer had already
+thrown away: it scanned the prose for digit runs and used heuristics
+(neighbouring unit words, adjacency to path/identifier characters, a set of
+"known count" values pulled from `details`) to guess which digits were counts to
+group and which were years, IDs, or path fragments to leave alone. Each new edge
+case (a date inside a folder name, a leading-zero code) needed another guard.
+
+A parallel smell sat next to it. Rename and copy headlines were detected with
+`summary_is_path_statement`, which string-matched the `"Moved from "` /
+`"Copied from "` prefixes that the renderer's own fallback emitted — the renderer
+pattern-matching its own output to recover a fact (`action`, `source_path`) that
+was already a typed field on the node.
+
+Both are the same anti-pattern: producers flatten typed values to prose, then the
+renderer parses the prose back into types it can format. The middle two steps are
+pure loss and can only ever be heuristic.
+
+A further constraint: rename/move/copy detection lives in transformers, some of
+them out-of-tree plugins, and `action` is an open set. A renderer must not encode
+what "move" means, or it cannot compose with a plugin that invents a new
+relational action.
+
+## Decision
+
+`DiffNode::summary` is now `Option<Summary>`, where a `Summary` is an ordered
+list of typed `Segment`s. Producers build it; renderers format each segment by
+its type and never parse prose.
+
+```rust
+pub enum Segment {
+    Text(String),                       // verbatim
+    Path { value: String, snapshot: Side }, // linkable; which side it resolves in
+    Uint(u64),                          // digit-grouped by the renderer
+    Float(f64),                         // decimal/precision policy by the renderer
+}
+pub struct Summary(pub Vec<Segment>);   // serializes transparently as a JSON array
+```
+
+Design rules that keep the variant set small and the layering clean:
+
+- **Variants track render behaviour, not meaning.** A variant exists only when a
+  renderer would do something to the value it cannot infer from `Text`: group an
+  integer (`Uint`), apply decimal policy (`Float`), hyperlink/shorten a path
+  (`Path`). Currency, percent, and units are `Text` plus a number, never their
+  own variant — this is the line that stops an "Excel zoo" of format types.
+- **Path/date are not how we avoid mangling.** Digits inside `Text` (and inside a
+  `Path` value, such as a year in a folder name) are never reformatted. A number
+  that should be grouped is a `Uint`; everything else is left exactly alone. The
+  old heuristics disappear because the question "is this digit run a count?" was
+  answered upstream, where the value was still a `u64`.
+- **Producers own concept wording; renderers own typography.** A rename detector
+  emits `Text("Moved from ") + Path(src, Side::From)`. The renderer formats a
+  `Path` (today: verbatim; a richer renderer can hyperlink it) without knowing it
+  is a rename. A future `split`/`merge` plugin emits its own wording and the same
+  renderer formats it with no new code. `summary_is_path_statement` and the
+  renderer's concept knowledge are gone.
+- **Direction is a property of the value.** `Segment::Path` carries `snapshot:
+  Side` (`From`/`To`) so a renderer that dereferences a path targets the correct
+  tree — framed as "which snapshot does this resolve in", not "rename direction".
+
+The ergonomic shortcut is `impl Into<Summary>`: `with_summary("plain text")` (and
+`with_summary(format!(...))`) still compiles and produces a single
+`Segment::Text`. Plain-string summaries remain valid and render verbatim;
+producers opt into structured segments only where formatting matters. Wire and
+Python surfaces preserve a plain-text view via `Summary::plain_text()`.
+
+This carries across the plugin ABI unchanged in mechanism — `DiffNode` already
+serializes to JSON for native plugins — and the persisted changeset now exposes
+`summary` as a typed segment array, which machine consumers can read directly or
+flatten.
+
+## Alternatives Considered
+
+**Keep the prose summary and harden the number scanner.** This was the prior
+direction (constrain humanization with more guards). It makes the reverse-parse
+safer but never removes the need to reverse-parse; every new summary phrasing is
+a new risk. Rejected as treating the symptom.
+
+**Push number formatting into the SDK so producers emit grouped strings.**
+Grouping is a render-time/locale decision the producer cannot make (it does not
+know the output sink). The formatter must run in the renderer, which means the
+renderer needs the raw number — i.e. structured segments. So this collapses back
+into the chosen design.
+
+**Generate the move/rename headline in the renderer from `source_path`/`path`.**
+This removes the prose reparse but reintroduces concept coupling: the renderer
+would `match` on `action` and could not compose with plugin-defined relational
+actions. Rejected in favour of producers emitting the segments (including their
+own `Path`s) and the renderer staying concept-free.
+
+**A semantic enum (`Count`, `Currency`, `Percent`, `Date`, `FileSize`, ...).**
+This is the unbounded "Excel zoo". Keyed on meaning, the set never closes.
+Rejected; variants are keyed on render behaviour instead. New *typographic*
+policies (humanized bytes, durations) remain possible as justified future
+additions, or via an optional format-hint axis, without encoding domain meaning.
+
+**Carry the trailing content summary on move nodes as structured segments too.**
+The `tabular_summary` / `content_summary` annotation trailers stay plain strings
+for now, because the folder-move detector reads them with `.as_str()`; they
+render verbatim (counts in a trailer are not grouped). A deliberate, documented
+boundary — the primary `summary` is structured; annotation trailers are prose.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -7,6 +7,7 @@ Newer entries appear first. Each entry shows its date and current status. Create
 | Date | Title | Status |
 |---|---|---|
 | 2026-06-03 | [Transformer-Initiated Recompare as a Correspondence Contract](2026-06-03-transformer_initiated_recompare.md) | Implemented |
+| 2026-06-03 | [Structured Summary Segments](2026-06-03-structured-summary-segments.md) | Implemented |
 | 2026-06-03 | [Progressive Renderer Annotations](2026-06-03-progressive_renderer_annotations.md) | Implemented |
 | 2026-06-03 | [Error Diagnostics Are Reportable Findings](2026-06-03-error_diagnostics_are_reportable_findings.md) | Implemented |
 | 2026-06-02 | [Markdown Renderer Groups Replace Significance-Map Grouping](2026-06-02-renderer_groups.md) | Implemented |

--- a/docs/explanation/test-vectors-gallery.md
+++ b/docs/explanation/test-vectors-gallery.md
@@ -49,7 +49,7 @@ just materialize
 | [`file-correspondence-scheme`](#file-correspondence-scheme) | Config declares that a state CSV moved into a new directory scheme is the same logical file | states/AL.csv: 1 row added | Custom config |
 | [`file-correspondence-token`](#file-correspondence-token) | Config declares that year-stamped CSV filenames are the same logical file | running_list.csv: 1 row added | Custom config |
 | [`folder-move-nested`](#folder-move-nested) | Detects a whole-folder rename and rolls many file moves up into one folder-move entry. | documentation: Folder moved from docs | Default pipeline |
-| [`folder-move-partial`](#folder-move-partial) | Detects a mostly-moved folder rename and preserves only the added/removed/modified remainder entries beneath it. | FoodData_Central_csv_2026-04-30: Folder moved from FoodData_Central_csv_2,025-12-18 | Custom config |
+| [`folder-move-partial`](#folder-move-partial) | Detects a mostly-moved folder rename and preserves only the added/removed/modified remainder entries beneath it. | FoodData_Central_csv_2026-04-30: Folder moved from FoodData_Central_csv_2025-12-18 | Custom config |
 | [`gzip-inner-dispatch`](#gzip-inner-dispatch) | Gzipped CSV and text are decompressed and redispatched under their inner names | census.txt: 1 line added, 1 removed | Default pipeline |
 | [`kitchen-sink`](#kitchen-sink) | Runs text, CSV, archive, move, and copy detection together in one end-to-end example. | archive.tar.gz/inventory.csv: 1 row added | Default pipeline |
 | [`single-file-add`](#single-file-add) | File present in B but not A | new_file.txt: New file (1 line) | Default pipeline |
@@ -657,7 +657,7 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-- **FoodData_Central_csv_2026-04-30**: Folder moved from FoodData_Central_csv_2,025-12-18
+- **FoodData_Central_csv_2026-04-30**: Folder moved from FoodData_Central_csv_2025-12-18
 - **FoodData_Central_csv_2026-04-30/data/new-table.csv**: New table (2 columns, 1 row)
 - **FoodData_Central_csv_2026-04-30/docs/modified.txt**: Text modified
 - **FoodData_Central_csv_2026-04-30/docs/old-table.txt**: File removed (1 line)

--- a/docs/reference/changeset-schema.json
+++ b/docs/reference/changeset-schema.json
@@ -328,10 +328,14 @@
           ]
         },
         "summary": {
-          "description": "Optional human-readable one-liner describing the change.\nSet by comparator or transformer; used by renderers for narrative rendering.",
-          "type": [
-            "string",
-            "null"
+          "description": "Optional structured one-liner describing the change. Set by a\ncomparator or transformer; renderers format each [`Segment`] by its\ntype. Build it with [`Summary`]'s builder, or pass a plain string —\n`impl Into<Summary>` wraps it as a single [`Segment::Text`].",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Summary"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "tags": {
@@ -441,6 +445,100 @@
         "logical_path",
         "is_dir"
       ]
+    },
+    "Segment": {
+      "description": "One piece of a [`Summary`].\n\nEach variant carries a value *and*, implicitly, the render-time policy\nfor it: group an integer, format a float, leave text alone, dereference\na path. Renderers format by variant; they never parse prose to recover\nthe type of a value, because the producer never threw it away. Variants\ntrack *render behavior*, not semantics — a currency or percent is `Text`\nplus a number, never its own variant. See ADR\n2026-06-03-structured-summary-segments.",
+      "oneOf": [
+        {
+          "description": "Verbatim text: connective wording, units, punctuation, and any\nvalue the renderer must not reinterpret. Embedded digits are never\nreformatted — a number that should be grouped is a [`Segment::Uint`],\nand a path that could be linked is a [`Segment::Path`].",
+          "type": "object",
+          "properties": {
+            "text": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "text"
+          ]
+        },
+        {
+          "description": "A path or locator. Renderers may shorten or hyperlink it; `snapshot`\nsays which side of the diff it resolves in.",
+          "type": "object",
+          "properties": {
+            "path": {
+              "type": "object",
+              "properties": {
+                "snapshot": {
+                  "$ref": "#/$defs/Side"
+                },
+                "value": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "value",
+                "snapshot"
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "path"
+          ]
+        },
+        {
+          "description": "A non-negative count. Renderers apply digit grouping / locale.",
+          "type": "object",
+          "properties": {
+            "uint": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "uint"
+          ]
+        },
+        {
+          "description": "A real-valued quantity. Renderers apply decimal / precision policy.",
+          "type": "object",
+          "properties": {
+            "float": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "float"
+          ]
+        }
+      ]
+    },
+    "Side": {
+      "description": "Which snapshot a [`Segment::Path`] resolves in.\n\nLets a renderer that can dereference a path — hyperlink it, shorten it\nagainst a tree, show an icon — target the correct side of the diff\nwithout understanding *why* the path appears (rename, copy,\ncross-reference, ...). It is a property of the value, not an encoding of\nany one concept. See ADR 2026-06-03-structured-summary-segments.",
+      "oneOf": [
+        {
+          "description": "The \"before\" snapshot (a source/original path).",
+          "type": "string",
+          "const": "from"
+        },
+        {
+          "description": "The \"after\" snapshot (a destination/current path).",
+          "type": "string",
+          "const": "to"
+        }
+      ]
+    },
+    "Summary": {
+      "description": "A structured, render-ready one-line summary: an ordered list of typed\n[`Segment`]s.\n\nProducers (comparators, transformers, plugins) build it; renderers format\neach segment by its type. This replaces free-text summaries so that\nnumber and path formatting is a render-time decision the renderer makes\nfrom typed values, rather than a fragile reparse of prose. A producer\nthat owns a concept (a rename detector) owns the *wording* — it emits the\nconnective `Text` and the `Path`s — while the renderer owns the\n*typography*. See ADR 2026-06-03-structured-summary-segments.\n\nThe ergonomic shortcut for the common case is `impl Into<Summary>`:\n`with_summary(\"plain text\")` still works and produces a single\n[`Segment::Text`].",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Segment"
+      }
     },
     "ValuePreview": {
       "description": "A bounded preview of one value in a detail example.",

--- a/docs/reference/changeset-schema.md
+++ b/docs/reference/changeset-schema.md
@@ -84,7 +84,7 @@ A node in the diff tree — the central data structure of the system. Every comp
 | `pending_recompare` | [`ItemPair`](#itempair) \| null | no | Request that the controller re-dispatch the given `ItemPair` through the comparator pipeline and merge the result into this semantic wrapper node before the next transformer runs. Set by transformers that have discovered a correspondence (for example, a rename-with-edits or a config-declared logical file pair) but still need normal comparators to parse the paired content. If the recomparison is identical, a plain `modify` wrapper is converted to `identical` so it can be pruned, while semantic wrappers such as moves remain reportable. Session-scoped working data: wire-visible so plugins can set it across the ABI boundary, but cleared by [`DiffNode::strip_transient`] before changeset output. The controller takes (clears) this field as it processes it; nodes in a finalized changeset never carry it. |
 | `source_items` | [`ItemPair`](#itempair) \| null | no | The original item pair that produced this node. Session-scoped working data: available during a live diff/transform session for transformers and extractors that need to re-read source data, and carried across the plugin ABI wire so separately-compiled plugins can access it. Callers writing changeset output must strip this via [`DiffNode::strip_transient`] before serializing. |
 | `source_path` | string \| null | no | For moves/renames: the original path. |
-| `summary` | string \| null | no | Optional human-readable one-liner describing the change. Set by comparator or transformer; used by renderers for narrative rendering. |
+| `summary` | [`Summary`](#summary) \| null | no | Optional structured one-liner describing the change. Set by a comparator or transformer; renderers format each [`Segment`] by its type. Build it with [`Summary`]'s builder, or pass a plain string — `impl Into<Summary>` wraps it as a single [`Segment::Text`]. |
 | `tags` | array of string | no | Open bag of semantic tags, namespaced by convention. e.g. "binoc.column-reorder", "biobinoc.gap-change" |
 | `transformed_by` | array of string | no | Transformers that modified this node, in order (provenance for extract chain). |
 
@@ -201,6 +201,18 @@ Pointer to an extract aspect that can return exhaustive content.
 |---|---|---|---|
 | `aspect` | string | yes | Aspect name accepted by `binoc extract`. |
 | `label` | string \| null | no |  |
+
+### `Segment`
+
+*(unrecognised schema shape)*
+
+### `Side`
+
+*(unrecognised schema shape)*
+
+### `Summary`
+
+*(unrecognised schema shape)*
 
 ### `ValuePreview`
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -162,6 +162,7 @@ nav:
           # BEGIN-ADR-NAV
           - adr/README.md
           - 'Transformer-Initiated Recompare as a Correspondence Contract': adr/2026-06-03-transformer_initiated_recompare.md
+          - 'Structured Summary Segments': adr/2026-06-03-structured-summary-segments.md
           - 'Progressive Renderer Annotations': adr/2026-06-03-progressive_renderer_annotations.md
           - 'Error Diagnostics Are Reportable Findings': adr/2026-06-03-error_diagnostics_are_reportable_findings.md
           - 'Markdown Renderer Groups Replace Significance-Map Grouping': adr/2026-06-02-renderer_groups.md

--- a/model-plugins/binoc-row-reorder/test-vectors/csv-row-reorder/expected-output/changeset.snap
+++ b/model-plugins/binoc-row-reorder/test-vectors/csv-row-reorder/expected-output/changeset.snap
@@ -14,7 +14,11 @@ expression: "&stable_changeset"
         "action": "modify",
         "item_type": "tabular",
         "path": "data.csv",
-        "summary": "Rows reordered (same data, different sort order)",
+        "summary": [
+          {
+            "text": "Rows reordered (same data, different sort order)"
+          }
+        ],
         "tags": [
           "binoc.cell-change",
           "binoc.row-reorder"

--- a/model-plugins/binoc-sqlite/src/sqlite.rs
+++ b/model-plugins/binoc-sqlite/src/sqlite.rs
@@ -398,7 +398,7 @@ fn diff_table(input: TableDiffInput<'_>) -> Option<DiffNode> {
         ));
     }
 
-    node.summary = Some(capitalize(&parts.join("; ")));
+    node.summary = Some(capitalize(&parts.join("; ")).into());
     Some(node)
 }
 
@@ -831,7 +831,7 @@ mod tests {
                 assert_eq!(node.action, "add");
                 assert_eq!(node.item_type, "tabular_collection");
                 assert_eq!(node.children.len(), 1);
-                assert!(node.summary.unwrap().contains("1 table"));
+                assert!(node.summary.unwrap().plain_text().contains("1 table"));
             }
             _ => panic!("expected Leaf"),
         }
@@ -858,7 +858,7 @@ mod tests {
                 assert_eq!(node.action, "remove");
                 assert_eq!(node.item_type, "tabular_collection");
                 assert_eq!(node.children.len(), 2);
-                assert!(node.summary.unwrap().contains("2 tables"));
+                assert!(node.summary.unwrap().plain_text().contains("2 tables"));
             }
             _ => panic!("expected Leaf"),
         }

--- a/model-plugins/binoc-sqlite/test-vectors/sqlite-multitable-changes/expected-output/changeset.snap
+++ b/model-plugins/binoc-sqlite/test-vectors/sqlite-multitable-changes/expected-output/changeset.snap
@@ -14,7 +14,35 @@ expression: "&stable_changeset"
         "action": "modify",
         "item_type": "tabular_collection",
         "path": "data.sqlite",
-        "summary": "Table users changed: 1 row added; Table orders added: new table (3 columns, 1 row)",
+        "summary": [
+          {
+            "text": "Table users changed: "
+          },
+          {
+            "uint": 1
+          },
+          {
+            "text": " row added; "
+          },
+          {
+            "text": "Table orders added: "
+          },
+          {
+            "text": "new table ("
+          },
+          {
+            "uint": 3
+          },
+          {
+            "text": " columns, "
+          },
+          {
+            "uint": 1
+          },
+          {
+            "text": " row)"
+          }
+        ],
         "tags": [
           "binoc.table-addition",
           "binoc.table-change",
@@ -25,7 +53,14 @@ expression: "&stable_changeset"
             "action": "modify",
             "item_type": "tabular",
             "path": "data.sqlite::users",
-            "summary": "1 row added",
+            "summary": [
+              {
+                "uint": 1
+              },
+              {
+                "text": " row added"
+              }
+            ],
             "tags": [
               "binoc-sqlite.row-addition",
               "binoc.row-addition",
@@ -57,7 +92,23 @@ expression: "&stable_changeset"
             "action": "add",
             "item_type": "tabular",
             "path": "data.sqlite::orders",
-            "summary": "New table (3 columns, 1 row)",
+            "summary": [
+              {
+                "text": "New table ("
+              },
+              {
+                "uint": 3
+              },
+              {
+                "text": " columns, "
+              },
+              {
+                "uint": 1
+              },
+              {
+                "text": " row)"
+              }
+            ],
             "tags": [
               "binoc-sqlite.table-addition",
               "binoc.content-changed",

--- a/model-plugins/binoc-sqlite/test-vectors/sqlite-row-addition/expected-output/changeset.snap
+++ b/model-plugins/binoc-sqlite/test-vectors/sqlite-row-addition/expected-output/changeset.snap
@@ -14,7 +14,17 @@ expression: "&stable_changeset"
         "action": "modify",
         "item_type": "tabular_collection",
         "path": "data.sqlite",
-        "summary": "Table users changed: 1 row added",
+        "summary": [
+          {
+            "text": "Table users changed: "
+          },
+          {
+            "uint": 1
+          },
+          {
+            "text": " row added"
+          }
+        ],
         "tags": [
           "binoc.table-change",
           "binoc.tabular-collection-change"
@@ -24,7 +34,14 @@ expression: "&stable_changeset"
             "action": "modify",
             "item_type": "tabular",
             "path": "data.sqlite::users",
-            "summary": "1 row added",
+            "summary": [
+              {
+                "uint": 1
+              },
+              {
+                "text": " row added"
+              }
+            ],
             "tags": [
               "binoc-sqlite.row-addition",
               "binoc.row-addition",

--- a/model-plugins/binoc-sqlite/test-vectors/sqlite-table-addition/expected-output/changeset.snap
+++ b/model-plugins/binoc-sqlite/test-vectors/sqlite-table-addition/expected-output/changeset.snap
@@ -14,7 +14,26 @@ expression: "&stable_changeset"
         "action": "modify",
         "item_type": "tabular_collection",
         "path": "data.sqlite",
-        "summary": "Table posts added: new table (3 columns, 1 row)",
+        "summary": [
+          {
+            "text": "Table posts added: "
+          },
+          {
+            "text": "new table ("
+          },
+          {
+            "uint": 3
+          },
+          {
+            "text": " columns, "
+          },
+          {
+            "uint": 1
+          },
+          {
+            "text": " row)"
+          }
+        ],
         "tags": [
           "binoc.table-addition",
           "binoc.tabular-collection-change"
@@ -24,7 +43,23 @@ expression: "&stable_changeset"
             "action": "add",
             "item_type": "tabular",
             "path": "data.sqlite::posts",
-            "summary": "New table (3 columns, 1 row)",
+            "summary": [
+              {
+                "text": "New table ("
+              },
+              {
+                "uint": 3
+              },
+              {
+                "text": " columns, "
+              },
+              {
+                "uint": 1
+              },
+              {
+                "text": " row)"
+              }
+            ],
             "tags": [
               "binoc-sqlite.table-addition",
               "binoc.content-changed",

--- a/model-plugins/binoc-sqlite/test-vectors/without-plugin/expected-output/changeset.snap
+++ b/model-plugins/binoc-sqlite/test-vectors/without-plugin/expected-output/changeset.snap
@@ -14,7 +14,11 @@ expression: "&stable_changeset"
         "action": "modify",
         "item_type": "file",
         "path": "data.sqlite",
-        "summary": "Content changed (8.0 KB → 8.0 KB)",
+        "summary": [
+          {
+            "text": "Content changed (8.0 KB → 8.0 KB)"
+          }
+        ],
         "tags": [
           "binoc.content-changed"
         ],

--- a/model-plugins/binoc-stat-binary/test-vectors/sas7bdat-column-addition/expected-output/changeset.snap
+++ b/model-plugins/binoc-stat-binary/test-vectors/sas7bdat-column-addition/expected-output/changeset.snap
@@ -14,7 +14,11 @@ expression: "&stable_changeset"
         "action": "modify",
         "item_type": "tabular",
         "path": "data.sas7bdat",
-        "summary": "Column added: 'score'",
+        "summary": [
+          {
+            "text": "Column added: 'score'"
+          }
+        ],
         "tags": [
           "binoc.column-addition",
           "binoc.schema-change"

--- a/model-plugins/binoc-stat-binary/test-vectors/stata-column-addition/expected-output/changeset.snap
+++ b/model-plugins/binoc-stat-binary/test-vectors/stata-column-addition/expected-output/changeset.snap
@@ -14,7 +14,11 @@ expression: "&stable_changeset"
         "action": "modify",
         "item_type": "tabular",
         "path": "data.dta",
-        "summary": "Column added: 'score'",
+        "summary": [
+          {
+            "text": "Column added: 'score'"
+          }
+        ],
         "tags": [
           "binoc.column-addition",
           "binoc.schema-change"

--- a/model-plugins/binoc-stat-binary/test-vectors/xpt-column-addition/expected-output/changeset.snap
+++ b/model-plugins/binoc-stat-binary/test-vectors/xpt-column-addition/expected-output/changeset.snap
@@ -14,7 +14,11 @@ expression: "&stable_changeset"
         "action": "modify",
         "item_type": "tabular",
         "path": "data.xpt",
-        "summary": "Column added: 'score'",
+        "summary": [
+          {
+            "text": "Column added: 'score'"
+          }
+        ],
         "tags": [
           "binoc.column-addition",
           "binoc.schema-change"

--- a/model-plugins/binoc-stat-binary/test-vectors/xpt-multidataset-members/expected-output/changeset.snap
+++ b/model-plugins/binoc-stat-binary/test-vectors/xpt-multidataset-members/expected-output/changeset.snap
@@ -14,7 +14,11 @@ expression: "&stable_changeset"
         "action": "modify",
         "item_type": "tabular_collection",
         "path": "data.xpt",
-        "summary": "Table DM changed: 1 row added; Table LB added: new table (2 columns, 1 row)",
+        "summary": [
+          {
+            "text": "Table DM changed: 1 row added; Table LB added: new table (2 columns, 1 row)"
+          }
+        ],
         "tags": [
           "binoc.table-addition",
           "binoc.table-change",
@@ -25,7 +29,14 @@ expression: "&stable_changeset"
             "action": "modify",
             "item_type": "tabular",
             "path": "data.xpt::DM",
-            "summary": "1 row added",
+            "summary": [
+              {
+                "uint": 1
+              },
+              {
+                "text": " row added"
+              }
+            ],
             "tags": [
               "binoc.row-addition",
               "binoc.table-change"
@@ -140,7 +151,23 @@ expression: "&stable_changeset"
             "action": "add",
             "item_type": "tabular",
             "path": "data.xpt::LB",
-            "summary": "New table (2 columns, 1 row)",
+            "summary": [
+              {
+                "text": "New table ("
+              },
+              {
+                "uint": 2
+              },
+              {
+                "text": " columns, "
+              },
+              {
+                "uint": 1
+              },
+              {
+                "text": " row)"
+              }
+            ],
             "tags": [
               "binoc.content-changed",
               "binoc.table-addition"

--- a/test-vectors/binary-fallback-diagnostic/expected-output/changeset.snap
+++ b/test-vectors/binary-fallback-diagnostic/expected-output/changeset.snap
@@ -14,7 +14,11 @@ expression: "&stable_changeset"
         "action": "modify",
         "item_type": "file",
         "path": "data.parquet",
-        "summary": "Content changed (7 bytes → 7 bytes)",
+        "summary": [
+          {
+            "text": "Content changed (7 bytes → 7 bytes)"
+          }
+        ],
         "tags": [
           "binoc.content-changed"
         ],

--- a/test-vectors/csv-cell-changes/expected-output/changeset.snap
+++ b/test-vectors/csv-cell-changes/expected-output/changeset.snap
@@ -14,7 +14,14 @@ expression: "&stable_changeset"
         "action": "modify",
         "item_type": "tabular",
         "path": "data.csv",
-        "summary": "2 cells changed",
+        "summary": [
+          {
+            "uint": 2
+          },
+          {
+            "text": " cells changed"
+          }
+        ],
         "tags": [
           "binoc.cell-change"
         ],

--- a/test-vectors/csv-column-addition/expected-output/changeset.snap
+++ b/test-vectors/csv-column-addition/expected-output/changeset.snap
@@ -14,7 +14,11 @@ expression: "&stable_changeset"
         "action": "modify",
         "item_type": "tabular",
         "path": "data.csv",
-        "summary": "Column added: 'email'",
+        "summary": [
+          {
+            "text": "Column added: 'email'"
+          }
+        ],
         "tags": [
           "binoc.column-addition",
           "binoc.schema-change"

--- a/test-vectors/csv-column-removal/expected-output/changeset.snap
+++ b/test-vectors/csv-column-removal/expected-output/changeset.snap
@@ -14,7 +14,11 @@ expression: "&stable_changeset"
         "action": "modify",
         "item_type": "tabular",
         "path": "data.csv",
-        "summary": "Column removed: 'city'",
+        "summary": [
+          {
+            "text": "Column removed: 'city'"
+          }
+        ],
         "tags": [
           "binoc.column-removal",
           "binoc.schema-change"

--- a/test-vectors/csv-column-reorder/expected-output/changeset.snap
+++ b/test-vectors/csv-column-reorder/expected-output/changeset.snap
@@ -14,7 +14,11 @@ expression: "&stable_changeset"
         "action": "reorder",
         "item_type": "tabular",
         "path": "data.csv",
-        "summary": "Columns reordered (content unchanged)",
+        "summary": [
+          {
+            "text": "Columns reordered (content unchanged)"
+          }
+        ],
         "tags": [
           "binoc.column-reorder"
         ],

--- a/test-vectors/csv-distribution-shift/expected-output/changeset.snap
+++ b/test-vectors/csv-distribution-shift/expected-output/changeset.snap
@@ -14,7 +14,14 @@ expression: "&stable_changeset"
         "action": "modify",
         "item_type": "tabular",
         "path": "data.csv",
-        "summary": "4 rows modified by key",
+        "summary": [
+          {
+            "uint": 4
+          },
+          {
+            "text": " rows modified by key"
+          }
+        ],
         "tags": [
           "binoc.cell-change"
         ],

--- a/test-vectors/csv-keyed-null-duplicate/expected-output/changeset.snap
+++ b/test-vectors/csv-keyed-null-duplicate/expected-output/changeset.snap
@@ -14,7 +14,26 @@ expression: "&stable_changeset"
         "action": "modify",
         "item_type": "tabular",
         "path": "data.csv",
-        "summary": "4 rows added by key; 4 rows removed by key; 1 row modified by key",
+        "summary": [
+          {
+            "uint": 4
+          },
+          {
+            "text": " rows added by key; "
+          },
+          {
+            "uint": 4
+          },
+          {
+            "text": " rows removed by key; "
+          },
+          {
+            "uint": 1
+          },
+          {
+            "text": " row modified by key"
+          }
+        ],
         "tags": [
           "binoc.ambiguous-key",
           "binoc.cell-change",

--- a/test-vectors/csv-keyed-row-diff/expected-output/changeset.snap
+++ b/test-vectors/csv-keyed-row-diff/expected-output/changeset.snap
@@ -14,7 +14,26 @@ expression: "&stable_changeset"
         "action": "modify",
         "item_type": "tabular",
         "path": "data.csv",
-        "summary": "1 row added by key; 1 row removed by key; 1 row modified by key",
+        "summary": [
+          {
+            "uint": 1
+          },
+          {
+            "text": " row added by key; "
+          },
+          {
+            "uint": 1
+          },
+          {
+            "text": " row removed by key; "
+          },
+          {
+            "uint": 1
+          },
+          {
+            "text": " row modified by key"
+          }
+        ],
         "tags": [
           "binoc.cell-change",
           "binoc.row-addition",

--- a/test-vectors/csv-mixed-changes/expected-output/changeset.snap
+++ b/test-vectors/csv-mixed-changes/expected-output/changeset.snap
@@ -14,7 +14,20 @@ expression: "&stable_changeset"
         "action": "modify",
         "item_type": "tabular",
         "path": "data.csv",
-        "summary": "Column added: 'email'; columns reordered; 1 row added",
+        "summary": [
+          {
+            "text": "Column added: 'email'; "
+          },
+          {
+            "text": "columns reordered; "
+          },
+          {
+            "uint": 1
+          },
+          {
+            "text": " row added"
+          }
+        ],
         "tags": [
           "binoc.column-addition",
           "binoc.column-reorder",

--- a/test-vectors/csv-rename-modify/expected-output/changeset.snap
+++ b/test-vectors/csv-rename-modify/expected-output/changeset.snap
@@ -15,7 +15,20 @@ expression: "&stable_changeset"
         "item_type": "tabular",
         "path": "data_v2.csv",
         "source_path": "data.csv",
-        "summary": "Moved from data.csv (modified)",
+        "summary": [
+          {
+            "text": "Moved from "
+          },
+          {
+            "path": {
+              "value": "data.csv",
+              "snapshot": "from"
+            }
+          },
+          {
+            "text": " (modified)"
+          }
+        ],
         "tags": [
           "binoc.column-addition",
           "binoc.move",

--- a/test-vectors/csv-row-addition/expected-output/changeset.snap
+++ b/test-vectors/csv-row-addition/expected-output/changeset.snap
@@ -14,7 +14,14 @@ expression: "&stable_changeset"
         "action": "modify",
         "item_type": "tabular",
         "path": "data.csv",
-        "summary": "2 rows added",
+        "summary": [
+          {
+            "uint": 2
+          },
+          {
+            "text": " rows added"
+          }
+        ],
         "tags": [
           "binoc.row-addition"
         ],

--- a/test-vectors/csv-row-removal/expected-output/changeset.snap
+++ b/test-vectors/csv-row-removal/expected-output/changeset.snap
@@ -14,7 +14,14 @@ expression: "&stable_changeset"
         "action": "modify",
         "item_type": "tabular",
         "path": "data.csv",
-        "summary": "2 rows removed",
+        "summary": [
+          {
+            "uint": 2
+          },
+          {
+            "text": " rows removed"
+          }
+        ],
         "tags": [
           "binoc.row-removal"
         ],

--- a/test-vectors/csv-stacked-tables/expected-output/changeset.snap
+++ b/test-vectors/csv-stacked-tables/expected-output/changeset.snap
@@ -14,7 +14,17 @@ expression: "&stable_changeset"
         "action": "modify",
         "item_type": "tabular_collection",
         "path": "data.csv",
-        "summary": "Table table_2 changed: 1 row added",
+        "summary": [
+          {
+            "text": "Table table_2 changed: "
+          },
+          {
+            "uint": 1
+          },
+          {
+            "text": " row added"
+          }
+        ],
         "tags": [
           "binoc.table-change",
           "binoc.tabular-collection",
@@ -25,7 +35,14 @@ expression: "&stable_changeset"
             "action": "modify",
             "item_type": "tabular",
             "path": "data.csv#table_2",
-            "summary": "1 row added",
+            "summary": [
+              {
+                "uint": 1
+              },
+              {
+                "text": " row added"
+              }
+            ],
             "tags": [
               "binoc.row-addition",
               "binoc.table-change"

--- a/test-vectors/csv-verbosity-full/expected-output/changeset.snap
+++ b/test-vectors/csv-verbosity-full/expected-output/changeset.snap
@@ -14,7 +14,14 @@ expression: "&stable_changeset"
         "action": "modify",
         "item_type": "tabular",
         "path": "data.csv",
-        "summary": "5 cells changed",
+        "summary": [
+          {
+            "uint": 5
+          },
+          {
+            "text": " cells changed"
+          }
+        ],
         "tags": [
           "binoc.cell-change"
         ],

--- a/test-vectors/directory-file-copy/expected-output/changeset.snap
+++ b/test-vectors/directory-file-copy/expected-output/changeset.snap
@@ -15,7 +15,17 @@ expression: "&stable_changeset"
         "item_type": "text",
         "path": "duplicate.txt",
         "source_path": "original.txt",
-        "summary": "Copied from original.txt",
+        "summary": [
+          {
+            "text": "Copied from "
+          },
+          {
+            "path": {
+              "value": "original.txt",
+              "snapshot": "from"
+            }
+          }
+        ],
         "tags": [
           "binoc.copy"
         ]

--- a/test-vectors/directory-nested-with-tar/expected-output/changeset.snap
+++ b/test-vectors/directory-nested-with-tar/expected-output/changeset.snap
@@ -19,7 +19,14 @@ expression: "&stable_changeset"
             "action": "modify",
             "item_type": "tabular",
             "path": "data/records.csv",
-            "summary": "1 row added",
+            "summary": [
+              {
+                "uint": 1
+              },
+              {
+                "text": " row added"
+              }
+            ],
             "tags": [
               "binoc.row-addition"
             ],
@@ -64,7 +71,14 @@ expression: "&stable_changeset"
                 "action": "modify",
                 "item_type": "tabular",
                 "path": "data.tar.gz/records.csv",
-                "summary": "1 cell changed",
+                "summary": [
+                  {
+                    "uint": 1
+                  },
+                  {
+                    "text": " cell changed"
+                  }
+                ],
                 "tags": [
                   "binoc.cell-change"
                 ],

--- a/test-vectors/directory-nested/expected-output/changeset.snap
+++ b/test-vectors/directory-nested/expected-output/changeset.snap
@@ -19,7 +19,23 @@ expression: "&stable_changeset"
             "action": "add",
             "item_type": "tabular",
             "path": "data/extra.csv",
-            "summary": "New table (2 columns, 1 row)",
+            "summary": [
+              {
+                "text": "New table ("
+              },
+              {
+                "uint": 2
+              },
+              {
+                "text": " columns, "
+              },
+              {
+                "uint": 1
+              },
+              {
+                "text": " row)"
+              }
+            ],
             "tags": [
               "binoc.content-changed"
             ],
@@ -40,7 +56,14 @@ expression: "&stable_changeset"
             "action": "modify",
             "item_type": "tabular",
             "path": "data/records.csv",
-            "summary": "1 row added",
+            "summary": [
+              {
+                "uint": 1
+              },
+              {
+                "text": " row added"
+              }
+            ],
             "tags": [
               "binoc.row-addition"
             ],
@@ -80,7 +103,20 @@ expression: "&stable_changeset"
             "action": "modify",
             "item_type": "text",
             "path": "docs/readme.txt",
-            "summary": "2 lines added, 1 removed",
+            "summary": [
+              {
+                "uint": 2
+              },
+              {
+                "text": " lines added, "
+              },
+              {
+                "uint": 1
+              },
+              {
+                "text": " removed"
+              }
+            ],
             "tags": [
               "binoc.content-changed",
               "binoc.lines-added",

--- a/test-vectors/file-correspondence-scheme/expected-output/changeset.snap
+++ b/test-vectors/file-correspondence-scheme/expected-output/changeset.snap
@@ -14,7 +14,14 @@ expression: "&stable_changeset"
         "action": "modify",
         "item_type": "tabular",
         "path": "states/AL.csv",
-        "summary": "1 row added",
+        "summary": [
+          {
+            "uint": 1
+          },
+          {
+            "text": " row added"
+          }
+        ],
         "tags": [
           "binoc.declared-correspondence",
           "binoc.row-addition"

--- a/test-vectors/file-correspondence-token/expected-output/changeset.snap
+++ b/test-vectors/file-correspondence-token/expected-output/changeset.snap
@@ -14,7 +14,14 @@ expression: "&stable_changeset"
         "action": "modify",
         "item_type": "tabular",
         "path": "running_list.csv",
-        "summary": "1 row added",
+        "summary": [
+          {
+            "uint": 1
+          },
+          {
+            "text": " row added"
+          }
+        ],
         "tags": [
           "binoc.declared-correspondence",
           "binoc.row-addition"

--- a/test-vectors/folder-move-nested/expected-output/changeset.snap
+++ b/test-vectors/folder-move-nested/expected-output/changeset.snap
@@ -15,7 +15,17 @@ expression: "&stable_changeset"
         "item_type": "directory",
         "path": "documentation",
         "source_path": "docs",
-        "summary": "Folder moved from docs",
+        "summary": [
+          {
+            "text": "Folder moved from "
+          },
+          {
+            "path": {
+              "value": "docs",
+              "snapshot": "from"
+            }
+          }
+        ],
         "tags": [
           "binoc.folder-move",
           "binoc.move"

--- a/test-vectors/folder-move-partial/expected-output/changelog.snap
+++ b/test-vectors/folder-move-partial/expected-output/changelog.snap
@@ -4,7 +4,7 @@ expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
 
-- **FoodData_Central_csv_2026-04-30**: Folder moved from FoodData_Central_csv_2,025-12-18
+- **FoodData_Central_csv_2026-04-30**: Folder moved from FoodData_Central_csv_2025-12-18
 - **FoodData_Central_csv_2026-04-30/data/new-table.csv**: New table (2 columns, 1 row)
 - **FoodData_Central_csv_2026-04-30/docs/modified.txt**: Text modified
 - **FoodData_Central_csv_2026-04-30/docs/old-table.txt**: File removed (1 line)

--- a/test-vectors/folder-move-partial/expected-output/changeset.snap
+++ b/test-vectors/folder-move-partial/expected-output/changeset.snap
@@ -15,7 +15,17 @@ expression: "&stable_changeset"
         "item_type": "directory",
         "path": "FoodData_Central_csv_2026-04-30",
         "source_path": "FoodData_Central_csv_2025-12-18",
-        "summary": "Folder moved from FoodData_Central_csv_2025-12-18",
+        "summary": [
+          {
+            "text": "Folder moved from "
+          },
+          {
+            "path": {
+              "value": "FoodData_Central_csv_2025-12-18",
+              "snapshot": "from"
+            }
+          }
+        ],
         "tags": [
           "binoc.folder-move",
           "binoc.move"
@@ -30,7 +40,23 @@ expression: "&stable_changeset"
                 "action": "add",
                 "item_type": "tabular",
                 "path": "FoodData_Central_csv_2026-04-30/data/new-table.csv",
-                "summary": "New table (2 columns, 1 row)",
+                "summary": [
+                  {
+                    "text": "New table ("
+                  },
+                  {
+                    "uint": 2
+                  },
+                  {
+                    "text": " columns, "
+                  },
+                  {
+                    "uint": 1
+                  },
+                  {
+                    "text": " row)"
+                  }
+                ],
                 "tags": [
                   "binoc.content-changed"
                 ],
@@ -72,7 +98,17 @@ expression: "&stable_changeset"
                 "action": "remove",
                 "item_type": "text",
                 "path": "FoodData_Central_csv_2026-04-30/docs/old-table.txt",
-                "summary": "File removed (1 line)",
+                "summary": [
+                  {
+                    "text": "File removed ("
+                  },
+                  {
+                    "uint": 1
+                  },
+                  {
+                    "text": " line)"
+                  }
+                ],
                 "tags": [
                   "binoc.content-changed"
                 ],

--- a/test-vectors/gzip-inner-dispatch/expected-output/changeset.snap
+++ b/test-vectors/gzip-inner-dispatch/expected-output/changeset.snap
@@ -19,7 +19,20 @@ expression: "&stable_changeset"
             "action": "modify",
             "item_type": "text",
             "path": "census.txt",
-            "summary": "1 line added, 1 removed",
+            "summary": [
+              {
+                "uint": 1
+              },
+              {
+                "text": " line added, "
+              },
+              {
+                "uint": 1
+              },
+              {
+                "text": " removed"
+              }
+            ],
             "tags": [
               "binoc.content-changed",
               "binoc.lines-added",
@@ -50,7 +63,20 @@ expression: "&stable_changeset"
             "action": "modify",
             "item_type": "tabular",
             "path": "data.csv",
-            "summary": "1 row added; 1 cell changed",
+            "summary": [
+              {
+                "uint": 1
+              },
+              {
+                "text": " row added; "
+              },
+              {
+                "uint": 1
+              },
+              {
+                "text": " cell changed"
+              }
+            ],
             "tags": [
               "binoc.cell-change",
               "binoc.row-addition"

--- a/test-vectors/kitchen-sink/expected-output/changeset.snap
+++ b/test-vectors/kitchen-sink/expected-output/changeset.snap
@@ -24,7 +24,14 @@ expression: "&stable_changeset"
                 "action": "modify",
                 "item_type": "tabular",
                 "path": "archive.tar.gz/inventory.csv",
-                "summary": "1 row added",
+                "summary": [
+                  {
+                    "uint": 1
+                  },
+                  {
+                    "text": " row added"
+                  }
+                ],
                 "tags": [
                   "binoc.row-addition"
                 ],
@@ -76,7 +83,20 @@ expression: "&stable_changeset"
                 "action": "modify",
                 "item_type": "text",
                 "path": "bundle.zip/notes.txt",
-                "summary": "2 lines added, 1 removed",
+                "summary": [
+                  {
+                    "uint": 2
+                  },
+                  {
+                    "text": " lines added, "
+                  },
+                  {
+                    "uint": 1
+                  },
+                  {
+                    "text": " removed"
+                  }
+                ],
                 "tags": [
                   "binoc.content-changed",
                   "binoc.lines-added",
@@ -105,7 +125,14 @@ expression: "&stable_changeset"
         "action": "modify",
         "item_type": "tabular",
         "path": "data.csv",
-        "summary": "2 cells changed",
+        "summary": [
+          {
+            "uint": 2
+          },
+          {
+            "text": " cells changed"
+          }
+        ],
         "tags": [
           "binoc.cell-change"
         ],
@@ -188,7 +215,17 @@ expression: "&stable_changeset"
             "action": "add",
             "item_type": "text",
             "path": "docs/new-file.txt",
-            "summary": "New file (1 line)",
+            "summary": [
+              {
+                "text": "New file ("
+              },
+              {
+                "uint": 1
+              },
+              {
+                "text": " line)"
+              }
+            ],
             "tags": [
               "binoc.content-changed"
             ],
@@ -202,7 +239,17 @@ expression: "&stable_changeset"
             "action": "remove",
             "item_type": "text",
             "path": "docs/old-notes.txt",
-            "summary": "File removed (1 line)",
+            "summary": [
+              {
+                "text": "File removed ("
+              },
+              {
+                "uint": 1
+              },
+              {
+                "text": " line)"
+              }
+            ],
             "tags": [
               "binoc.content-changed"
             ],
@@ -216,7 +263,20 @@ expression: "&stable_changeset"
             "action": "modify",
             "item_type": "text",
             "path": "docs/readme.txt",
-            "summary": "2 lines added, 2 removed",
+            "summary": [
+              {
+                "uint": 2
+              },
+              {
+                "text": " lines added, "
+              },
+              {
+                "uint": 2
+              },
+              {
+                "text": " removed"
+              }
+            ],
             "tags": [
               "binoc.content-changed",
               "binoc.lines-added",
@@ -238,7 +298,11 @@ expression: "&stable_changeset"
         "action": "modify",
         "item_type": "file",
         "path": "icon.bin",
-        "summary": "Content changed (19 bytes → 19 bytes)",
+        "summary": [
+          {
+            "text": "Content changed (19 bytes → 19 bytes)"
+          }
+        ],
         "tags": [
           "binoc.content-changed"
         ],
@@ -255,7 +319,17 @@ expression: "&stable_changeset"
         "item_type": "text",
         "path": "license-copy.txt",
         "source_path": "license.txt",
-        "summary": "Copied from license.txt",
+        "summary": [
+          {
+            "text": "Copied from "
+          },
+          {
+            "path": {
+              "value": "license.txt",
+              "snapshot": "from"
+            }
+          }
+        ],
         "tags": [
           "binoc.copy"
         ]
@@ -264,7 +338,11 @@ expression: "&stable_changeset"
         "action": "reorder",
         "item_type": "tabular",
         "path": "metrics.csv",
-        "summary": "Columns reordered (content unchanged)",
+        "summary": [
+          {
+            "text": "Columns reordered (content unchanged)"
+          }
+        ],
         "tags": [
           "binoc.column-reorder"
         ],
@@ -300,7 +378,17 @@ expression: "&stable_changeset"
         "item_type": "text",
         "path": "summary.txt",
         "source_path": "report.txt",
-        "summary": "Moved from report.txt",
+        "summary": [
+          {
+            "text": "Moved from "
+          },
+          {
+            "path": {
+              "value": "report.txt",
+              "snapshot": "from"
+            }
+          }
+        ],
         "tags": [
           "binoc.move"
         ]

--- a/test-vectors/single-file-add/expected-output/changeset.snap
+++ b/test-vectors/single-file-add/expected-output/changeset.snap
@@ -1,5 +1,5 @@
 ---
-source: binoc-stdlib/tests/test_vectors.rs
+source: binoc-stdlib/src/test_vectors.rs
 expression: "&stable_changeset"
 ---
 {
@@ -14,7 +14,17 @@ expression: "&stable_changeset"
         "action": "add",
         "item_type": "text",
         "path": "new_file.txt",
-        "summary": "New file (1 line)",
+        "summary": [
+          {
+            "text": "New file ("
+          },
+          {
+            "uint": 1
+          },
+          {
+            "text": " line)"
+          }
+        ],
         "tags": [
           "binoc.content-changed"
         ],

--- a/test-vectors/single-file-modify-binary/expected-output/changeset.snap
+++ b/test-vectors/single-file-modify-binary/expected-output/changeset.snap
@@ -14,7 +14,11 @@ expression: "&stable_changeset"
         "action": "modify",
         "item_type": "file",
         "path": "data.bin",
-        "summary": "Content changed (4 bytes → 4 bytes)",
+        "summary": [
+          {
+            "text": "Content changed (4 bytes → 4 bytes)"
+          }
+        ],
         "tags": [
           "binoc.content-changed"
         ],

--- a/test-vectors/single-file-modify-csv/expected-output/changeset.snap
+++ b/test-vectors/single-file-modify-csv/expected-output/changeset.snap
@@ -9,7 +9,14 @@ expression: "&stable_changeset"
     "action": "modify",
     "item_type": "tabular",
     "path": "data.csv",
-    "summary": "1 row added",
+    "summary": [
+      {
+        "uint": 1
+      },
+      {
+        "text": " row added"
+      }
+    ],
     "tags": [
       "binoc.row-addition"
     ],

--- a/test-vectors/single-file-modify-text-root/expected-output/changeset.snap
+++ b/test-vectors/single-file-modify-text-root/expected-output/changeset.snap
@@ -9,7 +9,20 @@ expression: "&stable_changeset"
     "action": "modify",
     "item_type": "text",
     "path": "story.txt",
-    "summary": "2 lines added, 1 removed",
+    "summary": [
+      {
+        "uint": 2
+      },
+      {
+        "text": " lines added, "
+      },
+      {
+        "uint": 1
+      },
+      {
+        "text": " removed"
+      }
+    ],
     "tags": [
       "binoc.content-changed",
       "binoc.lines-added",

--- a/test-vectors/single-file-modify-text/expected-output/changeset.snap
+++ b/test-vectors/single-file-modify-text/expected-output/changeset.snap
@@ -1,5 +1,5 @@
 ---
-source: binoc-stdlib/tests/test_vectors.rs
+source: binoc-stdlib/src/test_vectors.rs
 expression: "&stable_changeset"
 ---
 {
@@ -14,7 +14,20 @@ expression: "&stable_changeset"
         "action": "modify",
         "item_type": "text",
         "path": "story.txt",
-        "summary": "2 lines added, 1 removed",
+        "summary": [
+          {
+            "uint": 2
+          },
+          {
+            "text": " lines added, "
+          },
+          {
+            "uint": 1
+          },
+          {
+            "text": " removed"
+          }
+        ],
         "tags": [
           "binoc.content-changed",
           "binoc.lines-added",

--- a/test-vectors/single-file-remove/expected-output/changeset.snap
+++ b/test-vectors/single-file-remove/expected-output/changeset.snap
@@ -1,5 +1,5 @@
 ---
-source: binoc-stdlib/tests/test_vectors.rs
+source: binoc-stdlib/src/test_vectors.rs
 expression: "&stable_changeset"
 ---
 {
@@ -14,7 +14,17 @@ expression: "&stable_changeset"
         "action": "remove",
         "item_type": "text",
         "path": "removed_file.txt",
-        "summary": "File removed (1 line)",
+        "summary": [
+          {
+            "text": "File removed ("
+          },
+          {
+            "uint": 1
+          },
+          {
+            "text": " line)"
+          }
+        ],
         "tags": [
           "binoc.content-changed"
         ],

--- a/test-vectors/tar-nested/expected-output/changeset.snap
+++ b/test-vectors/tar-nested/expected-output/changeset.snap
@@ -34,7 +34,14 @@ expression: "&stable_changeset"
                         "action": "modify",
                         "item_type": "tabular",
                         "path": "outer.tar.gz/inner.tar.gz/data.csv",
-                        "summary": "1 row added",
+                        "summary": [
+                          {
+                            "uint": 1
+                          },
+                          {
+                            "text": " row added"
+                          }
+                        ],
                         "tags": [
                           "binoc.row-addition"
                         ],

--- a/test-vectors/tar-simple/expected-output/changeset.snap
+++ b/test-vectors/tar-simple/expected-output/changeset.snap
@@ -24,7 +24,14 @@ expression: "&stable_changeset"
                 "action": "modify",
                 "item_type": "tabular",
                 "path": "archive.tar.gz/data.csv",
-                "summary": "1 row added",
+                "summary": [
+                  {
+                    "uint": 1
+                  },
+                  {
+                    "text": " row added"
+                  }
+                ],
                 "tags": [
                   "binoc.row-addition"
                 ],
@@ -56,7 +63,14 @@ expression: "&stable_changeset"
                 "action": "modify",
                 "item_type": "text",
                 "path": "archive.tar.gz/hello.txt",
-                "summary": "1 line added",
+                "summary": [
+                  {
+                    "uint": 1
+                  },
+                  {
+                    "text": " line added"
+                  }
+                ],
                 "tags": [
                   "binoc.content-changed",
                   "binoc.lines-added"

--- a/test-vectors/text-rename-modify/expected-output/changeset.snap
+++ b/test-vectors/text-rename-modify/expected-output/changeset.snap
@@ -15,7 +15,20 @@ expression: "&stable_changeset"
         "item_type": "text",
         "path": "meeting-notes-v2.txt",
         "source_path": "notes.txt",
-        "summary": "Moved from notes.txt (modified)",
+        "summary": [
+          {
+            "text": "Moved from "
+          },
+          {
+            "path": {
+              "value": "notes.txt",
+              "snapshot": "from"
+            }
+          },
+          {
+            "text": " (modified)"
+          }
+        ],
         "tags": [
           "binoc.content-changed",
           "binoc.lines-added",

--- a/test-vectors/tree-wide-correlation/expected-output/changeset.snap
+++ b/test-vectors/tree-wide-correlation/expected-output/changeset.snap
@@ -15,7 +15,17 @@ expression: "&stable_changeset"
         "item_type": "text",
         "path": "gamma-renamed.txt",
         "source_path": "outer.zip/inner.zip/gamma.txt",
-        "summary": "Moved from outer.zip/inner.zip/gamma.txt",
+        "summary": [
+          {
+            "text": "Moved from "
+          },
+          {
+            "path": {
+              "value": "outer.zip/inner.zip/gamma.txt",
+              "snapshot": "from"
+            }
+          }
+        ],
         "tags": [
           "binoc.move"
         ]
@@ -25,7 +35,11 @@ expression: "&stable_changeset"
         "item_type": "text",
         "path": "kept-copy.txt",
         "source_path": "kept.txt",
-        "summary": "Copied from kept.txt to kept-copy.txt and outer.zip/kept-copy.txt",
+        "summary": [
+          {
+            "text": "Copied from kept.txt to kept-copy.txt and outer.zip/kept-copy.txt"
+          }
+        ],
         "tags": [
           "binoc.copy"
         ],
@@ -41,7 +55,11 @@ expression: "&stable_changeset"
         "item_type": "file",
         "path": "merged.bin",
         "source_path": "dup.bin",
-        "summary": "Moved from dup.bin and dup-b.bin",
+        "summary": [
+          {
+            "text": "Moved from dup.bin and dup-b.bin"
+          }
+        ],
         "tags": [
           "binoc.move"
         ],
@@ -67,7 +85,17 @@ expression: "&stable_changeset"
                 "item_type": "text",
                 "path": "outer.zip/alpha-renamed.txt",
                 "source_path": "alpha.txt",
-                "summary": "Moved from alpha.txt",
+                "summary": [
+                  {
+                    "text": "Moved from "
+                  },
+                  {
+                    "path": {
+                      "value": "alpha.txt",
+                      "snapshot": "from"
+                    }
+                  }
+                ],
                 "tags": [
                   "binoc.move"
                 ]
@@ -87,7 +115,17 @@ expression: "&stable_changeset"
                         "item_type": "text",
                         "path": "outer.zip/inner.zip/beta-renamed.txt",
                         "source_path": "outer.zip/beta.txt",
-                        "summary": "Moved from outer.zip/beta.txt",
+                        "summary": [
+                          {
+                            "text": "Moved from "
+                          },
+                          {
+                            "path": {
+                              "value": "outer.zip/beta.txt",
+                              "snapshot": "from"
+                            }
+                          }
+                        ],
                         "tags": [
                           "binoc.move"
                         ]

--- a/test-vectors/tsv-cell-changes/expected-output/changeset.snap
+++ b/test-vectors/tsv-cell-changes/expected-output/changeset.snap
@@ -14,7 +14,14 @@ expression: "&stable_changeset"
         "action": "modify",
         "item_type": "tabular",
         "path": "data.tsv",
-        "summary": "2 cells changed",
+        "summary": [
+          {
+            "uint": 2
+          },
+          {
+            "text": " cells changed"
+          }
+        ],
         "tags": [
           "binoc.cell-change"
         ],

--- a/test-vectors/zip-nested/expected-output/changeset.snap
+++ b/test-vectors/zip-nested/expected-output/changeset.snap
@@ -34,7 +34,14 @@ expression: "&stable_changeset"
                         "action": "modify",
                         "item_type": "tabular",
                         "path": "outer.zip/inner.zip/data.csv",
-                        "summary": "1 row added",
+                        "summary": [
+                          {
+                            "uint": 1
+                          },
+                          {
+                            "text": " row added"
+                          }
+                        ],
                         "tags": [
                           "binoc.row-addition"
                         ],

--- a/test-vectors/zip-simple/expected-output/changeset.snap
+++ b/test-vectors/zip-simple/expected-output/changeset.snap
@@ -24,7 +24,20 @@ expression: "&stable_changeset"
                 "action": "modify",
                 "item_type": "text",
                 "path": "archive.zip/data.txt",
-                "summary": "1 line added, 1 removed",
+                "summary": [
+                  {
+                    "uint": 1
+                  },
+                  {
+                    "text": " line added, "
+                  },
+                  {
+                    "uint": 1
+                  },
+                  {
+                    "text": " removed"
+                  }
+                ],
                 "tags": [
                   "binoc.content-changed",
                   "binoc.lines-added",
@@ -43,7 +56,17 @@ expression: "&stable_changeset"
                 "action": "add",
                 "item_type": "text",
                 "path": "archive.zip/extra.txt",
-                "summary": "New file (1 line)",
+                "summary": [
+                  {
+                    "text": "New file ("
+                  },
+                  {
+                    "uint": 1
+                  },
+                  {
+                    "text": " line)"
+                  }
+                ],
                 "tags": [
                   "binoc.content-changed"
                 ],


### PR DESCRIPTION
Trying to add commas to long numbers in markdown output exposed a basic issue -- by the time log strings get from transformers to renderers, there isn't enough type information to format numbers properly. "300000 rows" should have a comma but "02-04-2000" shouldn't, and adding special cases to try to guess type info is unworkable.

This patch lets transformers emit structured messages with text, path, int, and float components, so they can emit [pluralize(300000, "row), " moved"] or [path(foo, left), " moved to ", path(bar, right)] or whatever. The renderer can apply whatever humanization or localization or link rendering or whatever it wants.

We can add additional types if upstream plugins need to support some other type of data, like dates or file sizes or whatever.

--

## Summary
- Replace `DiffNode.summary: Option<String>` with `Option<Summary>` — an ordered list of typed `Segment`s (`Text`, `Path { value, snapshot }`, `Uint`, `Float`). Renderers format each segment by its type instead of scanning prose to decide which digit runs to group.
- A `Uint` is always digit-grouped; `Text`/`Path` values are verbatim, so years in folder names and other non-count digits are never mangled (the `humanize_numbers` prose scan is gone for summaries).
- Rename/move/copy detectors emit `Path` segments with a `snapshot` side. The renderer never recognizes the "move" concept or string-matches `"Moved from "` prefixes — producers own their concept wording, the renderer owns typography, and this composes with plugin-defined actions.

## Ergonomics
- Plain strings still work via `impl Into<Summary>` (one `Text` segment), so summary-less producers are untouched.
- `Summary::count(n, noun)` builds the common `"{n} rows"` shape with grouping + pluralization; `text()` coalesces adjacent text so `count()` costs nothing on the wire.
- Annotation trailers (`tabular_summary`/`content_summary`) stay plain text by design (read with `.as_str()` by the folder-move detector); documented in the ADR.

## Notes
- The persisted changeset JSON now exposes `summary` as a typed segment array (schema doc regenerated); machine consumers can read segments directly or flatten via plain text.
- Rationale and the rejected alternatives (hardening the prose scanner, generating headlines in the renderer, a semantic `Currency`/`Percent` enum) are in `docs/adr/2026-06-03-structured-summary-segments.md`.