### PR TITLE
Improve reporting

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,6 +30,24 @@ jobs:
 
       - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
 
+      # The browser-demo wasm build compiles bundled SQLite (rusqlite) for
+      # wasm32-wasip1, which needs a WASI sysroot and a wasm-targeting clang.
+      # The WASI SDK bundles both. The justfile's docs-browser-demo recipe
+      # picks these up via WASI_SYSROOT / CC_wasm32_wasip1 (consumed by the
+      # `cc` crate); locally they come from `brew install wasi-libc llvm`.
+      - name: Install WASI SDK (for the SQLite browser-demo wasm build)
+        run: |
+          set -euo pipefail
+          tag=wasi-sdk-33
+          asset=wasi-sdk-33.0-x86_64-linux
+          curl -fsSL -o /tmp/wasi-sdk.tar.gz \
+            "https://github.com/WebAssembly/wasi-sdk/releases/download/${tag}/${asset}.tar.gz"
+          sudo mkdir -p /opt/wasi-sdk
+          sudo tar -xzf /tmp/wasi-sdk.tar.gz -C /opt/wasi-sdk --strip-components=1
+          echo "WASI_SYSROOT=/opt/wasi-sdk/share/wasi-sysroot" >> "$GITHUB_ENV"
+          echo "CC_wasm32_wasip1=/opt/wasi-sdk/bin/clang" >> "$GITHUB_ENV"
+          echo "AR_wasm32_wasip1=/opt/wasi-sdk/bin/llvm-ar" >> "$GITHUB_ENV"
+
       # Regenerate every docs input the same way contributors do locally, so
       # CI and local flows stay in lockstep. See ADR
       # 2026-04-17-documentation_platform_and_info_design.md §6.

--- a/binoc-cli/tests/cli.rs
+++ b/binoc-cli/tests/cli.rs
@@ -265,7 +265,7 @@ dataset:
         .assert()
         .success()
         .stdout(predicates::str::contains("data.csv"))
-        .stdout(predicates::str::contains("1 edit"));
+        .stdout(predicates::str::contains("2 rows added"));
 }
 
 #[test]

--- a/binoc-core/src/correspondence/project.rs
+++ b/binoc-core/src/correspondence/project.rs
@@ -126,29 +126,6 @@ pub fn project(
 
         let left_path = &store.item(left_id).logical_path;
         let right_path = &store.item(right_id).logical_path;
-        let edits = edit_lists.get(&index).cloned().unwrap_or_default();
-        let visible_edits: Vec<Edit> = edits
-            .iter()
-            .filter(|edit| edit.projection.visible)
-            .cloned()
-            .collect();
-        // Grab each endpoint's own `item_type` BEFORE merging the two
-        // projections together — the merge collapses them into one, which would
-        // hide the fact that the representation changed across the link. These
-        // raw strings flow to the annotator so stdlib/plugin rules can decide
-        // whether a container reshaped (e.g. "directory" -> "SQLite database");
-        // core never interprets them.
-        let source_item_type = store.projection(left_id).item_type.clone();
-        let mut projection = store.projection(right_id).clone();
-        projection.merge_from(store.projection(left_id));
-        overlay_projection(&mut projection, &link.projection);
-        for edit in &edits {
-            overlay_projection(&mut projection, &edit.projection.hint);
-        }
-        let carried = carried_path_change(store, link.left, link.right);
-        let copied = projection.action.as_deref() == Some("copy");
-        let moved = left_path != right_path && !carried && !copied;
-        let changed = !edits.is_empty();
         let line_is_container = !store
             .tree(TreeSide::Right)
             .node(link.right)
@@ -159,6 +136,47 @@ pub fn project(
                 .node(link.left)
                 .children
                 .is_empty();
+        let edits = edit_lists.get(&index).cloned().unwrap_or_default();
+        let mut projected_edits = edits.clone();
+        // Grab each endpoint's own `item_type` BEFORE merging the two
+        // projections together — the merge collapses them into one, which would
+        // hide the fact that the representation changed across the link. These
+        // raw strings flow to the annotator so stdlib/plugin rules can decide
+        // whether a container reshaped (e.g. "directory" -> "SQLite database");
+        // core never interprets them.
+        let source_item_type = store.projection(left_id).item_type.clone();
+        let mut projection = store.projection(right_id).clone();
+        projection.merge_from(store.projection(left_id));
+        overlay_projection(&mut projection, &link.projection);
+        for edit in &projected_edits {
+            overlay_projection(&mut projection, &edit.projection.hint);
+        }
+        let carried = carried_path_change(store, link.left, link.right);
+        let copied = projection.action.as_deref() == Some("copy");
+        let moved = left_path != right_path && !carried && !copied;
+        if !line_is_container
+            && !copied
+            && !moved
+            && projection.action.is_none()
+            && projected_edits.iter().all(|edit| !edit.projection.visible)
+            && content_hashes_differ(store.item(left_id), store.item(right_id))
+        {
+            let edit = Edit::new(
+                "content.differs",
+                json!({
+                    "reason": "linked endpoints have different content hashes, but no visible edit explained the difference"
+                }),
+            )
+            .with_item_type("item");
+            overlay_projection(&mut projection, &edit.projection.hint);
+            projected_edits.push(edit);
+        }
+        let visible_edits: Vec<Edit> = projected_edits
+            .iter()
+            .filter(|edit| edit.projection.visible)
+            .cloned()
+            .collect();
+        let changed = !projected_edits.is_empty();
         let derived_action = match (copied, moved, changed) {
             (true, _, _) => "copy",
             (false, true, _) => "move",
@@ -215,7 +233,10 @@ pub fn project(
                 .with_evidence(link.evidence.clone())
                 .with_action(action)],
             evidence: Some(link.evidence.clone()),
-            verbs: edits.iter().map(|edit| edit.verb.clone()).collect(),
+            verbs: projected_edits
+                .iter()
+                .map(|edit| edit.verb.clone())
+                .collect(),
             edits: visible_edits,
             container: line_is_container,
             depth: store.tree(TreeSide::Right).ancestors(link.right).len(),
@@ -319,6 +340,16 @@ pub fn project(
     Projection {
         lines,
         container_item_types,
+    }
+}
+
+fn content_hashes_differ(left: &binoc_sdk::ItemRef, right: &binoc_sdk::ItemRef) -> bool {
+    if left.is_dir || right.is_dir {
+        return false;
+    }
+    match (&left.content_hash, &right.content_hash) {
+        (Some(left), Some(right)) => left != right,
+        _ => false,
     }
 }
 
@@ -580,6 +611,13 @@ mod tests {
         }
     }
 
+    fn hashed_item(path: &str, hash: &str) -> ItemRef {
+        ItemRef {
+            content_hash: Some(hash.into()),
+            ..item(path)
+        }
+    }
+
     #[test]
     fn projection_uses_rule_supplied_metadata_for_visible_output() {
         let mut store = Store::new(
@@ -633,6 +671,54 @@ mod tests {
         assert_eq!(node.item_type, "custom-item");
         assert!(node.tags.contains("test.tag"));
         assert_eq!(node.details["edits"][0]["verb"], json!("test.edit"));
+    }
+
+    #[test]
+    fn projection_surfaces_unexplained_content_difference() {
+        let mut store = Store::new(
+            ItemRef {
+                is_dir: true,
+                projection_hint: ProjectionHint::default().item_type("tree"),
+                ..item("")
+            },
+            ItemRef {
+                is_dir: true,
+                projection_hint: ProjectionHint::default().item_type("tree"),
+                ..item("")
+            },
+            ProjectionHint::default().item_type("tree"),
+        );
+        let left = store.left.add_child(
+            0,
+            hashed_item("data.csv", "left-hash"),
+            ProjectionHint::default().item_type("tabular"),
+        );
+        let right = store.right.add_child(
+            0,
+            hashed_item("data.csv", "right-hash"),
+            ProjectionHint::default().item_type("tabular"),
+        );
+        store.links.apply(
+            LinkProposal {
+                left,
+                right,
+                evidence: "test.evidence".into(),
+                settled: false,
+                projection: ProjectionHint::default(),
+            },
+            "test-rule",
+            1,
+        );
+
+        let changeset = project(&store, &BTreeMap::new(), &[]).to_changeset("left", "right");
+        let root = changeset.root.expect("root");
+        let node = root
+            .children
+            .iter()
+            .find(|node| node.path == "data.csv")
+            .unwrap();
+        assert_eq!(node.action, "modify");
+        assert_eq!(node.details["edits"][0]["verb"], json!("content.differs"));
     }
 
     #[test]

--- a/binoc-stdlib/src/correspondence/mod.rs
+++ b/binoc-stdlib/src/correspondence/mod.rs
@@ -318,7 +318,7 @@ fn summarize_known_edits(edits: &[Edit]) -> Option<String> {
         parts.push("Columns reordered".into());
     }
 
-    let rows_added = count_verb(edits, "tabular.add_row");
+    let rows_added = count_verb(edits, "tabular.add_row") + count_appended_rows(edits);
     let rows_removed = count_verb(edits, "tabular.remove_row");
     if rows_added > 0 {
         parts.push(count_phrase(rows_added, "row added", "rows added"));
@@ -370,6 +370,15 @@ fn column_names(edits: &[Edit], verb: &str) -> Vec<String> {
 
 fn count_verb(edits: &[Edit], verb: &str) -> usize {
     edits.iter().filter(|edit| edit.verb == verb).count()
+}
+
+fn count_appended_rows(edits: &[Edit]) -> usize {
+    edits
+        .iter()
+        .filter(|edit| edit.verb == "tabular.append_rows")
+        .filter_map(|edit| edit.params.get("rows").and_then(|value| value.as_array()))
+        .map(Vec::len)
+        .sum()
 }
 
 fn unique_keyed_rows(edits: &[&Edit]) -> BTreeSet<String> {

--- a/binoc-stdlib/src/correspondence/parse.rs
+++ b/binoc-stdlib/src/correspondence/parse.rs
@@ -60,8 +60,9 @@ impl ParseRule for CsvParse {
 
     fn parse(&self, item: &ItemRef, data: &dyn DataAccess) -> BinocResult<ParseOutput> {
         let bytes = data.read_bytes(item)?;
-        let tabular = parse_csv_bytes(&bytes, delimiter_for(item))?;
-        let sections = detect_stacked_sections(&tabular);
+        let records = parse_csv_records(&bytes, delimiter_for(item))?;
+        let tabular = table_from_csv_records(records.clone());
+        let sections = detect_stacked_sections_from_rows(&records);
 
         // Fewer than two qualifying regions: a plain CSV is a single table,
         // emitted as a LEAF `tabular_v1` artifact with no children.
@@ -697,31 +698,62 @@ fn delimiter_for(item: &ItemRef) -> u8 {
     }
 }
 
+#[cfg(test)]
 fn parse_csv_bytes(bytes: &[u8], delimiter: u8) -> BinocResult<TabularData> {
+    parse_csv_records(bytes, delimiter).map(table_from_csv_records)
+}
+
+fn parse_csv_records(bytes: &[u8], delimiter: u8) -> BinocResult<Vec<Vec<String>>> {
     let mut reader = csv::ReaderBuilder::new()
         .delimiter(delimiter)
+        .has_headers(false)
         .flexible(true)
         .from_reader(bytes);
-    let headers = reader
-        .byte_headers()
-        .map_err(|err| BinocError::Csv(err.to_string()))?
-        .iter()
-        .map(|field| String::from_utf8_lossy(field).into_owned())
-        .collect();
-    let mut rows = Vec::new();
+    let mut records = Vec::new();
     let mut record = csv::ByteRecord::new();
     while reader
         .read_byte_record(&mut record)
         .map_err(|err| BinocError::Csv(err.to_string()))?
     {
-        rows.push(
+        records.push(
             record
                 .iter()
                 .map(|field| String::from_utf8_lossy(field).into_owned())
                 .collect(),
         );
     }
-    Ok(TabularData::from_string_rows(headers, rows))
+    Ok(records)
+}
+
+fn table_from_csv_records(records: Vec<Vec<String>>) -> TabularData {
+    let Some(first) = records.first() else {
+        return TabularData::from_string_rows(Vec::new(), Vec::new());
+    };
+    let width = records.iter().map(Vec::len).max().unwrap_or(first.len());
+    let headers = complete_csv_headers(first, width);
+    let rows = records.into_iter().skip(1).collect();
+    TabularData::from_string_rows(headers, rows)
+}
+
+fn complete_csv_headers(first: &[String], width: usize) -> Vec<String> {
+    let mut headers = Vec::with_capacity(width);
+    let mut seen = BTreeSet::new();
+    for index in 0..width {
+        let raw = first
+            .get(index)
+            .map(|value| value.trim())
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+            .unwrap_or_else(|| format!("column_{}", index + 1));
+        let mut candidate = raw.clone();
+        let mut suffix = 2usize;
+        while !seen.insert(candidate.clone()) {
+            candidate = format!("{raw}_{suffix}");
+            suffix += 1;
+        }
+        headers.push(candidate);
+    }
+    headers
 }
 
 #[derive(Debug, Clone)]
@@ -747,13 +779,11 @@ struct StackedSection {
 /// has more than 10 rows (≥ 11, counting its header). When it qualifies, each
 /// region's first row is the header and the rest are data rows, trimmed to the
 /// region width. Otherwise an empty `Vec` is returned (a single flat table).
-fn detect_stacked_sections(table: &TabularData) -> Vec<StackedSection> {
-    let rows = raw_rows(table);
-
+fn detect_stacked_sections_from_rows(rows: &[Vec<String>]) -> Vec<StackedSection> {
     // Partition into regions of consecutive same-width rows, skipping blanks.
     let mut regions: Vec<Vec<Vec<String>>> = Vec::new();
     let mut current_width: Option<usize> = None;
-    for row in &rows {
+    for row in rows {
         let width = normalized_width(row);
         if width == 0 {
             // Blank rows are transparent.
@@ -816,17 +846,6 @@ fn children_from_sections(parent_path: &str, sections: &[StackedSection]) -> Vec
     children
 }
 
-fn raw_rows(table: &TabularData) -> Vec<Vec<String>> {
-    std::iter::once(table.headers.clone())
-        .chain(
-            table
-                .rows
-                .iter()
-                .map(|row| row.iter().map(|cell| cell.as_text().into_owned()).collect()),
-        )
-        .collect()
-}
-
 fn normalized_width(row: &[String]) -> usize {
     row.iter()
         .rposition(|cell| !cell.trim().is_empty())
@@ -849,8 +868,8 @@ mod tests {
     use super::*;
 
     fn detect(csv: &str) -> Vec<StackedSection> {
-        let table = parse_csv_bytes(csv.as_bytes(), b',').expect("parse csv");
-        detect_stacked_sections(&table)
+        let records = parse_csv_records(csv.as_bytes(), b',').expect("parse csv");
+        detect_stacked_sections_from_rows(&records)
     }
 
     /// Build a CSV body of `count` rows, each `width` comma-separated cells,
@@ -866,6 +885,27 @@ mod tests {
             out.push('\n');
         }
         out
+    }
+
+    #[test]
+    fn csv_parse_preserves_fields_after_single_cell_banner() {
+        let csv = "Land-Ocean: Global Means\n\
+                   Year,Jan,Feb\n\
+                   1880,-.18,-.24\n";
+        let table = parse_csv_bytes(csv.as_bytes(), b',').expect("parse csv");
+        assert_eq!(
+            table.headers,
+            vec![
+                "Land-Ocean: Global Means".to_string(),
+                "column_2".to_string(),
+                "column_3".to_string()
+            ]
+        );
+        assert_eq!(table.rows.len(), 2);
+        assert_eq!(table.rows[0][0].as_text(), "Year");
+        assert_eq!(table.rows[0][1].as_text(), "Jan");
+        assert_eq!(table.rows[0][2].as_text(), "Feb");
+        assert_eq!(table.rows[1][2].as_text(), "-.24");
     }
 
     #[test]

--- a/binoc-stdlib/src/correspondence/writers.rs
+++ b/binoc-stdlib/src/correspondence/writers.rs
@@ -16,6 +16,8 @@ const MAX_CAPTURED_VALUES: usize = 16;
 const MAX_VALUE_PREVIEW_BYTES: usize = 120;
 const MAX_TEXT_LINE_EXAMPLES: usize = 8;
 const MAX_ROW_ALIGNMENT_ROWS: usize = 512;
+const AUTO_KEY_MIN_JACCARD: f64 = 0.80;
+const AUTO_KEY_MAX_ROWS: usize = 10_000;
 const MAX_JSON_CHANGE_EXAMPLES: usize = 16;
 const UTF8_BOM: &[u8] = b"\xEF\xBB\xBF";
 
@@ -153,6 +155,35 @@ impl EditListWriter for TabularWriter {
             push_key_quality_diagnostics(&mut diagnostics, quality, ctx.row_identity_policies);
             if let Some(edit) = key_quality_edit(quality, ctx.row_identity_policies) {
                 edits.push(edit);
+            }
+        } else if ctx.row_keys.is_empty() {
+            if let Some(auto_key) = infer_auto_key(&left, &right) {
+                diagnostics.push(Diagnostic::suggestion(
+                    "binoc.tabular_auto_key",
+                    format!(
+                        "inferred row identity column '{}' from unique values with {:.0}% overlap",
+                        auto_key.column,
+                        auto_key.jaccard * 100.0
+                    ),
+                ));
+                edits.push(
+                    Edit::new(
+                        "tabular.auto_detected_key",
+                        json!({
+                            "columns": [auto_key.column.clone()],
+                            "overlap": auto_key.jaccard,
+                            "left_rows": left.rows.len(),
+                            "right_rows": right.rows.len(),
+                        }),
+                    )
+                    .with_item_type("tabular")
+                    .with_tag("binoc.row-identity-inferred")
+                    .hidden(),
+                );
+                let keys = vec![auto_key.column];
+                write_keyed_row_edits(&mut edits, &keys, &left, &right);
+                edits.extend(metadata_edits);
+                return Ok(Some(WriteOutput { edits, diagnostics }));
             }
         }
 
@@ -368,6 +399,94 @@ fn table_has_complete_unique_keys(table: &TabularData, keys: &[String]) -> bool 
         }
     }
     true
+}
+
+#[derive(Debug, Clone)]
+struct AutoKeyCandidate {
+    column: String,
+    jaccard: f64,
+    total_value_bytes: usize,
+}
+
+fn infer_auto_key(left: &TabularData, right: &TabularData) -> Option<AutoKeyCandidate> {
+    if left.rows.len() > AUTO_KEY_MAX_ROWS || right.rows.len() > AUTO_KEY_MAX_ROWS {
+        return None;
+    }
+    left.headers
+        .iter()
+        .filter(|header| right.column_index(header).is_some())
+        .filter_map(|header| auto_key_candidate(header, left, right))
+        .filter(|candidate| candidate.jaccard >= AUTO_KEY_MIN_JACCARD)
+        .min_by(|a, b| {
+            b.jaccard
+                .total_cmp(&a.jaccard)
+                .then_with(|| a.total_value_bytes.cmp(&b.total_value_bytes))
+                .then_with(|| a.column.cmp(&b.column))
+        })
+}
+
+fn auto_key_candidate(
+    column: &str,
+    left: &TabularData,
+    right: &TabularData,
+) -> Option<AutoKeyCandidate> {
+    let keys = [column.to_string()];
+    if !keyed_rows_complete(&keys, left, right) {
+        return None;
+    }
+    if !auto_key_would_change_alignment(&keys, left, right) {
+        return None;
+    }
+    let left_values = column_signatures(left, column)?;
+    let right_values = column_signatures(right, column)?;
+    let intersection = left_values.intersection(&right_values).count();
+    let union = left_values.union(&right_values).count();
+    if union == 0 {
+        return None;
+    }
+    Some(AutoKeyCandidate {
+        column: column.to_string(),
+        jaccard: intersection as f64 / union as f64,
+        total_value_bytes: total_column_value_bytes(left, column)?
+            + total_column_value_bytes(right, column)?,
+    })
+}
+
+fn auto_key_would_change_alignment(
+    keys: &[String],
+    left: &TabularData,
+    right: &TabularData,
+) -> bool {
+    let left_rows = unique_rows_by_key(left, keys);
+    let right_rows = unique_rows_by_key(right, keys);
+    left_rows.iter().any(|(signature, (_, left_index, _))| {
+        right_rows
+            .get(signature)
+            .is_some_and(|(_, right_index, _)| left_index != right_index)
+    })
+}
+
+fn column_signatures(table: &TabularData, column: &str) -> Option<BTreeSet<String>> {
+    let index = table.column_index(column)?;
+    Some(
+        table
+            .rows
+            .iter()
+            .filter_map(|row| row.get(index))
+            .map(|value| value.as_text().into_owned())
+            .collect(),
+    )
+}
+
+fn total_column_value_bytes(table: &TabularData, column: &str) -> Option<usize> {
+    let index = table.column_index(column)?;
+    Some(
+        table
+            .rows
+            .iter()
+            .map(|row| row.get(index).unwrap_or(&Value::Null).as_text().len())
+            .sum(),
+    )
 }
 
 /// A row's identity key: a `signature` of the cells' flat text for

--- a/binoc-stdlib/src/renderers/markdown.rs
+++ b/binoc-stdlib/src/renderers/markdown.rs
@@ -306,20 +306,31 @@ fn format_node(
         &node.path
     };
 
-    out.push_str(&format!("- **{path}**: "));
-
-    out.push_str(&render_summary(&node_summary(node)));
-    out.push('\n');
-
-    // For a move with content detail, emit the detail as a second
-    // top-level bullet under the same path. The two-bullet layout keeps
-    // the rename and the content change visually grouped (they share a
-    // path and stay in the same significance section) without needing
-    // inline punctuation or capitalization fixups.
-    if should_group_move_children(node) {
-        if let Some(detail) = move_trailer(node) {
-            out.push_str(&format!("- **{path}**: {}\n", render_summary(&detail)));
+    // A moved or copied node always names its origin, even when the pairing
+    // also carried a content change. When both are present they read as an
+    // indented pair under one path — origin first, then the change — matching
+    // the sub-bullet style used for edit detail. A move with no separate
+    // content (a pure rename, a copy, a merge whose summary already states the
+    // origin) stays a single inline line.
+    if is_move_node(node) {
+        match move_content(node) {
+            Some(content) => {
+                out.push_str(&format!("- **{path}**:\n"));
+                out.push_str(&format!("  - {}\n", render_summary(&move_origin(node))));
+                out.push_str(&format!("  - {}\n", render_summary(&content)));
+            }
+            None => {
+                out.push_str(&format!(
+                    "- **{path}**: {}\n",
+                    render_summary(&move_origin(node))
+                ));
+            }
         }
+    } else {
+        out.push_str(&format!(
+            "- **{path}**: {}\n",
+            render_summary(&node_summary(node))
+        ));
     }
 
     render_sources(out, node, config);
@@ -358,19 +369,68 @@ fn source_side_label(side: Side) -> &'static str {
     }
 }
 
-fn should_group_move_children(node: &DiffNode) -> bool {
-    node.action == "move"
-        && !node.tags.contains("binoc.folder-move")
-        && move_trailer(node).is_some()
+/// Whether a node represents a move or a copy (and so names its origin).
+fn is_move_node(node: &DiffNode) -> bool {
+    matches!(node.action.as_str(), "move" | "copy")
 }
 
-/// Build the trailing description for a move bullet, if any.
+/// The origin line for a moved or copied node: "Moved from X" / "Copied from X".
+///
+/// When the projection tagged the node `binoc.move.modified`, its `summary`
+/// holds the *content* change (see [`move_content`]) and the origin must be
+/// derived from the node's sources. Otherwise the producer's own summary is
+/// already an origin statement — a bare rename, a copy, or a multi-source
+/// "Merged from A, B" that names every source — and we use it verbatim, falling
+/// back to the synthesized phrasing only when no summary was supplied.
+fn move_origin(node: &DiffNode) -> Summary {
+    if node.tags.contains("binoc.move.modified") {
+        return synthesized_move_origin(node);
+    }
+    node_summary(node)
+}
+
+/// The synthesized "Moved from X" / "Copied from X" origin, reusing the same
+/// wording as [`fallback_summary`]'s move/copy arms.
+fn synthesized_move_origin(node: &DiffNode) -> Summary {
+    let item_type = if node.item_type.is_empty() {
+        "item"
+    } else {
+        &node.item_type
+    };
+    let (verb_phrase, fallback) = if node.action == "copy" {
+        ("Copied from ", "copied")
+    } else {
+        ("Moved from ", "moved")
+    };
+    match node.primary_from_source() {
+        Some(src) => Summary::new()
+            .text(verb_phrase)
+            .path(src.path.clone(), src.side),
+        None => format!("{} {fallback}", capitalize(item_type)).into(),
+    }
+}
+
+/// Whether a move/copy node carries a content change folded inline beneath the
+/// origin line (so its content children, if any, are not reported separately).
+/// Pure moves, copies, merges, and folder moves report normally.
+fn should_group_move_children(node: &DiffNode) -> bool {
+    is_move_node(node) && move_content(node).is_some()
+}
+
+/// The content change carried by a moved/copied node, shown beneath its origin
+/// line, or `None` for a pure move/copy. Folder moves describe their content
+/// through separately-rendered child nodes, so they contribute none here.
 ///
 /// Priority (first match wins):
 /// 1. `annotations.tabular_summary` — rich, from tabular writers.
 /// 2. `annotations.content_summary` — generic content detail.
-/// 3. A join of non-identical child summaries.
-fn move_trailer(node: &DiffNode) -> Option<Summary> {
+/// 3. The node's own `summary`, when it was tagged `binoc.move.modified` (its
+///    summary is the content change, not the origin).
+/// 4. A join of non-identical child summaries.
+fn move_content(node: &DiffNode) -> Option<Summary> {
+    if node.tags.contains("binoc.folder-move") {
+        return None;
+    }
     // The annotation trailers are carried as plain strings and render
     // verbatim as a single text segment.
     if let Some(s) = annotation_str(node, "tabular_summary") {
@@ -378,6 +438,11 @@ fn move_trailer(node: &DiffNode) -> Option<Summary> {
     }
     if let Some(s) = annotation_str(node, "content_summary") {
         return Some(s.into());
+    }
+    if node.tags.contains("binoc.move.modified") {
+        if let Some(summary) = &node.summary {
+            return Some(summary.clone());
+        }
     }
     if !node.children.is_empty() {
         let mut trailer = Summary::new();
@@ -1529,19 +1594,18 @@ mod tests {
 
     #[test]
     fn move_with_children_renders_as_paired_bullets() {
-        // A `move` node carrying its own content-change children should
-        // be reported as two stacked top-level bullets under the same
-        // path (move headline + content detail), classified together by
-        // the highest-significance descendant tag. Children must NOT
-        // also appear as separate enumerated entries elsewhere.
+        // A container `move` whose content change lives in a child (e.g. a
+        // renamed archive holding one modified member) reports as one unit: an
+        // origin line plus the joined child detail, indented under one path and
+        // classified together by the highest-significance descendant tag.
+        // Children must NOT also appear as separate enumerated entries.
         let child = DiffNode::new("modify", "column", "email")
             .with_summary("Column added: 'email'")
             .with_tag("binoc.column-addition");
         let move_node = DiffNode::new("move", "tabular", "data_v2.csv")
             .with_source(Source::new("data.csv", Side::From).with_action("move"))
-            .with_summary("Moved from data.csv (modified)")
+            .with_summary("Moved from data.csv")
             .with_tag("binoc.move")
-            .with_tag("binoc.move.modified")
             .with_children(vec![child]);
         let root = DiffNode::new("modify", "directory", "").with_children(vec![move_node]);
 
@@ -1560,8 +1624,9 @@ mod tests {
             md.contains("## Substantive changes"),
             "should land in substantive section (promoted from child tag)"
         );
-        assert!(md.contains("- **data_v2.csv**: Moved from data.csv (modified)\n"));
-        assert!(md.contains("- **data_v2.csv**: Column added: 'email'\n"));
+        assert!(md.contains("- **data_v2.csv**:\n"), "got:\n{md}");
+        assert!(md.contains("  - Moved from data.csv\n"), "got:\n{md}");
+        assert!(md.contains("  - Column added: 'email'\n"), "got:\n{md}");
         // The child detail should appear exactly once, never as its own
         // separately-categorized entry.
         assert_eq!(md.matches("Column added: 'email'").count(), 1);
@@ -1569,11 +1634,11 @@ mod tests {
 
     #[test]
     fn move_with_tabular_summary_annotation_renders_as_paired_bullets() {
-        // A CSV rename+modify produces a move node with no children but
-        // `annotations.tabular_summary` set by TabularAnalyzer.
+        // A CSV rename+modify produces a `binoc.move.modified` node whose
+        // origin is synthesized from its source and whose content comes from
+        // `annotations.tabular_summary` (set by TabularAnalyzer).
         let mut move_node = DiffNode::new("move", "tabular", "data_v2.csv")
             .with_source(Source::new("data.csv", Side::From).with_action("move"))
-            .with_summary("Moved from data.csv (modified)")
             .with_tag("binoc.move")
             .with_tag("binoc.move.modified")
             .with_tag("binoc.column-addition")
@@ -1598,23 +1663,22 @@ mod tests {
 
         assert!(md.contains("## Substantive changes"));
         assert!(
-            md.contains("- **data_v2.csv**: Moved from data.csv (modified)\n"),
-            "move headline bullet missing; got:\n{md}"
+            md.contains("  - Moved from data.csv\n"),
+            "origin line missing; got:\n{md}"
         );
         assert!(
-            md.contains("- **data_v2.csv**: Column added: 'email'\n"),
-            "tabular_summary must render as its own bullet under the same path; got:\n{md}"
+            md.contains("  - Column added: 'email'\n"),
+            "tabular_summary must render beneath the origin under the same path; got:\n{md}"
         );
     }
 
     #[test]
     fn move_with_content_summary_annotation_renders_as_paired_bullets() {
-        // A text rename+modify produces a move node with no children,
-        // no tabular_summary, but `annotations.content_summary` from
+        // A text rename+modify produces a `binoc.move.modified` node with no
+        // children, no tabular_summary, but `annotations.content_summary` from
         // the controller's re-dispatch merge.
         let mut move_node = DiffNode::new("move", "text", "meeting-notes-v2.txt")
             .with_source(Source::new("notes.txt", Side::From).with_action("move"))
-            .with_summary("Moved from notes.txt (modified)")
             .with_tag("binoc.move")
             .with_tag("binoc.move.modified")
             .with_tag("binoc.content-changed")
@@ -1632,12 +1696,12 @@ mod tests {
         );
 
         assert!(
-            md.contains("- **meeting-notes-v2.txt**: Moved from notes.txt (modified)\n"),
-            "move headline bullet missing; got:\n{md}"
+            md.contains("  - Moved from notes.txt\n"),
+            "origin line missing; got:\n{md}"
         );
         assert!(
-            md.contains("- **meeting-notes-v2.txt**: 2 lines added\n"),
-            "content_summary must render as its own bullet under the same path; got:\n{md}"
+            md.contains("  - 2 lines added\n"),
+            "content_summary must render beneath the origin under the same path; got:\n{md}"
         );
     }
 
@@ -1645,7 +1709,7 @@ mod tests {
     fn move_trailer_prefers_tabular_over_content_summary() {
         let mut move_node = DiffNode::new("move", "tabular", "data_v2.csv")
             .with_source(Source::new("data.csv", Side::From).with_action("move"))
-            .with_summary("Moved from data.csv (modified)")
+            .with_summary("Moved from data.csv")
             .with_tag("binoc.move");
         move_node.annotate_from(
             "binoc",
@@ -1664,7 +1728,7 @@ mod tests {
             &MarkdownRendererConfig::default(),
         );
 
-        assert!(md.contains("- **data_v2.csv**: Column added: 'email'\n"));
+        assert!(md.contains("  - Column added: 'email'\n"), "got:\n{md}");
         assert!(
             !md.contains("CSV modified"),
             "content_summary should be shadowed by tabular_summary"

--- a/binoc-stdlib/src/renderers/markdown.rs
+++ b/binoc-stdlib/src/renderers/markdown.rs
@@ -762,6 +762,177 @@ fn render_known_edit_details(
     // Metadata reads AFTER the primary table/content edits above, so a changelog
     // says "what the table did" then "what its metadata did" (CFM-82).
     render_metadata_details(out, edits, config, detail_budget);
+    render_generic_edit_details(out, node, edits, config, detail_budget);
+}
+
+fn render_generic_edit_details(
+    out: &mut String,
+    node: &DiffNode,
+    edits: &[serde_json::Value],
+    config: &MarkdownRendererConfig,
+    detail_budget: &mut DetailBudget,
+) {
+    let generic: Vec<&serde_json::Value> = edits
+        .iter()
+        .filter(|edit| {
+            edit.get("verb")
+                .and_then(|value| value.as_str())
+                .is_none_or(|verb| !specialized_detail_verb(verb))
+                && !summary_covered_generic_verb(node, edit)
+        })
+        .collect();
+    if generic.is_empty() {
+        return;
+    }
+    let total = generic.len();
+    let shown = example_count(generic.len(), config);
+    for edit in generic.into_iter().take(shown) {
+        if !render_generic_edit_detail(out, edit, config, detail_budget) {
+            return;
+        }
+    }
+    if shown < total {
+        let _ = detail_budget.push_line(
+            out,
+            format!(
+                "  - Additional edits omitted{}\n",
+                showing_suffix(shown, total)
+            ),
+        );
+    }
+}
+
+fn render_generic_edit_detail(
+    out: &mut String,
+    edit: &serde_json::Value,
+    config: &MarkdownRendererConfig,
+    detail_budget: &mut DetailBudget,
+) -> bool {
+    let verb = edit
+        .get("verb")
+        .and_then(|value| value.as_str())
+        .unwrap_or("edit");
+    let params = edit.get("params").unwrap_or(&serde_json::Value::Null);
+    if verb == "tabular.append_rows" {
+        return render_append_rows_detail(out, params, config, detail_budget);
+    }
+
+    let title = humanize_edit_verb(verb);
+    let detail = format_generic_edit_params(params, config);
+    let line = if detail.is_empty() {
+        title
+    } else {
+        format!("{title}: {detail}")
+    };
+    detail_budget.push_line(out, format!("  - {line}\n"))
+}
+
+fn render_append_rows_detail(
+    out: &mut String,
+    params: &serde_json::Value,
+    config: &MarkdownRendererConfig,
+    detail_budget: &mut DetailBudget,
+) -> bool {
+    let rows = params
+        .get("rows")
+        .and_then(|value| value.as_array())
+        .cloned()
+        .unwrap_or_default();
+    if rows.is_empty() {
+        return detail_budget.push_line(out, "  - Rows added\n".to_string());
+    }
+    let shown = example_count(rows.len(), config);
+    if !detail_budget.push_line(
+        out,
+        format!("  - Rows added{}\n", showing_suffix(shown, rows.len())),
+    ) {
+        return false;
+    }
+    let start = params.get("start").and_then(|value| value.as_u64());
+    for (offset, row) in rows.into_iter().take(shown).enumerate() {
+        let locator = start
+            .map(|start| format!("row {}", start + offset as u64 + 1))
+            .unwrap_or_else(|| "row".into());
+        let values = captured_row_values_text(&row, config);
+        if !detail_budget.push_line(out, format!("    - {locator}: {values}\n")) {
+            return false;
+        }
+    }
+    true
+}
+
+fn specialized_detail_verb(verb: &str) -> bool {
+    matches!(
+        verb,
+        "tabular.edit_cell"
+            | "tabular.add_row"
+            | "tabular.remove_row"
+            | "text.replace_lines"
+            | "binary.contents-differ"
+            | "metadata.value_change"
+    )
+}
+
+fn summary_covered_generic_verb(node: &DiffNode, edit: &serde_json::Value) -> bool {
+    let Some(verb) = edit.get("verb").and_then(|value| value.as_str()) else {
+        return false;
+    };
+    matches!(verb, "tabular.rename_column") && node.tags.contains("binoc.column-rename")
+}
+
+fn humanize_edit_verb(verb: &str) -> String {
+    let tail = verb.rsplit_once('.').map(|(_, tail)| tail).unwrap_or(verb);
+    tail.replace(['_', '-'], " ")
+        .split_whitespace()
+        .map(|word| {
+            let mut chars = word.chars();
+            match chars.next() {
+                Some(first) => format!("{}{}", first.to_uppercase(), chars.as_str()),
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn captured_row_values_text(row: &serde_json::Value, config: &MarkdownRendererConfig) -> String {
+    row.get("values")
+        .and_then(|value| value.as_array())
+        .map(|values| {
+            values
+                .iter()
+                .take(config.max_examples_per_block.max(1))
+                .map(|value| format_scalar_value(value, config))
+                .collect::<Vec<_>>()
+                .join(", ")
+        })
+        .filter(|values| !values.is_empty())
+        .unwrap_or_else(|| "values omitted".into())
+}
+
+fn format_generic_edit_params(
+    params: &serde_json::Value,
+    config: &MarkdownRendererConfig,
+) -> String {
+    match params {
+        serde_json::Value::Object(map) => map
+            .iter()
+            .take(config.max_examples_per_block.max(1))
+            .map(|(key, value)| format!("{key}: {}", compact_json_value(value, config)))
+            .collect::<Vec<_>>()
+            .join("; "),
+        serde_json::Value::Null => String::new(),
+        other => compact_json_value(other, config),
+    }
+}
+
+fn compact_json_value(value: &serde_json::Value, config: &MarkdownRendererConfig) -> String {
+    let rendered = match value {
+        serde_json::Value::String(text) => format!("'{text}'"),
+        other => serde_json::to_string(other).unwrap_or_else(|_| "null".into()),
+    };
+    let (rendered, truncated) = truncate_text(&rendered, config.max_value_chars);
+    format!("{rendered}{}", if truncated { "..." } else { "" })
 }
 
 /// Render `metadata.value_change` edits (column/table/file metadata) as human
@@ -1429,6 +1600,79 @@ mod tests {
         assert!(!md.contains("## "));
         assert!(md.contains("**data.csv**"));
         assert!(md.contains("Column added: 'email'"));
+    }
+
+    #[test]
+    fn to_markdown_renders_unknown_visible_edit_details() {
+        let mut node = DiffNode::new("modify", "tabular", "data.csv").with_summary("1 edit");
+        node.details.insert(
+            "edits".into(),
+            serde_json::json!([
+                {
+                    "verb": "tabular.append_rows",
+                    "params": {
+                        "start": 2,
+                        "rows": [
+                            { "values": ["south", "2025", "9"] },
+                            { "values": ["east", "2025", "21"] }
+                        ]
+                    }
+                }
+            ]),
+        );
+        let changeset = Changeset::new(
+            "v1",
+            "v2",
+            Some(DiffNode::new("modify", "directory", "").with_children(vec![node])),
+        );
+
+        let md = render_markdown(&[changeset], &MarkdownRendererConfig::default());
+        assert!(md.contains("  - Rows added\n"), "got:\n{md}");
+        assert!(
+            md.contains("    - row 3: 'south', '2025', '9'")
+                && md.contains("    - row 4: 'east', '2025', '21'"),
+            "got:\n{md}"
+        );
+    }
+
+    #[test]
+    fn to_markdown_does_not_duplicate_summary_covered_column_rename() {
+        let mut node = DiffNode::new("modify", "tabular", "data.csv")
+            .with_summary("Column renamed: 'count' -> 'total'")
+            .with_tag("binoc.column-rename");
+        node.details.insert(
+            "edits".into(),
+            serde_json::json!([
+                {
+                    "verb": "tabular.rename_column",
+                    "params": { "from": "count", "to": "total" }
+                },
+                {
+                    "verb": "tabular.append_rows",
+                    "params": {
+                        "start": 3,
+                        "rows": [
+                            { "values": ["south", "2025", "9"] },
+                            { "values": ["east", "2025", "21"] }
+                        ]
+                    }
+                }
+            ]),
+        );
+        let changeset = Changeset::new(
+            "v1",
+            "v2",
+            Some(DiffNode::new("modify", "directory", "").with_children(vec![node])),
+        );
+
+        let md = render_markdown(&[changeset], &MarkdownRendererConfig::default());
+        assert!(
+            md.contains("Column renamed: 'count' -> 'total'"),
+            "got:\n{md}"
+        );
+        assert!(!md.contains("Rename Column"), "got:\n{md}");
+        assert!(!md.contains("Other edits"), "got:\n{md}");
+        assert!(md.contains("  - Rows added\n"), "got:\n{md}");
     }
 
     #[test]

--- a/binoc-stdlib/tests/correspondence_engine.rs
+++ b/binoc-stdlib/tests/correspondence_engine.rs
@@ -839,6 +839,73 @@ fn keyed_row_exclusion_degrades_with_diagnostic() {
 }
 
 #[test]
+fn tabular_writer_infers_single_column_row_key_for_high_overlap_unique_values() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let left = temp.path().join("left");
+    let right = temp.path().join("right");
+    fs::create_dir_all(&left).unwrap();
+    fs::create_dir_all(&right).unwrap();
+    fs::write(
+        left.join("data.csv"),
+        "id,name,value\n1,alpha,a\n2,beta,b\n3,gamma,c\n4,delta,d\n",
+    )
+    .unwrap();
+    fs::write(
+        right.join("data.csv"),
+        "id,name,value\n4,delta,d\n3,gamma,c\n2,beta,B\n1,alpha,a\n",
+    )
+    .unwrap();
+
+    let changeset = diff_with_config(&left, &right, default_engine_config());
+    assert!(changeset
+        .diagnostics
+        .iter()
+        .any(|diagnostic| diagnostic.code == "binoc.tabular_auto_key"));
+    let root = changeset.root.expect("root");
+    let node = find(&root, "data.csv").expect("data.csv");
+    assert_eq!(node.action, "modify");
+    let edits = node.details["edits"].as_array().expect("edits");
+    assert_eq!(edits.len(), 1, "{edits:?}");
+    assert_eq!(edits[0]["verb"], "tabular.edit_cell");
+    assert_eq!(edits[0]["params"]["key"]["id"], "2");
+    assert_eq!(edits[0]["params"]["column"], "value");
+}
+
+#[test]
+fn csv_banner_line_does_not_truncate_later_rows_to_one_column() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let left = temp.path().join("left");
+    let right = temp.path().join("right");
+    fs::create_dir_all(&left).unwrap();
+    fs::create_dir_all(&right).unwrap();
+    fs::write(
+        left.join("gistemp.csv"),
+        "Land-Ocean: Global Means\nYear,Jan,Feb\n1880,-.18,-.24\n",
+    )
+    .unwrap();
+    fs::write(
+        right.join("gistemp.csv"),
+        "Land-Ocean: Global Means\nYear,Jan,Feb\n1880,-.17,-.24\n",
+    )
+    .unwrap();
+
+    let changeset = diff_with_config(&left, &right, default_engine_config());
+    let root = changeset.root.expect("root");
+    let node = find(&root, "gistemp.csv").expect("gistemp.csv");
+    assert_eq!(node.action, "modify");
+    let edits = node.details["edits"].as_array().expect("edits");
+    assert!(
+        edits.iter().any(|edit| {
+            edit["verb"] == "tabular.edit_cell"
+                && edit["params"]["column"] == "column_2"
+                && edit["params"]["from"] == "-.18"
+                && edit["params"]["to"] == "-.17"
+        }),
+        "{edits:?}"
+    );
+}
+
+#[test]
 fn keyed_row_degradation_tags_only_observed_failures() {
     let temp = tempfile::tempdir().expect("tempdir");
     let left = temp.path().join("left");

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -53,7 +53,6 @@ binoc diff ./test-vectors-materialized/trivial-identical/snapshot-a ./test-vecto
 ```output
 # Changelog: ./test-vectors-materialized/trivial-identical/snapshot-a → ./test-vectors-materialized/trivial-identical/snapshot-b
 
-No changes detected.
 
 ```
 
@@ -90,7 +89,9 @@ binoc diff ./test-vectors-materialized/single-file-modify-text/snapshot-a ./test
 ```output
 # Changelog: ./test-vectors-materialized/single-file-modify-text/snapshot-a → ./test-vectors-materialized/single-file-modify-text/snapshot-b
 
-- **story.txt**: 2 lines added, 1 removed
+- **story.txt**: 2 lines added; 1 line removed
+  - Line changes
+    - line 2: 'Line 2' -> 'Line 2 revised'
 
 ```
 
@@ -127,7 +128,8 @@ binoc diff ./test-vectors-materialized/csv-column-reorder/snapshot-a ./test-vect
 ```output
 # Changelog: ./test-vectors-materialized/csv-column-reorder/snapshot-a → ./test-vectors-materialized/csv-column-reorder/snapshot-b
 
-- **data.csv**: Columns reordered (content unchanged)
+- **data.csv**: Columns reordered
+  - Reorder Columns: order: ["city","name","age"]
 
 ```
 
@@ -145,7 +147,11 @@ binoc diff ./test-vectors-materialized/csv-mixed-changes/snapshot-a ./test-vecto
 ```output
 # Changelog: ./test-vectors-materialized/csv-mixed-changes/snapshot-a → ./test-vectors-materialized/csv-mixed-changes/snapshot-b
 
-- **data.csv**: Column added: 'email'; columns reordered; 1 row added
+- **data.csv**: Column added: 'email'; Columns reordered; 1 row added
+  - Rows added
+    - row 3: 'SF', 'Charlie', '35'
+  - Reorder Columns: order: ["city","name","age"]
+  - Add Column: name: 'email'; values: {"total_values":3,"truncated":false,"values":["a@test.com","b@test.com","c@test.com"]}
 
 ```
 
@@ -163,8 +169,10 @@ binoc diff ./test-vectors-materialized/zip-simple/snapshot-a ./test-vectors-mate
 ```output
 # Changelog: ./test-vectors-materialized/zip-simple/snapshot-a → ./test-vectors-materialized/zip-simple/snapshot-b
 
-- **archive.zip/data.txt**: 1 line added, 1 removed
-- **archive.zip/extra.txt**: New file (1 line)
+- **archive.zip/>data.txt**: 1 line added; 1 line removed
+  - Line changes
+    - line 1: 'hello from zip A' -> 'hello from zip B'
+- **archive.zip/>extra.txt**: Added
 
 ```
 
@@ -184,11 +192,11 @@ binoc diff ./docs/examples/fasta-demo/snapshot-a/sequences.fasta ./docs/examples
 ```output
 # Changelog: ./docs/examples/fasta-demo/snapshot-a/sequences.fasta → ./docs/examples/fasta-demo/snapshot-b/sequences.fasta
 
-- **sequences.fasta**: Content changed (92 bytes → 102 bytes)
-
-## Suggestions
-
-- Compared as binary; a plugin may provide a more semantic diff. (`sequences.fasta`) [binoc.binary-fallback]
+- **sequences.fasta**: Binary content changed; 1 extracted string added, 1 extracted string removed
+  - Extracted strings added
+    - '>gene_1 source=NCBI retrieved=2024-06\nATCGATCGATCG\n>gene_2 source=NCBI retrieved=2024-06\nGCTAGCTAGCTA\n'
+  - Extracted strings removed
+    - '>gene_1 src=GenBank date=2024-01\nATCGATCGATCG\n>gene_2 src=GenBank date=2024-01\nGCTAGCTAGCTA\n'
 
 ```
 

--- a/docs/users/explanation/test-vectors-gallery.md
+++ b/docs/users/explanation/test-vectors-gallery.md
@@ -13,7 +13,7 @@ audience: new user, data steward, archivist
 
 These are runnable examples from binoc's test suite. Each example links to its source folder on GitHub, tells you whether it needs any extra setup, gives you the exact command to run, and shows the Markdown changelog binoc is expected to print.
 
-Binoc currently ships **44 shared examples** in this gallery.
+Binoc currently ships **62 shared examples** in this gallery.
 
 ## One-time setup
 
@@ -29,50 +29,68 @@ just materialize
 
 | Example | What it shows | Example output | Setup |
 |---|---|---|---|
-| [`binary-fallback-diagnostic`](#binary-fallback-diagnostic) | Unknown file type compared by the binary fallback emits a suggestion | data.parquet: 1 edit | Default pipeline |
-| [`csv-cell-changes`](#csv-cell-changes) | Individual cell values changed | data.csv: 2 edits | Default pipeline |
-| [`csv-column-addition`](#csv-column-addition) | New column added | data.csv: 2 edits | Default pipeline |
-| [`csv-column-removal`](#csv-column-removal) | Column removed | data.csv: 2 edits | Default pipeline |
-| [`csv-column-reorder`](#csv-column-reorder) | Columns shuffled, content identical | data.csv: 1 edit | Default pipeline |
-| [`csv-distribution-shift`](#csv-distribution-shift) | Numeric column distribution shifts with keyed row matching | data.csv: 5 edits | Custom config |
-| [`csv-keyed-null-duplicate`](#csv-keyed-null-duplicate) | Configured CSV row keys surface null and duplicate key diagnostics | data.csv: 14 edits | Custom config |
-| [`csv-keyed-row-diff`](#csv-keyed-row-diff) | Configured CSV row keys match reordered rows and report keyed row/cell changes | data.csv: 3 edits | Custom config |
-| [`csv-mid-row-insertion`](#csv-mid-row-insertion) | A mid-table row insertion compacts while column reorder/addition rules remain independent | data.csv: 3 edits | Default pipeline |
-| [`csv-mixed-changes`](#csv-mixed-changes) | Multiple change types | data.csv: 3 edits | Default pipeline |
-| [`csv-rename-modify`](#csv-rename-modify) | CSV renamed and modified: detected as a single move by fuzzy correlation | data_v2.csv: Moved from data.csv (modified) | Default pipeline |
-| [`csv-row-addition`](#csv-row-addition) | New rows appended | data.csv: 1 edit | Default pipeline |
-| [`csv-row-removal`](#csv-row-removal) | Rows removed from CSV | data.csv: 2 edits | Default pipeline |
-| [`csv-stacked-tables`](#csv-stacked-tables) | Detects two logical tables stacked in one messy CSV | data.csv: 1 edit | Default pipeline |
-| [`csv-verbosity-full`](#csv-verbosity-full) | Markdown full verbosity renders every captured changed-cell example. | data.csv: 5 edits | Custom config |
+| [`binary-fallback-diagnostic`](#binary-fallback-diagnostic) | Unknown file type compared by the binary fallback emits a suggestion | data.parquet: Binary content changed; 1 extracted string added, 1 extracted string removed | Default pipeline |
+| [`binary-strings-fallback`](#binary-strings-fallback) | Two opaque binary blobs with differing hashes. The change is hash-driven (binoc.content-changed), and an additive extra… | firmware.bin: Binary content changed; 2 extracted strings added, 2 extracted strings removed | Default pipeline |
+| [`csv-cell-changes`](#csv-cell-changes) | Individual cell values changed | data.csv: 2 cells changed | Default pipeline |
+| [`csv-column-addition`](#csv-column-addition) | New column added | data.csv: Column added: 'email' | Default pipeline |
+| [`csv-column-removal`](#csv-column-removal) | Column removed | data.csv: Column removed: 'city' | Default pipeline |
+| [`csv-column-reorder`](#csv-column-reorder) | Columns shuffled, content identical | data.csv: Columns reordered | Default pipeline |
+| [`csv-distribution-shift`](#csv-distribution-shift) | Numeric column distribution shifts with keyed row matching | data.csv: 4 rows modified by key | Custom config |
+| [`csv-keyed-null-duplicate`](#csv-keyed-null-duplicate) | Configured CSV row keys surface null and duplicate key diagnostics | data.csv: 14 cells changed | Custom config |
+| [`csv-keyed-row-diff`](#csv-keyed-row-diff) | Configured CSV row keys match reordered rows and report keyed row/cell changes | data.csv: 1 row added; 1 row removed; 1 row modified by key | Custom config |
+| [`csv-mid-row-insertion`](#csv-mid-row-insertion) | A mid-table row insertion compacts while column reorder/addition rules remain independent | data.csv: Column added: 'email'; Columns reordered; 1 row added | Default pipeline |
+| [`csv-mixed-changes`](#csv-mixed-changes) | Multiple change types | data.csv: Column added: 'email'; Columns reordered; 1 row added | Default pipeline |
+| [`csv-rename-modify`](#csv-rename-modify) | CSV renamed and modified: detected as a single move by fuzzy correlation | data_v2.csv: | Default pipeline |
+| [`csv-row-addition`](#csv-row-addition) | New rows appended | data.csv: 2 rows added | Default pipeline |
+| [`csv-row-removal`](#csv-row-removal) | Rows removed from CSV | data.csv: 2 rows removed | Default pipeline |
+| [`csv-stacked-tables`](#csv-stacked-tables) | Detects two logical tables stacked in one messy CSV | data.csv/>table_2: 1 row added | Default pipeline |
+| [`csv-to-tsv-reformat`](#csv-to-tsv-reformat) | Table reformatted from CSV to TSV with row edits: detected as one reformatted-and-modified table, not remove + add | data.tsv: | Default pipeline |
+| [`csv-verbosity-full`](#csv-verbosity-full) | Markdown full verbosity renders every captured changed-cell example. | data.csv: 5 cells changed | Custom config |
 | [`directory-file-copy`](#directory-file-copy) | New file with same content as an existing unchanged file detected as a copy | duplicate.txt: Copied from original.txt | Default pipeline |
-| [`directory-nested`](#directory-nested) | Subdirectories with mixed changes | data: 0 edits | Default pipeline |
-| [`directory-nested-with-tar`](#directory-nested-with-tar) | Shows binoc diffing a tar archive and a plain directory that contain overlapping internal paths. | data.tar.gz/records.csv: 1 edit | Default pipeline |
+| [`directory-nested`](#directory-nested) | Subdirectories with mixed changes | data/records.csv: 1 row added | Default pipeline |
+| [`directory-nested-with-tar`](#directory-nested-with-tar) | Shows binoc diffing a tar archive and a plain directory that contain overlapping internal paths. | data.tar.gz/>records.csv: 1 cell changed | Default pipeline |
+| [`enforcement-actions-merge-years`](#enforcement-actions-merge-years) | Per-year CSVs merged row-wise into one file; detected as a clean partition merge (CFM-72) | actions_2023.csv, actions_2024.csv merged into actions.csv | Default pipeline |
 | [`file-correspondence-container`](#file-correspondence-container) | Config declares a correspondence between renamed zip containers | archive.zip: Moved from data.zip | Custom config |
-| [`file-correspondence-scheme`](#file-correspondence-scheme) | Config declares that a state CSV moved into a new directory scheme is the same logical file | (root): 0 edits | Custom config |
-| [`file-correspondence-token`](#file-correspondence-token) | Config declares that year-stamped CSV filenames are the same logical file | running_list_as_of_2023.csv: Moved from running_list_as_of_2022.csv (modified) | Custom config |
+| [`file-correspondence-scheme`](#file-correspondence-scheme) | Config declares that a state CSV moved into a new directory scheme is the same logical file | by-state: Added | Custom config |
+| [`file-correspondence-token`](#file-correspondence-token) | Config declares that year-stamped CSV filenames are the same logical file | running_list_as_of_2023.csv: | Custom config |
 | [`folder-move-nested`](#folder-move-nested) | Detects a whole-folder rename and rolls many file moves up into one folder-move entry. | documentation: Moved from docs | Default pipeline |
-| [`folder-move-partial`](#folder-move-partial) | Detects a mostly-moved folder rename and preserves only the added/removed/modified remainder entries beneath it. | (root): 0 edits | Default pipeline |
-| [`gzip-inner-dispatch`](#gzip-inner-dispatch) | Gzipped CSV and text are decompressed and redispatched under their inner names | census.txt.gz/census.txt: 1 edit | Default pipeline |
-| [`kitchen-sink`](#kitchen-sink) | Runs text, CSV, archive, move, and copy detection together in one end-to-end example. | archive.tar.gz/inventory.csv: 1 edit | Default pipeline |
-| [`single-file-add`](#single-file-add) | File present in B but not A | (root): 0 edits | Default pipeline |
+| [`folder-move-partial`](#folder-move-partial) | Detects a mostly-moved folder rename and preserves only the added/removed/modified remainder entries beneath it. | FoodData_Central_csv_2026-04-30: Added | Default pipeline |
+| [`geojson-feature-cell-change`](#geojson-feature-cell-change) | A GeoJSON FeatureCollection where one feature's property changes; transcoded to a tabular artifact with the geometry as… | places.geojson: 1 cell changed | Default pipeline |
+| [`gzip-inner-dispatch`](#gzip-inner-dispatch) | Gzipped CSV and text are decompressed and redispatched under their inner names | census.txt.gz/>census.txt: 1 line added; 1 line removed | Default pipeline |
+| [`ini-value-change`](#ini-value-change) | An INI value changes; transcoded to a structured_document and reported as a value change | config.ini: Document values changed | Default pipeline |
+| [`json-array-order-significant`](#json-array-order-significant) | JSON array order changes are semantic content changes in stage 1 | metadata.json: Document values changed | Default pipeline |
+| [`json-key-order-reexport`](#json-key-order-reexport) | JSON object key order and pretty-printing changed without semantic value changes | metadata.json: Document serialization changed | Default pipeline |
+| [`json-records-cell-change`](#json-records-cell-change) | JSON array of like-shaped objects parsed as a typed table; numeric cell values change | data.json: 2 cells changed | Default pipeline |
+| [`json-records-nested-value`](#json-records-nested-value) | JSON records with a nested object cell; the nested value changes and is reported as a single equality-based cell edit (… | people.json: 1 cell changed | Default pipeline |
+| [`jsonl-row-addition`](#jsonl-row-addition) | JSONL stream of like-shaped objects parsed as a table; a record is appended | events.jsonl: 1 row added | Default pipeline |
+| [`jsonld-value-change`](#jsonld-value-change) | A .jsonld file with no declared media type parses as a structured document tagged format=jsonld; a value change is repo… | person.jsonld: Document values changed | Default pipeline |
+| [`kitchen-sink`](#kitchen-sink) | Runs text, CSV, archive, move, and copy detection together in one end-to-end example. | archive.tar.gz/>inventory.csv: 1 row added | Default pipeline |
+| [`observations-repartition-equal-arity`](#observations-repartition-equal-arity) | Equal-arity N→M repartition: 2 tables grouped by region become 2 tables grouped by year, every row preserved exactly bu… | observations_2024.csv: | Default pipeline |
+| [`observations-split-by-year`](#observations-split-by-year) | One CSV split row-wise into per-year files; detected as a clean partition split (CFM-72) | observations.csv split into observations_2024.csv, observations_2025.csv | Default pipeline |
+| [`observations-split-residual`](#observations-split-residual) | A would-be split missing one row: partition declines (not complete), emits binoc.possible_split, and degrades to honest… | observations_2024.csv: | Default pipeline |
+| [`single-file-add`](#single-file-add) | File present in B but not A | new_file.txt: Added | Default pipeline |
 | [`single-file-modify-binary`](#single-file-modify-binary) | Binary file, different hash | data.bin: 1 edit | Default pipeline |
-| [`single-file-modify-csv`](#single-file-modify-csv) | CSV file compared directly (file-to-file, not via directory) | data.csv: 1 edit | Default pipeline |
-| [`single-file-modify-text`](#single-file-modify-text) | Text file with line-level changes | story.txt: 1 edit | Default pipeline |
-| [`single-file-modify-text-root`](#single-file-modify-text-root) | Text file compared directly (file-to-file, not via directory) | story.txt: 1 edit | Default pipeline |
-| [`single-file-remove`](#single-file-remove) | File present in A but not B | (root): 0 edits | Default pipeline |
-| [`tar-nested`](#tar-nested) | Nested tar.gz containing CSV | outer.tar.gz/inner.tar.gz/data.csv: 1 edit | Default pipeline |
-| [`tar-simple`](#tar-simple) | Tar.gz archive with changes inside | archive.tar.gz/data.csv: 1 edit | Default pipeline |
-| [`text-rename-modify`](#text-rename-modify) | Text file renamed and modified: detected as a single move by fuzzy correlation | meeting-notes-v2.txt: Moved from notes.txt (modified) | Default pipeline |
-| [`tree-wide-correlation`](#tree-wide-correlation) | Shows tree-wide move and copy detection across nested zip boundaries, including one-to-many copies and many-to-one moves. | gamma-renamed.txt: Moved from outer.zip/inner.zip/gamma.txt | Default pipeline |
-| [`trivial-identical`](#trivial-identical) | Two identical directories → empty changeset | Claims: none | Default pipeline |
-| [`trivial-identical-csv`](#trivial-identical-csv) | Two identical CSV files → no changes reported | Claims: none | Default pipeline |
-| [`tsv-cell-changes`](#tsv-cell-changes) | Tab-delimited file parses into real columns and reports cell changes | data.tsv: 2 edits | Default pipeline |
-| [`zip-declared-container`](#zip-declared-container) | Config declares a correspondence between nested zip containers and preserves inner CSV content detail | outer.zip/records.zip: Moved from outer.zip/records-old.zip | Custom config |
-| [`zip-nested`](#zip-nested) | Nested zip containing CSV | outer.zip/inner.zip/data.csv: 1 edit | Default pipeline |
-| [`zip-rename-contents-rewritten`](#zip-rename-contents-rewritten) | Documents a known gap — a renamed zip whose children were all renamed AND rewritten (no content similarity) yields unpa… | (root): 0 edits | Default pipeline |
+| [`single-file-modify-csv`](#single-file-modify-csv) | CSV file compared directly (file-to-file, not via directory) | data.csv: 1 row added | Default pipeline |
+| [`single-file-modify-text`](#single-file-modify-text) | Text file with line-level changes | story.txt: 2 lines added; 1 line removed | Default pipeline |
+| [`single-file-modify-text-root`](#single-file-modify-text-root) | Text file compared directly (file-to-file, not via directory) | story.txt: 2 lines added; 1 line removed | Default pipeline |
+| [`single-file-remove`](#single-file-remove) | File present in A but not B | removed_file.txt: Removed | Default pipeline |
+| [`stacked-csv-broken-out`](#stacked-csv-broken-out) | Stacked-CSV tables broken out into one file per table; whole-table rehoming (reshape + 1:1), NOT a partition split (CFM… | changes.csv: Moved from report.csv/>table_1 | Default pipeline |
+| [`tar-nested`](#tar-nested) | Nested tar.gz containing CSV | outer.tar.gz/>inner.tar.gz/>data.csv: 1 row added | Default pipeline |
+| [`tar-simple`](#tar-simple) | Tar.gz archive with changes inside | archive.tar.gz/>data.csv: 1 row added | Default pipeline |
+| [`text-rename-modify`](#text-rename-modify) | Text file renamed and modified: detected as a single move by fuzzy correlation | meeting-notes-v2.txt: | Default pipeline |
+| [`toml-value-change`](#toml-value-change) | A TOML value changes; transcoded to a structured_document and reported as a value change | config.toml: Document values changed | Default pipeline |
+| [`tree-wide-correlation`](#tree-wide-correlation) | Shows tree-wide move and copy detection across nested zip boundaries, including one-to-many copies and many-to-one moves. | gamma-renamed.txt: Moved from outer.zip/>inner.zip/>gamma.txt | Default pipeline |
+| [`trivial-identical`](#trivial-identical) | Two identical directories → empty changeset | # Changelog: snapshot-a → snapshot-b | Default pipeline |
+| [`trivial-identical-csv`](#trivial-identical-csv) | Two identical CSV files → no changes reported | # Changelog: snapshot-a → snapshot-b | Default pipeline |
+| [`tsv-cell-changes`](#tsv-cell-changes) | Tab-delimited file parses into real columns and reports cell changes | data.tsv: 2 cells changed | Default pipeline |
+| [`yaml-value-change`](#yaml-value-change) | A YAML scalar value changes; transcoded to a structured_document and reported as a value change | config.yaml: Document values changed | Default pipeline |
+| [`zip-declared-container`](#zip-declared-container) | Config declares a correspondence between nested zip containers and preserves inner CSV content detail | outer.zip/>records.zip: | Custom config |
+| [`zip-json-key-order-reexport`](#zip-json-key-order-reexport) | JSON files inside zip expansion get parsed and rendered as serialization-only changes | archive.zip/>metadata.json: Document serialization changed | Default pipeline |
+| [`zip-nested`](#zip-nested) | Nested zip containing CSV | outer.zip/>inner.zip/>data.csv: 1 row added | Default pipeline |
+| [`zip-rename-contents-rewritten`](#zip-rename-contents-rewritten) | Documents a known gap — a renamed zip whose children were all renamed AND rewritten (no content similarity) yields unpa… | data.zip: Removed | Default pipeline |
 | [`zip-rename-identical`](#zip-rename-identical) | Zip archive renamed with identical contents; bottom-up roll-up of the inner clean file moves compacts the pair into a s… | archive.zip: Moved from data.zip | Default pipeline |
 | [`zip-rename-inner-rename-edit`](#zip-rename-inner-rename-edit) | Zip archive renamed while its only child was renamed and had one cell edited; the modified move counts as roll-up evide… | archive.zip: Moved from data.zip | Default pipeline |
-| [`zip-simple`](#zip-simple) | Zipped files with changes inside | archive.zip: 0 edits | Default pipeline |
+| [`zip-simple`](#zip-simple) | Zipped files with changes inside | archive.zip/>data.txt: 1 line added; 1 line removed | Default pipeline |
 
 ## binary-fallback-diagnostic
 
@@ -92,11 +110,38 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-Claims: none
+- **data.parquet**: Binary content changed; 1 extracted string added, 1 extracted string removed
+  - Extracted strings added
+    - 'after!\n'
+  - Extracted strings removed
+    - 'before\n'
+```
 
-- **data.parquet**: 1 edit
-  - Sources
-    - data.parquet (from, modify, binoc.pair.name)
+## binary-strings-fallback
+
+Two opaque binary blobs with differing hashes. The change is hash-driven (binoc.content-changed), and an additive extra…
+
+- **Browse source:** [binary-strings-fallback](https://github.com/harvard-lil/binoc/tree/main/test-vectors/binary-strings-fallback)
+- **Tags:** `modify`, `binary`, `strings`
+- **Snapshots:** `snapshot-a` has 1 file — `firmware.bin`; `snapshot-b` has 1 file — `firmware.bin`
+
+Run it:
+```bash
+binoc diff \
+  ./test-vectors-materialized/binary-strings-fallback/snapshot-a \
+  ./test-vectors-materialized/binary-strings-fallback/snapshot-b
+```
+Result:
+```markdown
+# Changelog: snapshot-a → snapshot-b
+
+- **firmware.bin**: Binary content changed; 2 extracted strings added, 2 extracted strings removed
+  - Extracted strings added
+    - 'build-beta'
+    - 'version=2.0.0'
+  - Extracted strings removed
+    - 'build-alpha'
+    - 'version=1.0.0'
 ```
 
 ## csv-cell-changes
@@ -117,11 +162,10 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-Claims: none
-
-- **data.csv**: 2 edits
-  - Sources
-    - data.csv (from, modify, binoc.pair.name)
+- **data.csv**: 2 cells changed
+  - Changed cells
+    - row 1, column 'score': '85' -> '92'
+    - row 2, column 'score': '90' -> '88'
 ```
 
 ## csv-column-addition
@@ -142,11 +186,9 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-Claims: none
-
-- **data.csv**: 2 edits
-  - Sources
-    - data.csv (from, modify, binoc.pair.name)
+- **data.csv**: Column added: 'email'
+  - Set Headers: from: ["name","age"]; to: ["name","age","email"]
+  - Add Column: name: 'email'; values: {"total_values":2,"truncated":false,"values":["alice@test.com","bob@test.com"]}
 ```
 
 ## csv-column-removal
@@ -167,11 +209,9 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-Claims: none
-
-- **data.csv**: 2 edits
-  - Sources
-    - data.csv (from, modify, binoc.pair.name)
+- **data.csv**: Column removed: 'city'
+  - Set Headers: from: ["name","age","city"]; to: ["name","age"]
+  - Remove Column: name: 'city'; values: {"total_values":2,"truncated":false,"values":["NYC","LA"]}
 ```
 
 ## csv-column-reorder
@@ -192,11 +232,8 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-Claims: none
-
-- **data.csv**: 1 edit
-  - Sources
-    - data.csv (from, modify, binoc.pair.name)
+- **data.csv**: Columns reordered
+  - Reorder Columns: order: ["city","name","age"]
 ```
 
 ## csv-distribution-shift
@@ -230,11 +267,11 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-Claims: none
-
-- **data.csv**: 5 edits
-  - Sources
-    - data.csv (from, modify, binoc.pair.name)
+- **data.csv**: 4 rows modified by key
+  - Changed cells (showing 3 of 5)
+    - key id '1', column 'score': '10' -> '12'
+    - key id '2', column 'score': '20' -> '35'
+    - key id '2', column 'label': 'beta' -> 'beta2'
 ```
 
 ## csv-keyed-null-duplicate
@@ -272,11 +309,11 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-Claims: none
-
-- **data.csv**: 14 edits
-  - Sources
-    - data.csv (from, modify, binoc.pair.name)
+- **data.csv**: 14 cells changed
+  - Changed cells (showing 3 of 14)
+    - row 1, column 'id': 'a' -> 'b'
+    - row 1, column 'name': 'Alice' -> 'Bob'
+    - row 1, column 'score': '10' -> '21'
 
 ## Warnings
 
@@ -313,11 +350,13 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-Claims: none
-
-- **data.csv**: 3 edits
-  - Sources
-    - data.csv (from, modify, binoc.pair.name)
+- **data.csv**: 1 row added; 1 row removed; 1 row modified by key
+  - Changed cells
+    - key id 'p2', column 'price': '20' -> '25'
+  - Rows added
+    - key id 'p4': 'p4', 'Delta', '40'
+  - Rows removed
+    - key id 'p3': 'p3', 'Gamma', '30'
 ```
 
 ## csv-mid-row-insertion
@@ -338,11 +377,11 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-Claims: none
-
-- **data.csv**: 3 edits
-  - Sources
-    - data.csv (from, modify, binoc.pair.name)
+- **data.csv**: Column added: 'email'; Columns reordered; 1 row added
+  - Rows added
+    - row 2: 'LA', 'Bob', '25'
+  - Reorder Columns: order: ["city","name","age"]
+  - Add Column: name: 'email'; values: {"total_values":3,"truncated":false,"values":["alice@example.test","bob@example.test","charlie@example.test"]}
 ```
 
 ## csv-mixed-changes
@@ -363,11 +402,11 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-Claims: none
-
-- **data.csv**: 3 edits
-  - Sources
-    - data.csv (from, modify, binoc.pair.name)
+- **data.csv**: Column added: 'email'; Columns reordered; 1 row added
+  - Rows added
+    - row 3: 'SF', 'Charlie', '35'
+  - Reorder Columns: order: ["city","name","age"]
+  - Add Column: name: 'email'; values: {"total_values":3,"truncated":false,"values":["a@test.com","b@test.com","c@test.com"]}
 ```
 
 ## csv-rename-modify
@@ -388,11 +427,11 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-Claims: none
-
-- **data_v2.csv**: Moved from data.csv (modified)
-  - Sources
-    - data.csv (from, move, binoc.pair.fuzzy)
+- **data_v2.csv**:
+  - Moved from data.csv
+  - Column added: 'email'
+  - Set Headers: from: ["name","age","city"]; to: ["name","age","city","email"]
+  - Add Column: name: 'email'; values: {"total_values":3,"truncated":false,"values":["alice@test.com","bob@test.com","carol@test.com"]}
 ```
 
 ## csv-row-addition
@@ -413,11 +452,10 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-Claims: none
-
-- **data.csv**: 1 edit
-  - Sources
-    - data.csv (from, modify, binoc.pair.name)
+- **data.csv**: 2 rows added
+  - Rows added
+    - row 2: 'Bob', '25'
+    - row 3: 'Charlie', '35'
 ```
 
 ## csv-row-removal
@@ -438,11 +476,10 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-Claims: none
-
-- **data.csv**: 2 edits
-  - Sources
-    - data.csv (from, modify, binoc.pair.name)
+- **data.csv**: 2 rows removed
+  - Rows removed
+    - row 2: 'Bob', '25'
+    - row 3: 'Charlie', '35'
 ```
 
 ## csv-stacked-tables
@@ -450,7 +487,7 @@ Claims: none
 Detects two logical tables stacked in one messy CSV
 
 - **Browse source:** [csv-stacked-tables](https://github.com/harvard-lil/binoc/tree/main/test-vectors/csv-stacked-tables)
-- **Tags:** `csv`, `stacked-tables`, `tabular-collection`, `row-addition`
+- **Tags:** `csv`, `stacked-tables`, `row-addition`
 - **Snapshots:** `snapshot-a` has 1 file — `data.csv`; `snapshot-b` has 1 file — `data.csv`
 
 Run it:
@@ -463,14 +500,36 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-Claims: none
+- **data.csv/>table_2**: 1 row added
+  - Rows added
+    - row 12: '761012', 'Mu', 'Mu Pharma'
+```
 
-- **data.csv**: 1 edit
-  - Sources
-    - data.csv (from, modify, binoc.pair.name)
-- **data.csv#table_2**: 1 edit
-  - Sources
-    - data.csv#table_2 (from, modify, binoc.pair.name)
+## csv-to-tsv-reformat
+
+Table reformatted from CSV to TSV with row edits: detected as one reformatted-and-modified table, not remove + add
+
+- **Browse source:** [csv-to-tsv-reformat](https://github.com/harvard-lil/binoc/tree/main/test-vectors/csv-to-tsv-reformat)
+- **Tags:** `csv`, `tsv`, `reformat`, `serialization-change`, `tabular-pair`
+- **Snapshots:** `snapshot-a` has 1 file — `data.csv`; `snapshot-b` has 1 file — `data.tsv`
+
+Run it:
+```bash
+binoc diff \
+  ./test-vectors-materialized/csv-to-tsv-reformat/snapshot-a \
+  ./test-vectors-materialized/csv-to-tsv-reformat/snapshot-b
+```
+Result:
+```markdown
+# Changelog: snapshot-a → snapshot-b
+
+- **data.tsv**:
+  - Moved from data.csv
+  - 1 row added; 1 cell changed
+  - Changed cells
+    - row 2, column 'age': '25' -> '26'
+  - Rows added
+    - row 4: 'Dave', '41', 'Austin'
 ```
 
 ## csv-verbosity-full
@@ -501,11 +560,15 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-Claims: none
-
-- **data.csv**: 5 edits
+- **data.csv**: 5 cells changed
   - Sources
     - data.csv (from, modify, binoc.pair.name)
+  - Changed cells
+    - row 1, column 'score': '10' -> '11'
+    - row 2, column 'score': '20' -> '21'
+    - row 3, column 'score': '30' -> '31'
+    - row 4, column 'score': '40' -> '41'
+    - row 5, column 'score': '50' -> '51'
 ```
 
 ## directory-file-copy
@@ -526,11 +589,7 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-Claims: none
-
 - **duplicate.txt**: Copied from original.txt
-  - Sources
-    - original.txt (from, copy, binoc.pair.copy)
 ```
 
 ## directory-nested
@@ -551,20 +610,13 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-Claims: none
-
-- **data**: 0 edits
-  - Sources
-    - data (from, modify, binoc.pair.name)
-- **data/records.csv**: 1 edit
-  - Sources
-    - data/records.csv (from, modify, binoc.pair.name)
+- **data/records.csv**: 1 row added
+  - Rows added
+    - row 3: '3', 'Charlie'
 - **data/extra.csv**: Added
-  - Sources
-    - data/extra.csv (to, add)
-- **docs/readme.txt**: 1 edit
-  - Sources
-    - docs/readme.txt (from, modify, binoc.pair.name)
+- **docs/readme.txt**: 2 lines added; 1 line removed
+  - Line changes
+    - line 1: 'Version 1 readme' -> 'Version 2 readme'
 ```
 
 ## directory-nested-with-tar
@@ -585,14 +637,37 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-Claims: none
+- **data.tar.gz/>records.csv**: 1 cell changed
+  - Changed cells
+    - row 2, column 'count': '20' -> '25'
+- **data/records.csv**: 1 row added
+  - Rows added
+    - row 3: '3', 'Charlie'
+```
 
-- **data.tar.gz/records.csv**: 1 edit
-  - Sources
-    - data.tar.gz/records.csv (from, modify, binoc.pair.name)
-- **data/records.csv**: 1 edit
-  - Sources
-    - data/records.csv (from, modify, binoc.pair.name)
+## enforcement-actions-merge-years
+
+Per-year CSVs merged row-wise into one file; detected as a clean partition merge (CFM-72)
+
+- **Browse source:** [enforcement-actions-merge-years](https://github.com/harvard-lil/binoc/tree/main/test-vectors/enforcement-actions-merge-years)
+- **Tags:** `csv`, `partition`, `merge`
+- **Snapshots:** `snapshot-a` has 2 files — `actions_2023.csv`, `actions_2024.csv`; `snapshot-b` has 1 file — `actions.csv`
+
+Run it:
+```bash
+binoc diff \
+  ./test-vectors-materialized/enforcement-actions-merge-years/snapshot-a \
+  ./test-vectors-materialized/enforcement-actions-merge-years/snapshot-b
+```
+Result:
+```markdown
+# Changelog: snapshot-a → snapshot-b
+
+Claims
+
+- actions_2023.csv, actions_2024.csv merged into actions.csv
+
+- **actions.csv**: Merged from actions_2023.csv, actions_2024.csv
 ```
 
 ## file-correspondence-container
@@ -629,11 +704,7 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-Claims: none
-
 - **archive.zip**: Moved from data.zip
-  - Sources
-    - data.zip (from, move, binoc.pair.declared)
 ```
 
 ## file-correspondence-scheme
@@ -673,20 +744,13 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-Claims: none
-
-- **(root)**: 0 edits
-  - Sources
-    -  (from, modify, binoc.pair.root)
 - **by-state**: Added
-  - Sources
-    - by-state (to, add)
 - **by-state/AL**: Moved from data
-  - Sources
-    - data (from, move, binoc.pair.container_from_children)
-- **by-state/AL/records.csv**: Moved from data/state_AL.csv (modified)
-  - Sources
-    - data/state_AL.csv (from, move, binoc.pair.declared)
+- **by-state/AL/records.csv**:
+  - Moved from data/state_AL.csv
+  - 1 row added
+  - Rows added
+    - row 2: '2', 'Birmingham'
 ```
 
 ## file-correspondence-token
@@ -726,11 +790,11 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-Claims: none
-
-- **running_list_as_of_2023.csv**: Moved from running_list_as_of_2022.csv (modified)
-  - Sources
-    - running_list_as_of_2022.csv (from, move, binoc.pair.declared)
+- **running_list_as_of_2023.csv**:
+  - Moved from running_list_as_of_2022.csv
+  - 1 row added
+  - Rows added
+    - row 3: '3', 'Cy'
 ```
 
 ## folder-move-nested
@@ -751,11 +815,7 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-Claims: none
-
 - **documentation**: Moved from docs
-  - Sources
-    - docs (from, move, binoc.pair.container_from_children)
 ```
 
 ## folder-move-partial
@@ -776,50 +836,42 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-Claims: none
-
-- **(root)**: 0 edits
-  - Sources
-    -  (from, modify, binoc.pair.root)
 - **FoodData_Central_csv_2026-04-30**: Added
-  - Sources
-    - FoodData_Central_csv_2026-04-30 (to, add)
 - **FoodData_Central_csv_2026-04-30/README.txt**: Moved from FoodData_Central_csv_2025-12-18/README.txt
-  - Sources
-    - FoodData_Central_csv_2025-12-18/README.txt (from, move, binoc.pair.hash)
 - **FoodData_Central_csv_2026-04-30/data**: Moved from FoodData_Central_csv_2025-12-18/data
-  - Sources
-    - FoodData_Central_csv_2025-12-18/data (from, move, binoc.pair.container_from_children)
 - **FoodData_Central_csv_2026-04-30/data/new-table.csv**: Added
-  - Sources
-    - FoodData_Central_csv_2026-04-30/data/new-table.csv (to, add)
 - **FoodData_Central_csv_2026-04-30/docs**: Added
-  - Sources
-    - FoodData_Central_csv_2026-04-30/docs (to, add)
 - **FoodData_Central_csv_2026-04-30/docs/changelog-note.txt**: Moved from FoodData_Central_csv_2025-12-18/docs/changelog-note.txt
-  - Sources
-    - FoodData_Central_csv_2025-12-18/docs/changelog-note.txt (from, move, binoc.pair.hash)
 - **FoodData_Central_csv_2026-04-30/docs/license.txt**: Moved from FoodData_Central_csv_2025-12-18/docs/license.txt
-  - Sources
-    - FoodData_Central_csv_2025-12-18/docs/license.txt (from, move, binoc.pair.hash)
 - **FoodData_Central_csv_2026-04-30/docs/schema.txt**: Moved from FoodData_Central_csv_2025-12-18/docs/schema.txt
-  - Sources
-    - FoodData_Central_csv_2025-12-18/docs/schema.txt (from, move, binoc.pair.hash)
 - **FoodData_Central_csv_2026-04-30/docs/modified.txt**: Added
-  - Sources
-    - FoodData_Central_csv_2026-04-30/docs/modified.txt (to, add)
 - **FoodData_Central_csv_2025-12-18**: Removed
-  - Sources
-    - FoodData_Central_csv_2025-12-18 (from, remove)
 - **FoodData_Central_csv_2025-12-18/docs**: Removed
-  - Sources
-    - FoodData_Central_csv_2025-12-18/docs (from, remove)
 - **FoodData_Central_csv_2025-12-18/docs/modified.txt**: Removed
-  - Sources
-    - FoodData_Central_csv_2025-12-18/docs/modified.txt (from, remove)
 - **FoodData_Central_csv_2025-12-18/docs/old-table.txt**: Removed
-  - Sources
-    - FoodData_Central_csv_2025-12-18/docs/old-table.txt (from, remove)
+```
+
+## geojson-feature-cell-change
+
+A GeoJSON FeatureCollection where one feature's property changes; transcoded to a tabular artifact with the geometry as…
+
+- **Browse source:** [geojson-feature-cell-change](https://github.com/harvard-lil/binoc/tree/main/test-vectors/geojson-feature-cell-change)
+- **Tags:** `geojson`, `tabular`, `nested`, `cell-change`
+- **Snapshots:** `snapshot-a` has 1 file — `places.geojson`; `snapshot-b` has 1 file — `places.geojson`
+
+Run it:
+```bash
+binoc diff \
+  ./test-vectors-materialized/geojson-feature-cell-change/snapshot-a \
+  ./test-vectors-materialized/geojson-feature-cell-change/snapshot-b
+```
+Result:
+```markdown
+# Changelog: snapshot-a → snapshot-b
+
+- **places.geojson**: 1 cell changed
+  - Changed cells
+    - row 1, column 'properties': {"name":"Boston","population":650000} -> {"name":"Boston","population":675000}
 ```
 
 ## gzip-inner-dispatch
@@ -840,14 +892,172 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-Claims: none
+- **census.txt.gz/>census.txt**: 1 line added; 1 line removed
+  - Line changes
+    - line 2: '1|Aroostook|120' -> '1|Aroostook|121'
+- **data.csv.gz/>data.csv**: 1 row added; 1 cell changed
+  - Changed cells
+    - row 2, column 'name': 'Bob' -> 'Robert'
+  - Rows added
+    - row 3: '3', 'Carla'
+```
 
-- **census.txt.gz/census.txt**: 1 edit
-  - Sources
-    - census.txt.gz/census.txt (from, modify, binoc.pair.name)
-- **data.csv.gz/data.csv**: 2 edits
-  - Sources
-    - data.csv.gz/data.csv (from, modify, binoc.pair.name)
+## ini-value-change
+
+An INI value changes; transcoded to a structured_document and reported as a value change
+
+- **Browse source:** [ini-value-change](https://github.com/harvard-lil/binoc/tree/main/test-vectors/ini-value-change)
+- **Tags:** `ini`, `structured-document`, `value-change`
+- **Snapshots:** `snapshot-a` has 1 file — `config.ini`; `snapshot-b` has 1 file — `config.ini`
+
+Run it:
+```bash
+binoc diff \
+  ./test-vectors-materialized/ini-value-change/snapshot-a \
+  ./test-vectors-materialized/ini-value-change/snapshot-b
+```
+Result:
+```markdown
+# Changelog: snapshot-a → snapshot-b
+
+- **config.ini**: Document values changed
+  - Value Change: changes: [{"from":"\"3\"","kind":"replace","path":"$.replicas","to":"\"5\""}]; examples_truncated: false
+```
+
+## json-array-order-significant
+
+JSON array order changes are semantic content changes in stage 1
+
+- **Browse source:** [json-array-order-significant](https://github.com/harvard-lil/binoc/tree/main/test-vectors/json-array-order-significant)
+- **Tags:** `json`, `array-order`, `content-change`
+- **Snapshots:** `snapshot-a` has 1 file — `metadata.json`; `snapshot-b` has 1 file — `metadata.json`
+
+Run it:
+```bash
+binoc diff \
+  ./test-vectors-materialized/json-array-order-significant/snapshot-a \
+  ./test-vectors-materialized/json-array-order-significant/snapshot-b
+```
+Result:
+```markdown
+# Changelog: snapshot-a → snapshot-b
+
+- **metadata.json**: Document values changed
+  - Value Change: changes: [{"from":"2","kind":"replace","path":"$.ids[1]","to":"3"},{"from":"3","kind":"replace","path":"$.ids[2]","to":"2"}]; examples_truncated: false
+```
+
+## json-key-order-reexport
+
+JSON object key order and pretty-printing changed without semantic value changes
+
+- **Browse source:** [json-key-order-reexport](https://github.com/harvard-lil/binoc/tree/main/test-vectors/json-key-order-reexport)
+- **Tags:** `json`, `serialization`, `key-order`
+- **Snapshots:** `snapshot-a` has 1 file — `metadata.json`; `snapshot-b` has 1 file — `metadata.json`
+
+Run it:
+```bash
+binoc diff \
+  ./test-vectors-materialized/json-key-order-reexport/snapshot-a \
+  ./test-vectors-materialized/json-key-order-reexport/snapshot-b
+```
+Result:
+```markdown
+# Changelog: snapshot-a → snapshot-b
+
+- **metadata.json**: Document serialization changed
+  - Serialization Change: kinds: ["object_key_order","formatting"]; left: {"byte_len":70,"line_ending":"lf","object_key_orders":[{"keys":["id","name"],"path":"$.fields"},{"keys":["name","version","fields"],"path":"$"}],"trailing_newli...; right: {"byte_len":98,"indentation":"2 spaces","line_ending":"lf","object_key_orders":[{"keys":["name","id"],"path":"$.fields"},{"keys":["fields","version","name"],"pa...
+```
+
+## json-records-cell-change
+
+JSON array of like-shaped objects parsed as a typed table; numeric cell values change
+
+- **Browse source:** [json-records-cell-change](https://github.com/harvard-lil/binoc/tree/main/test-vectors/json-records-cell-change)
+- **Tags:** `json`, `records`, `tabular`, `cell-change`
+- **Snapshots:** `snapshot-a` has 1 file — `data.json`; `snapshot-b` has 1 file — `data.json`
+
+Run it:
+```bash
+binoc diff \
+  ./test-vectors-materialized/json-records-cell-change/snapshot-a \
+  ./test-vectors-materialized/json-records-cell-change/snapshot-b
+```
+Result:
+```markdown
+# Changelog: snapshot-a → snapshot-b
+
+- **data.json**: 2 cells changed
+  - Changed cells
+    - row 1, column 'score': 85 -> 92
+    - row 2, column 'score': 90 -> 88
+```
+
+## json-records-nested-value
+
+JSON records with a nested object cell; the nested value changes and is reported as a single equality-based cell edit (…
+
+- **Browse source:** [json-records-nested-value](https://github.com/harvard-lil/binoc/tree/main/test-vectors/json-records-nested-value)
+- **Tags:** `json`, `records`, `tabular`, `nested`, `cell-change`
+- **Snapshots:** `snapshot-a` has 1 file — `people.json`; `snapshot-b` has 1 file — `people.json`
+
+Run it:
+```bash
+binoc diff \
+  ./test-vectors-materialized/json-records-nested-value/snapshot-a \
+  ./test-vectors-materialized/json-records-nested-value/snapshot-b
+```
+Result:
+```markdown
+# Changelog: snapshot-a → snapshot-b
+
+- **people.json**: 1 cell changed
+  - Changed cells
+    - row 2, column 'meta': {"role":"user","tags":["z"]} -> {"role":"editor","tags":["z"]}
+```
+
+## jsonl-row-addition
+
+JSONL stream of like-shaped objects parsed as a table; a record is appended
+
+- **Browse source:** [jsonl-row-addition](https://github.com/harvard-lil/binoc/tree/main/test-vectors/jsonl-row-addition)
+- **Tags:** `jsonl`, `records`, `tabular`, `row-addition`
+- **Snapshots:** `snapshot-a` has 1 file — `events.jsonl`; `snapshot-b` has 1 file — `events.jsonl`
+
+Run it:
+```bash
+binoc diff \
+  ./test-vectors-materialized/jsonl-row-addition/snapshot-a \
+  ./test-vectors-materialized/jsonl-row-addition/snapshot-b
+```
+Result:
+```markdown
+# Changelog: snapshot-a → snapshot-b
+
+- **events.jsonl**: 1 row added
+  - Rows added
+    - row 3: 'carol', 'delete', 3
+```
+
+## jsonld-value-change
+
+A .jsonld file with no declared media type parses as a structured document tagged format=jsonld; a value change is repo…
+
+- **Browse source:** [jsonld-value-change](https://github.com/harvard-lil/binoc/tree/main/test-vectors/jsonld-value-change)
+- **Tags:** `json`, `jsonld`, `structured-document`
+- **Snapshots:** `snapshot-a` has 1 file — `person.jsonld`; `snapshot-b` has 1 file — `person.jsonld`
+
+Run it:
+```bash
+binoc diff \
+  ./test-vectors-materialized/jsonld-value-change/snapshot-a \
+  ./test-vectors-materialized/jsonld-value-change/snapshot-b
+```
+Result:
+```markdown
+# Changelog: snapshot-a → snapshot-b
+
+- **person.jsonld**: Document values changed
+  - Value Change: changes: [{"from":"\"Mathematician\"","kind":"replace","path":"$.jobTitle","to":"\"Computer Scientist\""}]; examples_truncated: false
 ```
 
 ## kitchen-sink
@@ -868,41 +1078,126 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-Claims: none
-
-- **archive.tar.gz/inventory.csv**: 1 edit
-  - Sources
-    - archive.tar.gz/inventory.csv (from, modify, binoc.pair.name)
-- **bundle.zip/notes.txt**: 1 edit
-  - Sources
-    - bundle.zip/notes.txt (from, modify, binoc.pair.name)
-- **data.csv**: 2 edits
-  - Sources
-    - data.csv (from, modify, binoc.pair.name)
-- **docs**: 0 edits
-  - Sources
-    - docs (from, modify, binoc.pair.name)
-- **docs/readme.txt**: 1 edit
-  - Sources
-    - docs/readme.txt (from, modify, binoc.pair.name)
+- **archive.tar.gz/>inventory.csv**: 1 row added
+  - Rows added
+    - row 3: 'sprockets', '20'
+- **bundle.zip/>notes.txt**: 2 lines added; 1 line removed
+  - Line changes
+    - line 1: 'Version 1 notes.' -> 'Version 2 notes.'
+- **data.csv**: 2 cells changed
+  - Changed cells
+    - row 1, column 'age': '30' -> '31'
+    - row 3, column 'city': 'Seattle' -> 'Portland'
+- **docs/readme.txt**: 2 lines added; 2 lines removed
+  - Line changes
+    - line 2: 'This is the original readme.' -> 'This is the updated readme.'
+    - line 4: 'Some will change.' -> 'New content added here.'
 - **docs/old-notes.txt**: Removed
-  - Sources
-    - docs/old-notes.txt (from, remove)
 - **docs/new-file.txt**: Added
-  - Sources
-    - docs/new-file.txt (to, add)
-- **icon.bin**: 1 edit
-  - Sources
-    - icon.bin (from, modify, binoc.pair.name)
+- **icon.bin**: Binary content changed; 1 extracted string added, 1 extracted string removed
+  - Extracted strings added
+    - '\nFAKEICONv2'
+  - Extracted strings removed
+    - '\nFAKEICONv1'
 - **license-copy.txt**: Copied from license.txt
-  - Sources
-    - license.txt (from, copy, binoc.pair.copy)
-- **metrics.csv**: 1 edit
-  - Sources
-    - metrics.csv (from, modify, binoc.pair.name)
+- **metrics.csv**: Columns reordered
+  - Reorder Columns: order: ["category","year","value"]
 - **summary.txt**: Moved from report.txt
-  - Sources
-    - report.txt (from, move, binoc.pair.hash)
+```
+
+## observations-repartition-equal-arity
+
+Equal-arity N→M repartition: 2 tables grouped by region become 2 tables grouped by year, every row preserved exactly bu…
+
+- **Browse source:** [observations-repartition-equal-arity](https://github.com/harvard-lil/binoc/tree/main/test-vectors/observations-repartition-equal-arity)
+- **Tags:** `csv`, `partition`, `possible-split`, `equal-arity`
+- **Snapshots:** `snapshot-a` has 2 files — `observations_north.csv`, `observations_south.csv`; `snapshot-b` has 2 files — `observations_2024.csv`, `observations_2025.csv`
+
+Run it:
+```bash
+binoc diff \
+  ./test-vectors-materialized/observations-repartition-equal-arity/snapshot-a \
+  ./test-vectors-materialized/observations-repartition-equal-arity/snapshot-b
+```
+Result:
+```markdown
+# Changelog: snapshot-a → snapshot-b
+
+- **observations_2024.csv**:
+  - Moved from observations_north.csv
+  - 3 cells changed
+  - Changed cells
+    - row 2, column 'year': '2025' -> '2024'
+    - row 2, column 'region': 'north' -> 'south'
+    - row 2, column 'count': '15' -> '12'
+- **observations_2025.csv**:
+  - Moved from observations_south.csv
+  - 3 cells changed
+  - Changed cells
+    - row 1, column 'year': '2024' -> '2025'
+    - row 1, column 'region': 'south' -> 'north'
+    - row 1, column 'count': '12' -> '15'
+
+## Suggestions
+
+- 'observations_north.csv' shares rows with other unmatched tables but the relationship is not a clean partition (residual, shared, or extra rows); left as add/remove (`binoc.pair.partition`) [binoc.possible_split]
+```
+
+## observations-split-by-year
+
+One CSV split row-wise into per-year files; detected as a clean partition split (CFM-72)
+
+- **Browse source:** [observations-split-by-year](https://github.com/harvard-lil/binoc/tree/main/test-vectors/observations-split-by-year)
+- **Tags:** `csv`, `partition`, `split`
+- **Snapshots:** `snapshot-a` has 1 file — `observations.csv`; `snapshot-b` has 2 files — `observations_2024.csv`, `observations_2025.csv`
+
+Run it:
+```bash
+binoc diff \
+  ./test-vectors-materialized/observations-split-by-year/snapshot-a \
+  ./test-vectors-materialized/observations-split-by-year/snapshot-b
+```
+Result:
+```markdown
+# Changelog: snapshot-a → snapshot-b
+
+Claims
+
+- observations.csv split into observations_2024.csv, observations_2025.csv
+
+- **observations_2024.csv**: Split from observations.csv
+- **observations_2025.csv**: Split from observations.csv
+```
+
+## observations-split-residual
+
+A would-be split missing one row: partition declines (not complete), emits binoc.possible_split, and degrades to honest…
+
+- **Browse source:** [observations-split-residual](https://github.com/harvard-lil/binoc/tree/main/test-vectors/observations-split-residual)
+- **Tags:** `csv`, `partition`, `possible-split`
+- **Snapshots:** `snapshot-a` has 1 file — `observations.csv`; `snapshot-b` has 2 files — `observations_2024.csv`, `observations_2025.csv`
+
+Run it:
+```bash
+binoc diff \
+  ./test-vectors-materialized/observations-split-residual/snapshot-a \
+  ./test-vectors-materialized/observations-split-residual/snapshot-b
+```
+Result:
+```markdown
+# Changelog: snapshot-a → snapshot-b
+
+- **observations_2024.csv**:
+  - Moved from observations.csv
+  - 2 rows removed
+  - Rows removed
+    - row 3: '2025', 'north', '15'
+    - row 4: '2025', 'south', '9'
+- **observations_2025.csv**: Added
+
+## Suggestions
+
+- 'observations.csv' shares rows with other unmatched tables but the relationship is not a clean partition (residual, shared, or extra rows); left as add/remove (`binoc.pair.partition`) [binoc.possible_split]
 ```
 
 ## single-file-add
@@ -923,14 +1218,7 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-Claims: none
-
-- **(root)**: 0 edits
-  - Sources
-    -  (from, modify, binoc.pair.root)
 - **new_file.txt**: Added
-  - Sources
-    - new_file.txt (to, add)
 ```
 
 ## single-file-modify-binary
@@ -951,11 +1239,7 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-Claims: none
-
 - **data.bin**: 1 edit
-  - Sources
-    - data.bin (from, modify, binoc.pair.name)
 ```
 
 ## single-file-modify-csv
@@ -976,11 +1260,9 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-Claims: none
-
-- **data.csv**: 1 edit
-  - Sources
-    - data.csv (from, modify, binoc.pair.fuzzy)
+- **data.csv**: 1 row added
+  - Rows added
+    - row 3: 'Charlie', '35'
 ```
 
 ## single-file-modify-text
@@ -1001,11 +1283,9 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-Claims: none
-
-- **story.txt**: 1 edit
-  - Sources
-    - story.txt (from, modify, binoc.pair.name)
+- **story.txt**: 2 lines added; 1 line removed
+  - Line changes
+    - line 2: 'Line 2' -> 'Line 2 revised'
 ```
 
 ## single-file-modify-text-root
@@ -1026,11 +1306,9 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-Claims: none
-
-- **story.txt**: 1 edit
-  - Sources
-    - story.txt (from, modify, binoc.pair.fuzzy)
+- **story.txt**: 2 lines added; 1 line removed
+  - Line changes
+    - line 2: 'Line 2' -> 'Line 2 revised'
 ```
 
 ## single-file-remove
@@ -1051,14 +1329,30 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-Claims: none
-
-- **(root)**: 0 edits
-  - Sources
-    -  (from, modify, binoc.pair.root)
 - **removed_file.txt**: Removed
-  - Sources
-    - removed_file.txt (from, remove)
+```
+
+## stacked-csv-broken-out
+
+Stacked-CSV tables broken out into one file per table; whole-table rehoming (reshape + 1:1), NOT a partition split (CFM…
+
+- **Browse source:** [stacked-csv-broken-out](https://github.com/harvard-lil/binoc/tree/main/test-vectors/stacked-csv-broken-out)
+- **Tags:** `csv`, `stacked-tables`, `reshape`
+- **Snapshots:** `snapshot-a` has 1 file — `report.csv`; `snapshot-b` has 2 files — `changes.csv`, `products.csv`
+
+Run it:
+```bash
+binoc diff \
+  ./test-vectors-materialized/stacked-csv-broken-out/snapshot-a \
+  ./test-vectors-materialized/stacked-csv-broken-out/snapshot-b
+```
+Result:
+```markdown
+# Changelog: snapshot-a → snapshot-b
+
+- **changes.csv**: Moved from report.csv/>table_1
+- **products.csv**: Reshaped from report.csv (stacked tables → tabular)
+- **report.csv/>table_2**: Removed
 ```
 
 ## tar-nested
@@ -1079,11 +1373,9 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-Claims: none
-
-- **outer.tar.gz/inner.tar.gz/data.csv**: 1 edit
-  - Sources
-    - outer.tar.gz/inner.tar.gz/data.csv (from, modify, binoc.pair.name)
+- **outer.tar.gz/>inner.tar.gz/>data.csv**: 1 row added
+  - Rows added
+    - row 2: 'Bob', '25'
 ```
 
 ## tar-simple
@@ -1104,14 +1396,10 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-Claims: none
-
-- **archive.tar.gz/data.csv**: 1 edit
-  - Sources
-    - archive.tar.gz/data.csv (from, modify, binoc.pair.name)
-- **archive.tar.gz/hello.txt**: 1 edit
-  - Sources
-    - archive.tar.gz/hello.txt (from, modify, binoc.pair.name)
+- **archive.tar.gz/>data.csv**: 1 row added
+  - Rows added
+    - row 3: 'gamma', '3'
+- **archive.tar.gz/>hello.txt**: 1 line added
 ```
 
 ## text-rename-modify
@@ -1132,11 +1420,35 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-Claims: none
+- **meeting-notes-v2.txt**:
+  - Moved from notes.txt
+  - 2 lines added
+  - Line changes (showing 3 of 4)
+    - line 10: '' -> '- Marketing strategy update'
+    - line 11: 'Action Items:' -> ''
+    - line 12: '- Alice to finalize budget by Friday' -> 'Action Items:'
+```
 
-- **meeting-notes-v2.txt**: Moved from notes.txt (modified)
-  - Sources
-    - notes.txt (from, move, binoc.pair.fuzzy)
+## toml-value-change
+
+A TOML value changes; transcoded to a structured_document and reported as a value change
+
+- **Browse source:** [toml-value-change](https://github.com/harvard-lil/binoc/tree/main/test-vectors/toml-value-change)
+- **Tags:** `toml`, `structured-document`, `value-change`
+- **Snapshots:** `snapshot-a` has 1 file — `config.toml`; `snapshot-b` has 1 file — `config.toml`
+
+Run it:
+```bash
+binoc diff \
+  ./test-vectors-materialized/toml-value-change/snapshot-a \
+  ./test-vectors-materialized/toml-value-change/snapshot-b
+```
+Result:
+```markdown
+# Changelog: snapshot-a → snapshot-b
+
+- **config.toml**: Document values changed
+  - Value Change: changes: [{"from":"3","kind":"replace","path":"$.replicas","to":"5"}]; examples_truncated: false
 ```
 
 ## tree-wide-correlation
@@ -1157,32 +1469,13 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-Claims: none
-
-- **gamma-renamed.txt**: Moved from outer.zip/inner.zip/gamma.txt
-  - Sources
-    - outer.zip/inner.zip/gamma.txt (from, move, binoc.pair.hash)
+- **gamma-renamed.txt**: Moved from outer.zip/>inner.zip/>gamma.txt
 - **kept-copy.txt**: Copied from kept.txt
-  - Sources
-    - kept.txt (from, copy, binoc.pair.copy)
 - **merged.bin**: Moved from dup.bin
-  - Sources
-    - dup.bin (from, move, binoc.pair.hash)
-- **outer.zip**: 0 edits
-  - Sources
-    - outer.zip (from, modify, binoc.pair.name)
-- **outer.zip/alpha-renamed.txt**: Moved from alpha.txt
-  - Sources
-    - alpha.txt (from, move, binoc.pair.hash)
-- **outer.zip/inner.zip/beta-renamed.txt**: Moved from outer.zip/beta.txt
-  - Sources
-    - outer.zip/beta.txt (from, move, binoc.pair.hash)
-- **outer.zip/kept-copy.txt**: Copied from kept.txt
-  - Sources
-    - kept.txt (from, copy, binoc.pair.copy)
-- **outer.zip/dup-b.bin**: Removed
-  - Sources
-    - outer.zip/dup-b.bin (from, remove)
+- **outer.zip/>alpha-renamed.txt**: Moved from alpha.txt
+- **outer.zip/>inner.zip/>beta-renamed.txt**: Moved from outer.zip/>beta.txt
+- **outer.zip/>kept-copy.txt**: Copied from kept.txt
+- **outer.zip/>dup-b.bin**: Removed
 ```
 
 ## trivial-identical
@@ -1202,8 +1495,6 @@ binoc diff \
 Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
-
-Claims: none
 ```
 
 ## trivial-identical-csv
@@ -1223,8 +1514,6 @@ binoc diff \
 Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
-
-Claims: none
 ```
 
 ## tsv-cell-changes
@@ -1245,11 +1534,32 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-Claims: none
+- **data.tsv**: 2 cells changed
+  - Changed cells
+    - row 1, column 'age': '30' -> '31'
+    - row 2, column 'city': 'Boston' -> 'Cambridge'
+```
 
-- **data.tsv**: 2 edits
-  - Sources
-    - data.tsv (from, modify, binoc.pair.name)
+## yaml-value-change
+
+A YAML scalar value changes; transcoded to a structured_document and reported as a value change
+
+- **Browse source:** [yaml-value-change](https://github.com/harvard-lil/binoc/tree/main/test-vectors/yaml-value-change)
+- **Tags:** `yaml`, `structured-document`, `value-change`
+- **Snapshots:** `snapshot-a` has 1 file — `config.yaml`; `snapshot-b` has 1 file — `config.yaml`
+
+Run it:
+```bash
+binoc diff \
+  ./test-vectors-materialized/yaml-value-change/snapshot-a \
+  ./test-vectors-materialized/yaml-value-change/snapshot-b
+```
+Result:
+```markdown
+# Changelog: snapshot-a → snapshot-b
+
+- **config.yaml**: Document values changed
+  - Value Change: changes: [{"from":"3","kind":"replace","path":"$.replicas","to":"5"}]; examples_truncated: false
 ```
 
 ## zip-declared-container
@@ -1268,13 +1578,13 @@ dataset:
     correspondences:
       - name: inner-archive-pair
         key: records
-        logical_path: outer.zip/records.zip
+        logical_path: outer.zip/>records.zip
         on_null_key: diagnostic
         on_duplicate_key: diagnostic
         left:
-          path_regex: ^outer\.zip/records-old\.zip$
+          path_regex: ^outer\.zip/>records-old\.zip$
         right:
-          path_regex: ^outer\.zip/records\.zip$
+          path_regex: ^outer\.zip/>records\.zip$
 ```
 
 
@@ -1289,12 +1599,31 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-Claims: none
+- **outer.zip/>records.zip**:
+  - Moved from outer.zip/>records-old.zip
+  - 1 cell changed
+```
 
-- **outer.zip/records.zip**: Moved from outer.zip/records-old.zip
-- **outer.zip/records.zip**: 1 edit
-  - Sources
-    - outer.zip/records-old.zip (from, move, binoc.pair.declared)
+## zip-json-key-order-reexport
+
+JSON files inside zip expansion get parsed and rendered as serialization-only changes
+
+- **Browse source:** [zip-json-key-order-reexport](https://github.com/harvard-lil/binoc/tree/main/test-vectors/zip-json-key-order-reexport)
+- **Tags:** `zip`, `json`, `serialization`, `key-order`
+- **Snapshots:** `snapshot-a` has 1 file — `archive.zip.d/metadata.json`; `snapshot-b` has 1 file — `archive.zip.d/metadata.json`
+
+Run it:
+```bash
+binoc diff \
+  ./test-vectors-materialized/zip-json-key-order-reexport/snapshot-a \
+  ./test-vectors-materialized/zip-json-key-order-reexport/snapshot-b
+```
+Result:
+```markdown
+# Changelog: snapshot-a → snapshot-b
+
+- **archive.zip/>metadata.json**: Document serialization changed
+  - Serialization Change: kinds: ["object_key_order","formatting"]; left: {"byte_len":82,"line_ending":"lf","object_key_orders":[{"keys":["id","name"],"path":"$.schema"},{"keys":["dataset","issued","schema"],"path":"$"}],"trailing_new...; right: {"byte_len":110,"indentation":"2 spaces","line_ending":"lf","object_key_orders":[{"keys":["name","id"],"path":"$.schema"},{"keys":["schema","issued","dataset"],...
 ```
 
 ## zip-nested
@@ -1315,11 +1644,9 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-Claims: none
-
-- **outer.zip/inner.zip/data.csv**: 1 edit
-  - Sources
-    - outer.zip/inner.zip/data.csv (from, modify, binoc.pair.name)
+- **outer.zip/>inner.zip/>data.csv**: 1 row added
+  - Rows added
+    - row 2: 'Bob', '25'
 ```
 
 ## zip-rename-contents-rewritten
@@ -1340,35 +1667,14 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-Claims: none
-
-- **(root)**: 0 edits
-  - Sources
-    -  (from, modify, binoc.pair.root)
 - **data.zip**: Removed
-  - Sources
-    - data.zip (from, remove)
-- **data.zip/x.csv**: Removed
-  - Sources
-    - data.zip/x.csv (from, remove)
-- **data.zip/y.csv**: Removed
-  - Sources
-    - data.zip/y.csv (from, remove)
-- **data.zip/z.csv**: Removed
-  - Sources
-    - data.zip/z.csv (from, remove)
+- **data.zip/>x.csv**: Removed
+- **data.zip/>y.csv**: Removed
+- **data.zip/>z.csv**: Removed
 - **archive.zip**: Added
-  - Sources
-    - archive.zip (to, add)
-- **archive.zip/p.csv**: Added
-  - Sources
-    - archive.zip/p.csv (to, add)
-- **archive.zip/q.csv**: Added
-  - Sources
-    - archive.zip/q.csv (to, add)
-- **archive.zip/r.csv**: Added
-  - Sources
-    - archive.zip/r.csv (to, add)
+- **archive.zip/>p.csv**: Added
+- **archive.zip/>q.csv**: Added
+- **archive.zip/>r.csv**: Added
 ```
 
 ## zip-rename-identical
@@ -1389,11 +1695,7 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-Claims: none
-
 - **archive.zip**: Moved from data.zip
-  - Sources
-    - data.zip (from, move, binoc.pair.hash)
 ```
 
 ## zip-rename-inner-rename-edit
@@ -1414,14 +1716,12 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-Claims: none
-
 - **archive.zip**: Moved from data.zip
-  - Sources
-    - data.zip (from, move, binoc.pair.container_from_children)
-- **archive.zip/new.csv**: Moved from data.zip/old.csv (modified)
-  - Sources
-    - data.zip/old.csv (from, move, binoc.pair.fuzzy)
+- **archive.zip/>new.csv**:
+  - Moved from data.zip/>old.csv
+  - 1 cell changed
+  - Changed cells
+    - row 5, column 'score': '60' -> '61'
 ```
 
 ## zip-simple
@@ -1442,15 +1742,8 @@ Result:
 ```markdown
 # Changelog: snapshot-a → snapshot-b
 
-Claims: none
-
-- **archive.zip**: 0 edits
-  - Sources
-    - archive.zip (from, modify, binoc.pair.name)
-- **archive.zip/data.txt**: 1 edit
-  - Sources
-    - archive.zip/data.txt (from, modify, binoc.pair.name)
-- **archive.zip/extra.txt**: Added
-  - Sources
-    - archive.zip/extra.txt (to, add)
+- **archive.zip/>data.txt**: 1 line added; 1 line removed
+  - Line changes
+    - line 1: 'hello from zip A' -> 'hello from zip B'
+- **archive.zip/>extra.txt**: Added
 ```

--- a/docs/users/reference/changeset-schema.json
+++ b/docs/users/reference/changeset-schema.json
@@ -223,7 +223,7 @@
           ]
         },
         "message": {
-          "type": "string"
+          "$ref": "#/$defs/Summary"
         },
         "severity": {
           "$ref": "#/$defs/DiagnosticSeverity"
@@ -478,6 +478,13 @@
             "string",
             "null"
           ]
+        },
+        "retract_tags": {
+          "description": "Tags this hint *removes* from the accumulated projection. Tag overlay is\nunion-only, so an annotator that supersedes an earlier framing (e.g. a\nCFM-71 container reshape replacing a pair-time `binoc.move`) needs a way to\ndrop the now-stale tag — otherwise the IR carries contradictory tags\n(inert in rendering, but incoherent in JSON). A retraction is honored\nwhenever tags are merged: the named tags are removed from the result and\ncan never be re-introduced by the *same* hint.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "summary": {
           "anyOf": [

--- a/docs/users/reference/changeset-schema.md
+++ b/docs/users/reference/changeset-schema.md
@@ -181,7 +181,7 @@ One bounded example inside a detail block.
 |---|---|---|---|
 | `code` | string | yes |  |
 | `location` | string \| null | no |  |
-| `message` | string | yes |  |
+| `message` | [`Summary`](#summary) | yes |  |
 | `severity` | [`DiagnosticSeverity`](#diagnosticseverity) | yes |  |
 
 ### `DiagnosticSeverity`
@@ -219,6 +219,7 @@ Product-facing projection metadata supplied by rules, not inferred by core.
 |---|---|---|---|
 | `action` | string \| null | no |  |
 | `item_type` | string \| null | no |  |
+| `retract_tags` | array of string | no | Tags this hint *removes* from the accumulated projection. Tag overlay is union-only, so an annotator that supersedes an earlier framing (e.g. a CFM-71 container reshape replacing a pair-time `binoc.move`) needs a way to drop the now-stale tag — otherwise the IR carries contradictory tags (inert in rendering, but incoherent in JSON). A retraction is honored whenever tags are merged: the named tags are removed from the result and can never be re-introduced by the *same* hint. |
 | `summary` | [`Summary`](#summary) \| null | no |  |
 | `tags` | array of string | no |  |
 

--- a/docs/users/reference/cli.md
+++ b/docs/users/reference/cli.md
@@ -29,6 +29,7 @@ and `binoc <subcommand> --help` print the same information at the terminal.
 
 * [`binoc`↴](#binoc)
 * [`binoc diff`↴](#binoc-diff)
+* [`binoc replay`↴](#binoc-replay)
 * [`binoc changelog`↴](#binoc-changelog)
 * [`binoc extract`↴](#binoc-extract)
 
@@ -41,6 +42,7 @@ Binoc produces the missing changelog for datasets. It detects, classifies, and r
 ###### **Subcommands:**
 
 * `diff` — Diff an ordered sequence of snapshots and produce a changelog
+* `replay` — Render a saved run trace as a self-contained HTML replay
 * `changelog` — Generate a human-readable changelog from one or more saved changesets
 * `extract` — Extract actual changed data from a changeset node
 
@@ -66,6 +68,25 @@ Runs pairwise comparisons over each consecutive snapshot pair and emits the resu
 
   Default value: `markdown`
 * `-q`, `--quiet` — Suppress stdout. Useful when every rendered output is directed to a file via -o
+* `--trace <TRACE>` — Write a detailed replay trace (JSON) of the correspondence run to this path: every expand/parse/link/write/compaction step plus the final side trees and links. Requires exactly two snapshots. Convert it to an interactive HTML replay with `binoc replay`
+
+
+
+## `binoc replay`
+
+Render a saved run trace as a self-contained HTML replay.
+
+Reads a trace JSON produced by `binoc diff --trace` and writes a single standalone HTML file that animates the comparison: the two snapshot trees growing from the bottom up, links forming between them, and the per-link edit lists building and compacting, with play/step/scrub controls and a detail inspector.
+
+**Usage:** `binoc replay [OPTIONS] <TRACE>`
+
+###### **Arguments:**
+
+* `<TRACE>` — Path to a trace JSON file produced by `binoc diff --trace`
+
+###### **Options:**
+
+* `-o`, `--output <OUTPUT>` — Output HTML path. Defaults to the trace path with a `.html` extension
 
 
 

--- a/model-plugins/binoc-binformats/test-vectors/bson-value-change/expected-output/changelog.snap
+++ b/model-plugins/binoc-binformats/test-vectors/bson-value-change/expected-output/changelog.snap
@@ -5,3 +5,4 @@ expression: "&md"
 # Changelog: snapshot-a → snapshot-b
 
 - **data.bson**: Document values changed
+  - Value Change: changes: [{"from":"2","kind":"replace","path":"$.settings.retries","to":"4"}]; examples_truncated: false

--- a/model-plugins/binoc-binformats/test-vectors/cbor-value-change/expected-output/changelog.snap
+++ b/model-plugins/binoc-binformats/test-vectors/cbor-value-change/expected-output/changelog.snap
@@ -5,3 +5,4 @@ expression: "&md"
 # Changelog: snapshot-a → snapshot-b
 
 - **data.cbor**: Document values changed
+  - Value Change: changes: [{"from":"3","kind":"replace","path":"$.replicas","to":"5"}]; examples_truncated: false

--- a/model-plugins/binoc-binformats/test-vectors/ion-value-change/expected-output/changelog.snap
+++ b/model-plugins/binoc-binformats/test-vectors/ion-value-change/expected-output/changelog.snap
@@ -5,3 +5,4 @@ expression: "&md"
 # Changelog: snapshot-a → snapshot-b
 
 - **data.ion**: Document values changed
+  - Value Change: changes: [{"from":"2","kind":"replace","path":"$.settings.retries","to":"7"}]; examples_truncated: false

--- a/model-plugins/binoc-binformats/test-vectors/msgpack-value-change/expected-output/changelog.snap
+++ b/model-plugins/binoc-binformats/test-vectors/msgpack-value-change/expected-output/changelog.snap
@@ -5,3 +5,4 @@ expression: "&md"
 # Changelog: snapshot-a → snapshot-b
 
 - **data.msgpack**: Document values changed
+  - Value Change: changes: [{"from":"30","kind":"replace","path":"$.settings.timeout","to":"45"}]; examples_truncated: false

--- a/model-plugins/binoc-binformats/test-vectors/plist-value-change/expected-output/changelog.snap
+++ b/model-plugins/binoc-binformats/test-vectors/plist-value-change/expected-output/changelog.snap
@@ -5,3 +5,4 @@ expression: "&md"
 # Changelog: snapshot-a → snapshot-b
 
 - **data.plist**: Document values changed
+  - Value Change: changes: [{"from":"3","kind":"replace","path":"$.replicas","to":"6"}]; examples_truncated: false

--- a/model-plugins/binoc-parquet/test-vectors/parquet-column-addition/expected-output/changelog.snap
+++ b/model-plugins/binoc-parquet/test-vectors/parquet-column-addition/expected-output/changelog.snap
@@ -5,3 +5,5 @@ expression: "&md"
 # Changelog: snapshot-a → snapshot-b
 
 - **data.parquet**: Column added: 'in_stock'
+  - Set Headers: from: ["id","name","price"]; to: ["id","name","price","in_stock"]
+  - Add Column: name: 'in_stock'; values: {"total_values":3,"truncated":false,"values":[true,false,true]}

--- a/model-plugins/binoc-row-reorder/test-vectors/csv-row-reorder/expected-output/changelog.snap
+++ b/model-plugins/binoc-row-reorder/test-vectors/csv-row-reorder/expected-output/changelog.snap
@@ -5,3 +5,4 @@ expression: "&md"
 # Changelog: snapshot-a → snapshot-b
 
 - **data.csv**: Rows reordered (same data, different sort order)
+  - Reorder Rows: row_count: 3

--- a/model-plugins/binoc-shapefile/test-vectors/shapefile-feature-addition/expected-output/changelog.snap
+++ b/model-plugins/binoc-shapefile/test-vectors/shapefile-feature-addition/expected-output/changelog.snap
@@ -5,3 +5,4 @@ expression: "&md"
 # Changelog: snapshot-a → snapshot-b
 
 - **data.shp**: Document values changed
+  - Value Change: changes: [{"from":"3.0","kind":"replace","path":"$.bbox.max_x","to":"6.0"},{"from":"3.0","kind":"replace","path":"$.bbox.max_y","to":"6.0"},{"from":"2","kind":"replace",...; examples_truncated: false

--- a/model-plugins/binoc-shapefile/test-vectors/shapefile-fusion-equal-arity-tiebreak/expected-output/changelog.snap
+++ b/model-plugins/binoc-shapefile/test-vectors/shapefile-fusion-equal-arity-tiebreak/expected-output/changelog.snap
@@ -8,7 +8,9 @@ expression: "&md"
   - Changed cells
     - row 2, column 'navigable': false -> true
 - **rivers.shp/>geometry**: Document values changed
+  - Value Change: changes: [{"from":"11.0","kind":"replace","path":"$.bbox.max_x","to":"12.0"},{"from":"11.0","kind":"replace","path":"$.bbox.max_y","to":"12.0"},{"from":"2","kind":"repla...; examples_truncated: false
 - **roads.shp/>attributes**: 1 row added
   - Rows added
     - row 3: 'Pine Rd', 1.0
 - **roads.shp/>geometry**: Document values changed
+  - Value Change: changes: [{"from":"1.0","kind":"replace","path":"$.bbox.max_x","to":"2.0"},{"from":"1.0","kind":"replace","path":"$.bbox.max_y","to":"2.0"},{"from":"2","kind":"replace",...; examples_truncated: false

--- a/model-plugins/binoc-shapefile/test-vectors/shapefile-fusion-roads/expected-output/changelog.snap
+++ b/model-plugins/binoc-shapefile/test-vectors/shapefile-fusion-roads/expected-output/changelog.snap
@@ -10,3 +10,4 @@ expression: "&md"
   - Rows added
     - row 3: 'Pine Rd', 1.0
 - **roads.shp/>geometry**: Document values changed
+  - Value Change: changes: [{"from":"1.0","kind":"replace","path":"$.bbox.max_x","to":"4.0"},{"from":"1.0","kind":"replace","path":"$.bbox.max_y","to":"5.0"},{"from":"2","kind":"replace",...; examples_truncated: false

--- a/model-plugins/binoc-shapefile/test-vectors/shapefile-point-shift/expected-output/changelog.snap
+++ b/model-plugins/binoc-shapefile/test-vectors/shapefile-point-shift/expected-output/changelog.snap
@@ -5,3 +5,4 @@ expression: "&md"
 # Changelog: snapshot-a → snapshot-b
 
 - **data.shp**: Document values changed
+  - Value Change: changes: [{"from":"5.0","kind":"replace","path":"$.bbox.max_x","to":"9.0"},{"from":"5.0","kind":"replace","path":"$.bbox.max_y","to":"9.0"}]; examples_truncated: false

--- a/model-plugins/binoc-shapefile/test-vectors/shapefile-stem-collision/expected-output/changelog.snap
+++ b/model-plugins/binoc-shapefile/test-vectors/shapefile-stem-collision/expected-output/changelog.snap
@@ -8,7 +8,9 @@ expression: "&md"
   - Changed cells
     - row 2, column 'lanes': 2.0 -> 4.0
 - **roads.shp/>geometry**: Document values changed
+  - Value Change: changes: [{"from":"1.0","kind":"replace","path":"$.bbox.max_x","to":"2.0"},{"from":"1.0","kind":"replace","path":"$.bbox.max_y","to":"2.0"},{"from":"2","kind":"replace",...; examples_truncated: false
 - **roads.v2.shp/>attributes**: 1 cell changed
   - Changed cells
     - row 2, column 'surface': 'gravel' -> 'paved'
 - **roads.v2.shp/>geometry**: Document values changed
+  - Value Change: changes: [{"from":"6.0","kind":"replace","path":"$.bbox.max_x","to":"7.0"},{"from":"6.0","kind":"replace","path":"$.bbox.max_y","to":"7.0"},{"from":"2","kind":"replace",...; examples_truncated: false

--- a/model-plugins/binoc-sqlite/test-vectors/csv-dir-to-sqlite-reshape/expected-output/changelog.snap
+++ b/model-plugins/binoc-sqlite/test-vectors/csv-dir-to-sqlite-reshape/expected-output/changelog.snap
@@ -5,13 +5,17 @@ expression: "&md"
 # Changelog: snapshot-a → snapshot-b
 
 - **data.sqlite**: Reshaped from data (directory → SQLite database)
-- **data.sqlite/>customers**: 1 row added; 2 cells changed
+- **data.sqlite/>customers**:
+  - Moved from data/customers.csv
+  - 1 row added; 2 cells changed
   - Changed cells
     - row 1, column 'id': '1' -> 1
     - row 2, column 'id': '2' -> 2
   - Rows added
     - row 3: 3, 'Carol', 'NY'
-- **data.sqlite/>orders**: 6 cells changed
+- **data.sqlite/>orders**:
+  - Moved from data/orders.csv
+  - 6 cells changed
   - Changed cells (showing 3 of 6)
     - row 1, column 'id': '100' -> 100
     - row 1, column 'customer_id': '1' -> 1

--- a/model-plugins/binoc-stat-binary/test-vectors/sas7bdat-column-addition/expected-output/changelog.snap
+++ b/model-plugins/binoc-stat-binary/test-vectors/sas7bdat-column-addition/expected-output/changelog.snap
@@ -5,3 +5,5 @@ expression: "&md"
 # Changelog: snapshot-a → snapshot-b
 
 - **data.sas7bdat**: Column added: 'score'
+  - Set Headers: from: ["id","name"]; to: ["id","name","score"]
+  - Add Column: name: 'score'; values: {"total_values":2,"truncated":false,"values":["10","20"]}

--- a/model-plugins/binoc-stat-binary/test-vectors/stata-column-addition/expected-output/changelog.snap
+++ b/model-plugins/binoc-stat-binary/test-vectors/stata-column-addition/expected-output/changelog.snap
@@ -5,3 +5,5 @@ expression: "&md"
 # Changelog: snapshot-a → snapshot-b
 
 - **data.dta**: Column added: 'score'
+  - Set Headers: from: ["id","name"]; to: ["id","name","score"]
+  - Add Column: name: 'score'; values: {"total_values":2,"truncated":false,"values":["9","10"]}

--- a/model-plugins/binoc-stat-binary/test-vectors/xpt-column-addition/expected-output/changelog.snap
+++ b/model-plugins/binoc-stat-binary/test-vectors/xpt-column-addition/expected-output/changelog.snap
@@ -5,3 +5,5 @@ expression: "&md"
 # Changelog: snapshot-a → snapshot-b
 
 - **data.xpt/>BINOCTST**: Column added: 'score'
+  - Set Headers: from: ["id","name"]; to: ["id","name","score"]
+  - Add Column: name: 'score'; values: {"total_values":2,"truncated":false,"values":["9","7"]}

--- a/model-plugins/binoc-xml/test-vectors/xml-iso19139-metadata-change/expected-output/changelog.snap
+++ b/model-plugins/binoc-xml/test-vectors/xml-iso19139-metadata-change/expected-output/changelog.snap
@@ -5,3 +5,4 @@ expression: "&md"
 # Changelog: snapshot-a → snapshot-b
 
 - **metadata.xml**: Document values changed
+  - Value Change: changes: [{"from":"\"2024-03-01\"","kind":"replace","path":"$[\"gmd:MD_Metadata\"][\"gmd:identificationInfo\"][\"gmd:MD_DataIdentification\"][\"gmd:citation\"][\"gmd:CI_...; examples_truncated: false

--- a/model-plugins/binoc-xml/test-vectors/xml-socrata-rows-row-addition/expected-output/changelog.snap
+++ b/model-plugins/binoc-xml/test-vectors/xml-socrata-rows-row-addition/expected-output/changelog.snap
@@ -5,3 +5,4 @@ expression: "&md"
 # Changelog: snapshot-a → snapshot-b
 
 - **rows.xml**: Document values changed
+  - Value Change: changes: [{"from":"2","kind":"array_length","path":"$.response.row.row","to":"3"},{"from":null,"kind":"add","path":"$.response.row.row[2]","to":"{\"@_id\":\"row-3\",\"@_...; examples_truncated: false

--- a/test-vectors/csv-column-addition/expected-output/changelog.snap
+++ b/test-vectors/csv-column-addition/expected-output/changelog.snap
@@ -5,3 +5,5 @@ expression: "&md"
 # Changelog: snapshot-a → snapshot-b
 
 - **data.csv**: Column added: 'email'
+  - Set Headers: from: ["name","age"]; to: ["name","age","email"]
+  - Add Column: name: 'email'; values: {"total_values":2,"truncated":false,"values":["alice@test.com","bob@test.com"]}

--- a/test-vectors/csv-column-removal/expected-output/changelog.snap
+++ b/test-vectors/csv-column-removal/expected-output/changelog.snap
@@ -5,3 +5,5 @@ expression: "&md"
 # Changelog: snapshot-a → snapshot-b
 
 - **data.csv**: Column removed: 'city'
+  - Set Headers: from: ["name","age","city"]; to: ["name","age"]
+  - Remove Column: name: 'city'; values: {"total_values":2,"truncated":false,"values":["NYC","LA"]}

--- a/test-vectors/csv-column-reorder/expected-output/changelog.snap
+++ b/test-vectors/csv-column-reorder/expected-output/changelog.snap
@@ -5,3 +5,4 @@ expression: "&md"
 # Changelog: snapshot-a → snapshot-b
 
 - **data.csv**: Columns reordered
+  - Reorder Columns: order: ["city","name","age"]

--- a/test-vectors/csv-mid-row-insertion/expected-output/changelog.snap
+++ b/test-vectors/csv-mid-row-insertion/expected-output/changelog.snap
@@ -7,3 +7,5 @@ expression: "&md"
 - **data.csv**: Column added: 'email'; Columns reordered; 1 row added
   - Rows added
     - row 2: 'LA', 'Bob', '25'
+  - Reorder Columns: order: ["city","name","age"]
+  - Add Column: name: 'email'; values: {"total_values":3,"truncated":false,"values":["alice@example.test","bob@example.test","charlie@example.test"]}

--- a/test-vectors/csv-mixed-changes/expected-output/changelog.snap
+++ b/test-vectors/csv-mixed-changes/expected-output/changelog.snap
@@ -7,3 +7,5 @@ expression: "&md"
 - **data.csv**: Column added: 'email'; Columns reordered; 1 row added
   - Rows added
     - row 3: 'SF', 'Charlie', '35'
+  - Reorder Columns: order: ["city","name","age"]
+  - Add Column: name: 'email'; values: {"total_values":3,"truncated":false,"values":["a@test.com","b@test.com","c@test.com"]}

--- a/test-vectors/csv-rename-modify/expected-output/changelog.snap
+++ b/test-vectors/csv-rename-modify/expected-output/changelog.snap
@@ -7,3 +7,5 @@ expression: "&md"
 - **data_v2.csv**:
   - Moved from data.csv
   - Column added: 'email'
+  - Set Headers: from: ["name","age","city"]; to: ["name","age","city","email"]
+  - Add Column: name: 'email'; values: {"total_values":3,"truncated":false,"values":["alice@test.com","bob@test.com","carol@test.com"]}

--- a/test-vectors/csv-rename-modify/expected-output/changelog.snap
+++ b/test-vectors/csv-rename-modify/expected-output/changelog.snap
@@ -4,4 +4,6 @@ expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
 
-- **data_v2.csv**: Column added: 'email'
+- **data_v2.csv**:
+  - Moved from data.csv
+  - Column added: 'email'

--- a/test-vectors/csv-row-addition/expected-output/changelog.snap
+++ b/test-vectors/csv-row-addition/expected-output/changelog.snap
@@ -4,4 +4,7 @@ expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
 
-- **data.csv**: 1 edit
+- **data.csv**: 2 rows added
+  - Rows added
+    - row 2: 'Bob', '25'
+    - row 3: 'Charlie', '35'

--- a/test-vectors/csv-row-addition/expected-output/changeset.snap
+++ b/test-vectors/csv-row-addition/expected-output/changeset.snap
@@ -25,10 +25,7 @@ expression: "&stable_changeset"
         ],
         "summary": [
           {
-            "uint": 1
-          },
-          {
-            "text": " edit"
+            "text": "2 rows added"
           }
         ],
         "tags": [

--- a/test-vectors/csv-to-tsv-reformat/expected-output/changelog.snap
+++ b/test-vectors/csv-to-tsv-reformat/expected-output/changelog.snap
@@ -4,7 +4,9 @@ expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
 
-- **data.tsv**: 1 row added; 1 cell changed
+- **data.tsv**:
+  - Moved from data.csv
+  - 1 row added; 1 cell changed
   - Changed cells
     - row 2, column 'age': '25' -> '26'
   - Rows added

--- a/test-vectors/file-correspondence-scheme/expected-output/changelog.snap
+++ b/test-vectors/file-correspondence-scheme/expected-output/changelog.snap
@@ -6,6 +6,8 @@ expression: "&md"
 
 - **by-state**: Added
 - **by-state/AL**: Moved from data
-- **by-state/AL/records.csv**: 1 row added
+- **by-state/AL/records.csv**:
+  - Moved from data/state_AL.csv
+  - 1 row added
   - Rows added
     - row 2: '2', 'Birmingham'

--- a/test-vectors/file-correspondence-token/expected-output/changelog.snap
+++ b/test-vectors/file-correspondence-token/expected-output/changelog.snap
@@ -4,6 +4,8 @@ expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
 
-- **running_list_as_of_2023.csv**: 1 row added
+- **running_list_as_of_2023.csv**:
+  - Moved from running_list_as_of_2022.csv
+  - 1 row added
   - Rows added
     - row 3: '3', 'Cy'

--- a/test-vectors/ini-value-change/expected-output/changelog.snap
+++ b/test-vectors/ini-value-change/expected-output/changelog.snap
@@ -5,3 +5,4 @@ expression: "&md"
 # Changelog: snapshot-a → snapshot-b
 
 - **config.ini**: Document values changed
+  - Value Change: changes: [{"from":"\"3\"","kind":"replace","path":"$.replicas","to":"\"5\""}]; examples_truncated: false

--- a/test-vectors/json-array-order-significant/expected-output/changelog.snap
+++ b/test-vectors/json-array-order-significant/expected-output/changelog.snap
@@ -5,3 +5,4 @@ expression: "&md"
 # Changelog: snapshot-a → snapshot-b
 
 - **metadata.json**: Document values changed
+  - Value Change: changes: [{"from":"2","kind":"replace","path":"$.ids[1]","to":"3"},{"from":"3","kind":"replace","path":"$.ids[2]","to":"2"}]; examples_truncated: false

--- a/test-vectors/json-key-order-reexport/expected-output/changelog.snap
+++ b/test-vectors/json-key-order-reexport/expected-output/changelog.snap
@@ -5,3 +5,4 @@ expression: "&md"
 # Changelog: snapshot-a → snapshot-b
 
 - **metadata.json**: Document serialization changed
+  - Serialization Change: kinds: ["object_key_order","formatting"]; left: {"byte_len":70,"line_ending":"lf","object_key_orders":[{"keys":["id","name"],"path":"$.fields"},{"keys":["name","version","fields"],"path":"$"}],"trailing_newli...; right: {"byte_len":98,"indentation":"2 spaces","line_ending":"lf","object_key_orders":[{"keys":["name","id"],"path":"$.fields"},{"keys":["fields","version","name"],"pa...

--- a/test-vectors/jsonld-value-change/expected-output/changelog.snap
+++ b/test-vectors/jsonld-value-change/expected-output/changelog.snap
@@ -5,3 +5,4 @@ expression: "&md"
 # Changelog: snapshot-a → snapshot-b
 
 - **person.jsonld**: Document values changed
+  - Value Change: changes: [{"from":"\"Mathematician\"","kind":"replace","path":"$.jobTitle","to":"\"Computer Scientist\""}]; examples_truncated: false

--- a/test-vectors/kitchen-sink/expected-output/changelog.snap
+++ b/test-vectors/kitchen-sink/expected-output/changelog.snap
@@ -27,4 +27,5 @@ expression: "&md"
     - '\nFAKEICONv1'
 - **license-copy.txt**: Copied from license.txt
 - **metrics.csv**: Columns reordered
+  - Reorder Columns: order: ["category","year","value"]
 - **summary.txt**: Moved from report.txt

--- a/test-vectors/observations-repartition-equal-arity/expected-output/changelog.snap
+++ b/test-vectors/observations-repartition-equal-arity/expected-output/changelog.snap
@@ -4,12 +4,16 @@ expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
 
-- **observations_2024.csv**: 3 cells changed
+- **observations_2024.csv**:
+  - Moved from observations_north.csv
+  - 3 cells changed
   - Changed cells
     - row 2, column 'year': '2025' -> '2024'
     - row 2, column 'region': 'north' -> 'south'
     - row 2, column 'count': '15' -> '12'
-- **observations_2025.csv**: 3 cells changed
+- **observations_2025.csv**:
+  - Moved from observations_south.csv
+  - 3 cells changed
   - Changed cells
     - row 1, column 'year': '2024' -> '2025'
     - row 1, column 'region': 'south' -> 'north'

--- a/test-vectors/observations-split-residual/expected-output/changelog.snap
+++ b/test-vectors/observations-split-residual/expected-output/changelog.snap
@@ -4,7 +4,9 @@ expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
 
-- **observations_2024.csv**: 2 rows removed
+- **observations_2024.csv**:
+  - Moved from observations.csv
+  - 2 rows removed
   - Rows removed
     - row 3: '2025', 'north', '15'
     - row 4: '2025', 'south', '9'

--- a/test-vectors/text-rename-modify/expected-output/changelog.snap
+++ b/test-vectors/text-rename-modify/expected-output/changelog.snap
@@ -4,7 +4,9 @@ expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
 
-- **meeting-notes-v2.txt**: 2 lines added
+- **meeting-notes-v2.txt**:
+  - Moved from notes.txt
+  - 2 lines added
   - Line changes (showing 3 of 4)
     - line 10: '' -> '- Marketing strategy update'
     - line 11: 'Action Items:' -> ''

--- a/test-vectors/toml-value-change/expected-output/changelog.snap
+++ b/test-vectors/toml-value-change/expected-output/changelog.snap
@@ -5,3 +5,4 @@ expression: "&md"
 # Changelog: snapshot-a → snapshot-b
 
 - **config.toml**: Document values changed
+  - Value Change: changes: [{"from":"3","kind":"replace","path":"$.replicas","to":"5"}]; examples_truncated: false

--- a/test-vectors/yaml-value-change/expected-output/changelog.snap
+++ b/test-vectors/yaml-value-change/expected-output/changelog.snap
@@ -5,3 +5,4 @@ expression: "&md"
 # Changelog: snapshot-a → snapshot-b
 
 - **config.yaml**: Document values changed
+  - Value Change: changes: [{"from":"3","kind":"replace","path":"$.replicas","to":"5"}]; examples_truncated: false

--- a/test-vectors/zip-declared-container/expected-output/changelog.snap
+++ b/test-vectors/zip-declared-container/expected-output/changelog.snap
@@ -4,5 +4,6 @@ expression: "&md"
 ---
 # Changelog: snapshot-a → snapshot-b
 
-- **outer.zip/>records.zip**: Moved from outer.zip/>records-old.zip
-- **outer.zip/>records.zip**: 1 cell changed
+- **outer.zip/>records.zip**:
+  - Moved from outer.zip/>records-old.zip
+  - 1 cell changed

--- a/test-vectors/zip-json-key-order-reexport/expected-output/changelog.snap
+++ b/test-vectors/zip-json-key-order-reexport/expected-output/changelog.snap
@@ -5,3 +5,4 @@ expression: "&md"
 # Changelog: snapshot-a → snapshot-b
 
 - **archive.zip/>metadata.json**: Document serialization changed
+  - Serialization Change: kinds: ["object_key_order","formatting"]; left: {"byte_len":82,"line_ending":"lf","object_key_orders":[{"keys":["id","name"],"path":"$.schema"},{"keys":["dataset","issued","schema"],"path":"$"}],"trailing_new...; right: {"byte_len":110,"indentation":"2 spaces","line_ending":"lf","object_key_orders":[{"keys":["name","id"],"path":"$.schema"},{"keys":["schema","issued","dataset"],...

--- a/test-vectors/zip-rename-inner-rename-edit/expected-output/changelog.snap
+++ b/test-vectors/zip-rename-inner-rename-edit/expected-output/changelog.snap
@@ -5,6 +5,8 @@ expression: "&md"
 # Changelog: snapshot-a → snapshot-b
 
 - **archive.zip**: Moved from data.zip
-- **archive.zip/>new.csv**: 1 cell changed
+- **archive.zip/>new.csv**:
+  - Moved from data.zip/>old.csv
+  - 1 cell changed
   - Changed cells
     - row 5, column 'score': '60' -> '61'


### PR DESCRIPTION
The new engine needs some rendering cleanup. As a first pass, make sure that moved files include the move itself as a change, not just the content changes; and make sure that all changes are printed by the renderer (not just verbs with special handling) and that non-identical files without detected changes are flagged as having unknown changes.

Fixes #103