### PR TITLE
Vintage-audience benchmark vector + ADR

### DIFF
--- a/binoc-core/src/correspondence/driver.rs
+++ b/binoc-core/src/correspondence/driver.rs
@@ -205,18 +205,12 @@ impl CorrespondenceRunResult {
         })?;
         let link = self.store.links.link(link_index);
         let view = CoreEngineView::new(&self.store, false);
-        let link_ref = view.link_ref(link_index);
-        let path = &self.store.right.node(link.right).item.logical_path;
-        let ctx = LinkCtx {
-            view: &view,
-            link: link_ref,
-            row_keys: config.row_keys.get(path).map(Vec::as_slice).unwrap_or(&[]),
-            row_identity_policies: config
-                .row_identity_policies
-                .get(path)
-                .copied()
-                .unwrap_or_default(),
-        };
+        let ctx = link_ctx(
+            &view,
+            view.link_ref(link_index),
+            &self.store.right.node(link.right).item.logical_path,
+            config,
+        );
         let edits = self
             .edit_lists
             .get(&link_index)
@@ -349,21 +343,15 @@ fn run_inner(
     let mut expanded: BTreeSet<(u8, u32)> = BTreeSet::new();
     // A *successful* parse memoizes per (node, output format): first claim wins
     // for that format on that node, so no other same-format rule re-parses it.
-    let mut parsed: BTreeSet<(u8, u32, binoc_sdk::ArtifactFormat)> = BTreeSet::new();
+    let mut parsed: BTreeSet<ParseClaim> = BTreeSet::new();
     // A *declined* parse memoizes per (node, output format, RULE) so the same
     // rule is not retried, while leaving the format free for a different rule.
     // This is what lets a fusing claim decline a bare/invalid group and still
     // have the single-input parser (same output format) claim the node (CFM-83).
-    let mut declined: BTreeSet<(u8, u32, binoc_sdk::ArtifactFormat, String)> = BTreeSet::new();
+    let mut declined: BTreeSet<Decline> = BTreeSet::new();
 
     fn key(side: TreeSide, index: u32) -> (u8, u32) {
-        (
-            match side {
-                TreeSide::Left => 0,
-                TreeSide::Right => 1,
-            },
-            index,
-        )
+        (side_code(side), index)
     }
 
     // Per-round rule processing order (CFM-83). Parse rules are attempted
@@ -510,19 +498,13 @@ fn run_inner(
                     let mut jobs = Vec::new();
                     for side in [TreeSide::Left, TreeSide::Right] {
                         for index in 0..frontier_of(side) {
-                            let parsed_key = (key(side, index).0, index, descriptor.output.clone());
-                            if parsed.contains(&parsed_key) {
+                            let claim = ParseClaim::new(side, index, descriptor.output.clone());
+                            if parsed.contains(&claim) {
                                 continue;
                             }
                             // This rule already declined this node — don't retry
                             // it (but a different same-format rule still may).
-                            let declined_key = (
-                                parsed_key.0,
-                                parsed_key.1,
-                                parsed_key.2.clone(),
-                                descriptor.name.clone(),
-                            );
-                            if declined.contains(&declined_key) {
+                            if declined.contains(&claim.declined_by(&descriptor.name)) {
                                 continue;
                             }
                             // A node already folded into a fusing result node is
@@ -566,7 +548,7 @@ fn run_inner(
                             }
                             jobs.push(ParseJob {
                                 id,
-                                parsed_key,
+                                claim,
                                 beneath,
                                 group,
                                 member_indices,
@@ -595,12 +577,7 @@ fn run_inner(
                                 );
                                 // Rule-scoped: an erroring rule does not block a
                                 // different same-format rule from trying the node.
-                                declined.insert((
-                                    result.parsed_key.0,
-                                    result.parsed_key.1,
-                                    result.parsed_key.2.clone(),
-                                    descriptor.name.clone(),
-                                ));
+                                declined.insert(result.claim.declined_by(&descriptor.name));
                                 continue;
                             }
                         };
@@ -619,12 +596,7 @@ fn run_inner(
                         // shapefile fusing claim to release a bare/invalid group to
                         // the single-input parser (CFM-83).
                         if output.bytes.is_empty() && output.children.is_empty() {
-                            declined.insert((
-                                result.parsed_key.0,
-                                result.parsed_key.1,
-                                result.parsed_key.2.clone(),
-                                descriptor.name.clone(),
-                            ));
+                            declined.insert(result.claim.declined_by(&descriptor.name));
                             continue;
                         }
                         // Let the parse rule name the node it just decomposed
@@ -702,7 +674,7 @@ fn run_inner(
                                 .tree_mut(result.id.side)
                                 .subsume(member_index, result.id.index);
                         }
-                        parsed.insert(result.parsed_key);
+                        parsed.insert(result.claim);
                         stats.record_fire(
                             round,
                             &descriptor.name,
@@ -871,14 +843,7 @@ fn run_inner(
         trace.as_deref_mut(),
     )?;
 
-    compact_edit_lists(
-        config,
-        &store,
-        &mut edit_lists,
-        &mut stats,
-        data,
-        trace.as_deref_mut(),
-    )?;
+    compact_edit_lists(config, &store, &mut edit_lists, &mut stats, data, trace)?;
 
     Ok(CorrespondenceRunResult {
         store,
@@ -888,6 +853,31 @@ fn run_inner(
         claims,
         stats,
     })
+}
+
+/// Build a `LinkCtx` for one link. Centralizes the per-link row-key and
+/// row-identity-policy lookups (keyed on the right node's logical path) that
+/// every writer/compaction/extract dispatch needs.
+fn link_ctx<'a>(
+    view: &'a dyn EngineView,
+    link: LinkRef,
+    right_path: &str,
+    config: &'a CorrespondenceEngineConfig,
+) -> LinkCtx<'a> {
+    LinkCtx {
+        view,
+        link,
+        row_keys: config
+            .row_keys
+            .get(right_path)
+            .map(Vec::as_slice)
+            .unwrap_or(&[]),
+        row_identity_policies: config
+            .row_identity_policies
+            .get(right_path)
+            .copied()
+            .unwrap_or_default(),
+    }
 }
 
 fn build_edit_lists(
@@ -936,20 +926,12 @@ fn build_edit_lists(
             edit_lists.insert(index, Vec::new());
             continue;
         };
-        let ctx = LinkCtx {
-            view: &view,
-            link: link_ref,
-            row_keys: config
-                .row_keys
-                .get(&store.right.node(link.right).item.logical_path)
-                .map(Vec::as_slice)
-                .unwrap_or(&[]),
-            row_identity_policies: config
-                .row_identity_policies
-                .get(&store.right.node(link.right).item.logical_path)
-                .copied()
-                .unwrap_or_default(),
-        };
+        let ctx = link_ctx(
+            &view,
+            link_ref,
+            &store.right.node(link.right).item.logical_path,
+            config,
+        );
 
         // Dispatch composes, then selects (CFM-81). The link's edit list is
         // the concatenation of:
@@ -1065,20 +1047,12 @@ fn compact_edit_lists(
                 continue;
             }
             let link = store.links.link(*link_index);
-            let ctx = LinkCtx {
-                view: &view,
-                link: view.link_ref(*link_index),
-                row_keys: config
-                    .row_keys
-                    .get(&store.right.node(link.right).item.logical_path)
-                    .map(Vec::as_slice)
-                    .unwrap_or(&[]),
-                row_identity_policies: config
-                    .row_identity_policies
-                    .get(&store.right.node(link.right).item.logical_path)
-                    .copied()
-                    .unwrap_or_default(),
-            };
+            let ctx = link_ctx(
+                &view,
+                view.link_ref(*link_index),
+                &store.right.node(link.right).item.logical_path,
+                config,
+            );
             // Format-scoped compaction (CFM-81): a rule that declares a
             // `format()` sees and rewrites only the provenance-scoped segment
             // of that format, never the whole mixed list. A rule with no
@@ -1160,12 +1134,56 @@ fn run_expand_jobs(
     }
 }
 
+/// Stable side encoding (`Left = 0`, `Right = 1`) used as the leading sort key
+/// for node-scoped memoization sets.
+fn side_code(side: TreeSide) -> u8 {
+    match side {
+        TreeSide::Left => 0,
+        TreeSide::Right => 1,
+    }
+}
+
+/// Memoization key for a *successful* parse: first claim wins per (node, output
+/// format), so no other same-format rule re-parses that node.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct ParseClaim {
+    side: u8,
+    index: u32,
+    format: ArtifactFormat,
+}
+
+/// Memoization key for a *declined* parse: scoped to the rule, so the same rule
+/// is not retried while the output format stays free for a different rule
+/// (CFM-83).
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct Decline {
+    claim: ParseClaim,
+    rule: String,
+}
+
+impl ParseClaim {
+    fn new(side: TreeSide, index: u32, format: ArtifactFormat) -> Self {
+        ParseClaim {
+            side: side_code(side),
+            index,
+            format,
+        }
+    }
+
+    fn declined_by(&self, rule: &str) -> Decline {
+        Decline {
+            claim: self.clone(),
+            rule: rule.to_string(),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 struct ParseJob {
     /// The anchor node (the required, defining member — e.g. the `.shp`). The
     /// parse result, artifacts, and any subsumption all attribute to this node.
     id: NodeId,
-    parsed_key: (u8, u32, ArtifactFormat),
+    claim: ParseClaim,
     beneath: bool,
     /// The resolved member group handed to `parse_group`. For a single-input
     /// rule this is just the anchor (`ParseGroup::single`).
@@ -1177,7 +1195,7 @@ struct ParseJob {
 
 struct ParseJobResult {
     id: NodeId,
-    parsed_key: (u8, u32, ArtifactFormat),
+    claim: ParseClaim,
     beneath: bool,
     item: ItemRef,
     member_indices: Vec<u32>,
@@ -1192,7 +1210,7 @@ fn run_parse_jobs(
 ) -> Vec<ParseJobResult> {
     let run_one = |job: &ParseJob| ParseJobResult {
         id: job.id,
-        parsed_key: job.parsed_key.clone(),
+        claim: job.claim.clone(),
         beneath: job.beneath,
         item: job.group.anchor.clone(),
         member_indices: job.member_indices.clone(),

--- a/binoc-core/src/correspondence/driver.rs
+++ b/binoc-core/src/correspondence/driver.rs
@@ -81,6 +81,30 @@ impl RunStats {
         *self.rule_elapsed_nanos.entry(rule.to_string()).or_insert(0) += elapsed.as_nanos();
     }
 
+    /// Record a rule firing: bump the per-rule fire counter (and the
+    /// beneath-settled counter when applicable) and append the `FireEvent`.
+    /// The matching `TraceStep` push stays at the call site because its variant
+    /// differs per rule family.
+    fn record_fire(
+        &mut self,
+        round: u32,
+        rule: &str,
+        kind: &'static str,
+        subject: String,
+        beneath: bool,
+    ) {
+        Self::bump(&mut self.fires, rule);
+        if beneath {
+            Self::bump(&mut self.fires_beneath_settled, rule);
+        }
+        self.events.push(FireEvent {
+            round,
+            rule: rule.to_string(),
+            kind,
+            subject,
+        });
+    }
+
     pub fn fires_of(&self, rule: &str) -> u64 {
         self.fires.get(rule).copied().unwrap_or(0)
     }
@@ -458,16 +482,13 @@ fn run_inner(
                             child_indices.push(child_index);
                         }
                         expanded.insert(key(result.side, result.index));
-                        RunStats::bump(&mut stats.fires, &descriptor.name);
-                        if result.beneath {
-                            RunStats::bump(&mut stats.fires_beneath_settled, &descriptor.name);
-                        }
-                        stats.events.push(FireEvent {
+                        stats.record_fire(
                             round,
-                            rule: descriptor.name.clone(),
-                            kind: "expand",
-                            subject: format!("{}:{}", result.side.label(), path),
-                        });
+                            &descriptor.name,
+                            "expand",
+                            format!("{}:{}", result.side.label(), path),
+                            result.beneath,
+                        );
                         if let Some(trace) = trace.as_deref_mut() {
                             let step = trace.push(TraceStep::Expand {
                                 round,
@@ -682,16 +703,13 @@ fn run_inner(
                                 .subsume(member_index, result.id.index);
                         }
                         parsed.insert(result.parsed_key);
-                        RunStats::bump(&mut stats.fires, &descriptor.name);
-                        if result.beneath {
-                            RunStats::bump(&mut stats.fires_beneath_settled, &descriptor.name);
-                        }
-                        stats.events.push(FireEvent {
+                        stats.record_fire(
                             round,
-                            rule: descriptor.name.clone(),
-                            kind: "parse",
-                            subject: format!("{}:{}", result.id.side.label(), path),
-                        });
+                            &descriptor.name,
+                            "parse",
+                            format!("{}:{}", result.id.side.label(), path),
+                            result.beneath,
+                        );
                         if let Some(trace) = trace.as_deref_mut() {
                             let step = trace.push(TraceStep::Parse {
                                 round,
@@ -756,13 +774,13 @@ fn run_inner(
                         match outcome {
                             ApplyOutcome::Added => {
                                 stats.links_added += 1;
-                                RunStats::bump(&mut stats.fires, &descriptor.name);
-                                stats.events.push(FireEvent {
+                                stats.record_fire(
                                     round,
-                                    rule: descriptor.name.clone(),
-                                    kind: "link-add",
+                                    &descriptor.name,
+                                    "link-add",
                                     subject,
-                                });
+                                    false,
+                                );
                                 if let Some(trace) = trace.as_deref_mut() {
                                     let link = link_index_of(&store, proposal_left, proposal_right);
                                     let step = trace.push(TraceStep::LinkAdd {
@@ -780,13 +798,13 @@ fn run_inner(
                             }
                             ApplyOutcome::Upgraded => {
                                 stats.links_upgraded += 1;
-                                RunStats::bump(&mut stats.fires, &descriptor.name);
-                                stats.events.push(FireEvent {
+                                stats.record_fire(
                                     round,
-                                    rule: descriptor.name.clone(),
-                                    kind: "link-upgrade",
+                                    &descriptor.name,
+                                    "link-upgrade",
                                     subject,
-                                });
+                                    false,
+                                );
                                 if let Some(trace) = trace.as_deref_mut() {
                                     let link = link_index_of(&store, proposal_left, proposal_right);
                                     let revision = store.links.revisions.last();
@@ -844,48 +862,212 @@ fn run_inner(
         }
     }
 
-    let mut edit_lists = BTreeMap::new();
-    {
-        let view = CoreEngineView::new(&store, false);
-        let link_indexes: Vec<usize> = store.links.iter().map(|(index, _)| index).collect();
-        for index in link_indexes {
-            let link = store.links.link(index);
-            if link.settled {
-                edit_lists.insert(index, Vec::new());
-                continue;
-            }
-            let left_id = NodeId {
-                side: TreeSide::Left,
-                index: link.left,
-            };
-            let right_id = NodeId {
-                side: TreeSide::Right,
-                index: link.right,
-            };
-            if !view.visible(left_id) || !view.visible(right_id) {
-                edit_lists.insert(index, Vec::new());
-                continue;
-            }
-            // A subsumed member is folded into a fusing result node; its own link
-            // (e.g. a `roads.dbf` ↔ `roads.dbf` name pairing that formed before
-            // the shapefile claim subsumed it) contributes no edits and is not
-            // dispatched to per-artifact writers (CFM-81 + CFM-83).
-            if store.is_subsumed(left_id) || store.is_subsumed(right_id) {
-                edit_lists.insert(index, Vec::new());
-                continue;
-            }
+    let mut edit_lists = build_edit_lists(
+        config,
+        &store,
+        &mut diagnostics,
+        &mut stats,
+        data,
+        trace.as_deref_mut(),
+    )?;
 
-            let Some(link_ref) = view
-                .links_of(left_id)
-                .into_iter()
-                .find(|l| l.index == index)
-            else {
-                edit_lists.insert(index, Vec::new());
+    compact_edit_lists(
+        config,
+        &store,
+        &mut edit_lists,
+        &mut stats,
+        data,
+        trace.as_deref_mut(),
+    )?;
+
+    Ok(CorrespondenceRunResult {
+        store,
+        edit_lists,
+        annotators: config.annotators.clone(),
+        diagnostics,
+        claims,
+        stats,
+    })
+}
+
+fn build_edit_lists(
+    config: &CorrespondenceEngineConfig,
+    store: &Store,
+    diagnostics: &mut Vec<Diagnostic>,
+    stats: &mut RunStats,
+    data: &dyn DataAccess,
+    mut trace: Option<&mut TraceRecorder>,
+) -> BinocResult<BTreeMap<usize, Vec<Edit>>> {
+    let mut edit_lists = BTreeMap::new();
+    let view = CoreEngineView::new(store, false);
+    let link_indexes: Vec<usize> = store.links.iter().map(|(index, _)| index).collect();
+    for index in link_indexes {
+        let link = store.links.link(index);
+        if link.settled {
+            edit_lists.insert(index, Vec::new());
+            continue;
+        }
+        let left_id = NodeId {
+            side: TreeSide::Left,
+            index: link.left,
+        };
+        let right_id = NodeId {
+            side: TreeSide::Right,
+            index: link.right,
+        };
+        if !view.visible(left_id) || !view.visible(right_id) {
+            edit_lists.insert(index, Vec::new());
+            continue;
+        }
+        // A subsumed member is folded into a fusing result node; its own link
+        // (e.g. a `roads.dbf` ↔ `roads.dbf` name pairing that formed before
+        // the shapefile claim subsumed it) contributes no edits and is not
+        // dispatched to per-artifact writers (CFM-81 + CFM-83).
+        if store.is_subsumed(left_id) || store.is_subsumed(right_id) {
+            edit_lists.insert(index, Vec::new());
+            continue;
+        }
+
+        let Some(link_ref) = view
+            .links_of(left_id)
+            .into_iter()
+            .find(|l| l.index == index)
+        else {
+            edit_lists.insert(index, Vec::new());
+            continue;
+        };
+        let ctx = LinkCtx {
+            view: &view,
+            link: link_ref,
+            row_keys: config
+                .row_keys
+                .get(&store.right.node(link.right).item.logical_path)
+                .map(Vec::as_slice)
+                .unwrap_or(&[]),
+            row_identity_policies: config
+                .row_identity_policies
+                .get(&store.right.node(link.right).item.logical_path)
+                .copied()
+                .unwrap_or_default(),
+        };
+
+        // Dispatch composes, then selects (CFM-81). The link's edit list is
+        // the concatenation of:
+        //   * one artifact writer per *present* artifact format — within a
+        //     format, registration order picks the first writer that returns
+        //     `Some` (the substitutability / dialect axis);
+        //   * each applicable structural writer (empty `formats`), excluding
+        //     the fallback;
+        //   * the fallback, but only when nothing above claimed the link.
+        // Each contribution's edits are stamped with the producer's
+        // provenance so downstream compaction/extract/summary stay
+        // per-content-type. Ordering is deterministic: artifact formats in
+        // sorted order, then structural writers in registration order.
+        let mut writers_used: BTreeSet<String> = BTreeSet::new();
+        let mut artifact_segments: BTreeMap<ArtifactFormat, Vec<Edit>> = BTreeMap::new();
+        let mut structural_edits: Vec<Edit> = Vec::new();
+        let mut fallback: Option<&Arc<dyn binoc_sdk::EditListWriter>> = None;
+        // A link is "claimed" once any non-fallback writer returns `Some`
+        // (even an empty edit list), exactly as the old first-match loop's
+        // `break` claimed it. The fallback fires only on unclaimed links.
+        let mut claimed = false;
+
+        for writer in &config.writers {
+            let descriptor = writer.descriptor();
+            if !writer_matches(&descriptor, store, left_id, right_id) {
                 continue;
-            };
+            }
+            let is_fallback = descriptor.formats.is_empty() && is_fallback_writer(&descriptor);
+            if is_fallback {
+                // Defer the fallback until we know whether the link was
+                // claimed by anything else.
+                fallback.get_or_insert(writer);
+                continue;
+            }
+            let provenance = writer_provenance(&descriptor);
+            if descriptor.formats.is_empty() {
+                // Structural writer (container/text).
+                if let Some(output) = writer.write(&ctx, data)? {
+                    append_rule_diagnostics(diagnostics, &descriptor.name, output.diagnostics);
+                    claimed = true;
+                    writers_used.insert(descriptor.name.clone());
+                    structural_edits.extend(stamp(output.edits, &provenance));
+                }
+            } else {
+                // Artifact writer. Within a format, the first writer (by
+                // registration order) that returns `Some` wins; later
+                // writers for an already-produced format are skipped.
+                let format = descriptor.formats[0].clone();
+                if artifact_segments.contains_key(&format) {
+                    continue;
+                }
+                if let Some(output) = writer.write(&ctx, data)? {
+                    append_rule_diagnostics(diagnostics, &descriptor.name, output.diagnostics);
+                    claimed = true;
+                    writers_used.insert(descriptor.name.clone());
+                    artifact_segments.insert(format, stamp(output.edits, &provenance));
+                }
+            }
+        }
+
+        // Concatenate in deterministic order: artifact formats sorted, then
+        // structural contributions.
+        let mut composed: Vec<Edit> = Vec::new();
+        for (_format, segment) in artifact_segments {
+            composed.extend(segment);
+        }
+        composed.extend(structural_edits);
+
+        if !claimed {
+            if let Some(writer) = fallback {
+                let descriptor = writer.descriptor();
+                if let Some(output) = writer.write(&ctx, data)? {
+                    append_rule_diagnostics(diagnostics, &descriptor.name, output.diagnostics);
+                    claimed = true;
+                    writers_used.insert(descriptor.name.clone());
+                    composed.extend(stamp(output.edits, &writer_provenance(&descriptor)));
+                }
+            }
+        }
+
+        if let Some(trace) = trace.as_deref_mut() {
+            if !writers_used.is_empty() {
+                trace.push(TraceStep::Write {
+                    writers: writers_used.iter().cloned().collect(),
+                    link: index,
+                    edits: composed.clone(),
+                });
+            }
+        }
+
+        if claimed {
+            stats.writer_used.insert(index, writers_used);
+        } else {
+            stats.unwritten_links.push(index);
+        }
+        edit_lists.insert(index, composed);
+    }
+    Ok(edit_lists)
+}
+
+fn compact_edit_lists(
+    config: &CorrespondenceEngineConfig,
+    store: &Store,
+    edit_lists: &mut BTreeMap<usize, Vec<Edit>>,
+    stats: &mut RunStats,
+    data: &dyn DataAccess,
+    mut trace: Option<&mut TraceRecorder>,
+) -> BinocResult<()> {
+    let view = CoreEngineView::new(store, false);
+    for rule in &config.compaction {
+        for (link_index, edits) in edit_lists.iter_mut() {
+            if edits.is_empty() {
+                continue;
+            }
+            let link = store.links.link(*link_index);
             let ctx = LinkCtx {
                 view: &view,
-                link: link_ref,
+                link: view.link_ref(*link_index),
                 row_keys: config
                     .row_keys
                     .get(&store.right.node(link.right).item.logical_path)
@@ -897,192 +1079,50 @@ fn run_inner(
                     .copied()
                     .unwrap_or_default(),
             };
-
-            // Dispatch composes, then selects (CFM-81). The link's edit list is
-            // the concatenation of:
-            //   * one artifact writer per *present* artifact format — within a
-            //     format, registration order picks the first writer that returns
-            //     `Some` (the substitutability / dialect axis);
-            //   * each applicable structural writer (empty `formats`), excluding
-            //     the fallback;
-            //   * the fallback, but only when nothing above claimed the link.
-            // Each contribution's edits are stamped with the producer's
-            // provenance so downstream compaction/extract/summary stay
-            // per-content-type. Ordering is deterministic: artifact formats in
-            // sorted order, then structural writers in registration order.
-            let mut writers_used: BTreeSet<String> = BTreeSet::new();
-            let mut artifact_segments: BTreeMap<ArtifactFormat, Vec<Edit>> = BTreeMap::new();
-            let mut structural_edits: Vec<Edit> = Vec::new();
-            let mut fallback: Option<&Arc<dyn binoc_sdk::EditListWriter>> = None;
-            // A link is "claimed" once any non-fallback writer returns `Some`
-            // (even an empty edit list), exactly as the old first-match loop's
-            // `break` claimed it. The fallback fires only on unclaimed links.
-            let mut claimed = false;
-
-            for writer in &config.writers {
-                let descriptor = writer.descriptor();
-                if !writer_matches(&descriptor, &store, left_id, right_id) {
-                    continue;
-                }
-                let is_fallback = descriptor.formats.is_empty() && is_fallback_writer(&descriptor);
-                if is_fallback {
-                    // Defer the fallback until we know whether the link was
-                    // claimed by anything else.
-                    fallback.get_or_insert(writer);
-                    continue;
-                }
-                let provenance = writer_provenance(&descriptor);
-                if descriptor.formats.is_empty() {
-                    // Structural writer (container/text).
-                    if let Some(output) = writer.write(&ctx, data)? {
-                        append_rule_diagnostics(
-                            &mut diagnostics,
-                            &descriptor.name,
-                            output.diagnostics,
-                        );
-                        claimed = true;
-                        writers_used.insert(descriptor.name.clone());
-                        structural_edits.extend(stamp(output.edits, &provenance));
-                    }
-                } else {
-                    // Artifact writer. Within a format, the first writer (by
-                    // registration order) that returns `Some` wins; later
-                    // writers for an already-produced format are skipped.
-                    let format = descriptor.formats[0].clone();
-                    if artifact_segments.contains_key(&format) {
-                        continue;
-                    }
-                    if let Some(output) = writer.write(&ctx, data)? {
-                        append_rule_diagnostics(
-                            &mut diagnostics,
-                            &descriptor.name,
-                            output.diagnostics,
-                        );
-                        claimed = true;
-                        writers_used.insert(descriptor.name.clone());
-                        artifact_segments.insert(format, stamp(output.edits, &provenance));
-                    }
-                }
+            // Format-scoped compaction (CFM-81): a rule that declares a
+            // `format()` sees and rewrites only the provenance-scoped segment
+            // of that format, never the whole mixed list. A rule with no
+            // declared format keeps operating on the full list.
+            let scope = rule.format().map(|format| format.to_string());
+            let scoped: Vec<Edit> = match &scope {
+                Some(provenance) => scoped_edits(edits, provenance),
+                None => edits.clone(),
+            };
+            if scoped.is_empty() {
+                continue;
             }
-
-            // Concatenate in deterministic order: artifact formats sorted, then
-            // structural contributions.
-            let mut composed: Vec<Edit> = Vec::new();
-            for (_format, segment) in artifact_segments {
-                composed.extend(segment);
-            }
-            composed.extend(structural_edits);
-
-            if !claimed {
-                if let Some(writer) = fallback {
-                    let descriptor = writer.descriptor();
-                    if let Some(output) = writer.write(&ctx, data)? {
-                        append_rule_diagnostics(
-                            &mut diagnostics,
-                            &descriptor.name,
-                            output.diagnostics,
-                        );
-                        claimed = true;
-                        writers_used.insert(descriptor.name.clone());
-                        composed.extend(stamp(output.edits, &writer_provenance(&descriptor)));
+            if let Some(rewritten_segment) = rule.rewrite(&ctx, &scoped, data)? {
+                // Re-stamp the rewritten segment with its format provenance
+                // (rewrite rules synthesize fresh edits without it), then
+                // splice it back into the full list at the position of the
+                // first edit it replaced — preserving other content types'
+                // edits in place.
+                let rewritten = match &scope {
+                    Some(provenance) => {
+                        splice_scoped(edits, provenance, stamp(rewritten_segment, provenance))
                     }
-                }
-            }
-
-            if let Some(trace) = trace.as_deref_mut() {
-                if !writers_used.is_empty() {
-                    trace.push(TraceStep::Write {
-                        writers: writers_used.iter().cloned().collect(),
-                        link: index,
-                        edits: composed.clone(),
+                    None => rewritten_segment,
+                };
+                let accepted = cost(&rewritten) < cost(edits);
+                if let Some(trace) = trace.as_deref_mut() {
+                    trace.push(TraceStep::Compact {
+                        rule: rule.name().to_string(),
+                        link: *link_index,
+                        accepted,
+                        before: edits.clone(),
+                        after: rewritten.clone(),
                     });
                 }
-            }
-
-            if claimed {
-                stats.writer_used.insert(index, writers_used);
-            } else {
-                stats.unwritten_links.push(index);
-            }
-            edit_lists.insert(index, composed);
-        }
-    }
-
-    {
-        let view = CoreEngineView::new(&store, false);
-        for rule in &config.compaction {
-            for (link_index, edits) in edit_lists.iter_mut() {
-                if edits.is_empty() {
-                    continue;
-                }
-                let link = store.links.link(*link_index);
-                let ctx = LinkCtx {
-                    view: &view,
-                    link: view.link_ref(*link_index),
-                    row_keys: config
-                        .row_keys
-                        .get(&store.right.node(link.right).item.logical_path)
-                        .map(Vec::as_slice)
-                        .unwrap_or(&[]),
-                    row_identity_policies: config
-                        .row_identity_policies
-                        .get(&store.right.node(link.right).item.logical_path)
-                        .copied()
-                        .unwrap_or_default(),
-                };
-                // Format-scoped compaction (CFM-81): a rule that declares a
-                // `format()` sees and rewrites only the provenance-scoped segment
-                // of that format, never the whole mixed list. A rule with no
-                // declared format keeps operating on the full list.
-                let scope = rule.format().map(|format| format.to_string());
-                let scoped: Vec<Edit> = match &scope {
-                    Some(provenance) => scoped_edits(edits, provenance),
-                    None => edits.clone(),
-                };
-                if scoped.is_empty() {
-                    continue;
-                }
-                if let Some(rewritten_segment) = rule.rewrite(&ctx, &scoped, data)? {
-                    // Re-stamp the rewritten segment with its format provenance
-                    // (rewrite rules synthesize fresh edits without it), then
-                    // splice it back into the full list at the position of the
-                    // first edit it replaced — preserving other content types'
-                    // edits in place.
-                    let rewritten = match &scope {
-                        Some(provenance) => {
-                            splice_scoped(edits, provenance, stamp(rewritten_segment, provenance))
-                        }
-                        None => rewritten_segment,
-                    };
-                    let accepted = cost(&rewritten) < cost(edits);
-                    if let Some(trace) = trace.as_deref_mut() {
-                        trace.push(TraceStep::Compact {
-                            rule: rule.name().to_string(),
-                            link: *link_index,
-                            accepted,
-                            before: edits.clone(),
-                            after: rewritten.clone(),
-                        });
-                    }
-                    if accepted {
-                        *edits = rewritten;
-                        RunStats::bump(&mut stats.compaction_accepted, rule.name());
-                    } else {
-                        RunStats::bump(&mut stats.compaction_rejected, rule.name());
-                    }
+                if accepted {
+                    *edits = rewritten;
+                    RunStats::bump(&mut stats.compaction_accepted, rule.name());
+                } else {
+                    RunStats::bump(&mut stats.compaction_rejected, rule.name());
                 }
             }
         }
     }
-
-    Ok(CorrespondenceRunResult {
-        store,
-        edit_lists,
-        annotators: config.annotators.clone(),
-        diagnostics,
-        claims,
-        stats,
-    })
+    Ok(())
 }
 
 #[derive(Debug, Clone)]

--- a/docs/adr/2026-06-22-vintage_audience_and_metadata_only_benchmark.md
+++ b/docs/adr/2026-06-22-vintage_audience_and_metadata_only_benchmark.md
@@ -1,0 +1,105 @@
+# The Vintage Audience: a Kept Benchmark for Metadata-Over-Data Reading
+
+**Date:** 2026-06-22
+**Status:** Accepted (benchmark landed; features deliberately deferred)
+
+## Context
+
+Binoc is tuned for one audience today: readers comparing two snapshots of the
+*same* dataset who want every change explained — every edited cell, every added
+row. Call them the **same-data** audience.
+
+There is a second, latent audience: readers comparing two **vintages** — two
+editions of the same published dataset (a yearly facilities register, a
+re-released survey). A vintage reader cares about the *shape* of the data: did a
+column appear, did a categorical vocabulary shift. They deliberately do **not**
+want to read the bulk cell/row churn — for them it is noise, possibly millions
+of rows of it.
+
+We are not ready to serve the vintage audience. The same-data experience needs
+to be bulletproof first, and inviting vintage feedback now would split our
+attention and our optics before the core is solid. But we do need confidence
+that the *engine* does not foreclose the vintage audience — that when we choose
+to open that channel, it is a matter of configuration and plugins, not a
+re-architecture. The risk we want to retire is a silent one: that some
+assumption baked into the controller, the IR, or the correspondence engine
+quietly assumes the same-data stance.
+
+## Decision
+
+Land a **kept benchmark vector**, `test-vectors/csv-vintage-benchmark`, that
+exercises the vintage stance end to end and stays green, rather than building any
+vintage feature. The vector is a two-CSV "published dataset" across two editions:
+`facilities.csv` gains a `region` column and one row's `status` moves to a new
+category value (`decommissioned`); `inspections.csv` changes only in its data
+(edited scores, appended rows). A markdown `groups` config expresses the vintage
+stance as significance — schema/vocabulary tags are the high-priority group, bulk
+cell/row tags the low-priority group.
+
+The benchmark confirms what already works: because significance is a renderer
+concern (per [2026-03-09 renderer config](2026-03-09-renderer_config.md)) and
+`classify_tags` promotes a node to the highest-priority group among its tags, the
+schema-touching `facilities.csv` floats up to the structural section while the
+pure-data `inspections.csv` sinks to the bulk section. That file-granularity
+separation is the best vintage view binoc offers today, and it is pure
+config — the type-ignorant controller (AGENTS rule 1) never participates.
+
+The vector ships two renderings side by side: `expected-output/changelog.snap`
+is the real, harness-checked engine output; `VINTAGE-IDEAL.md` is a hand-authored
+target that is *not* harness-checked. The benchmark is kept green so the gap
+between the two stays visible and measurable. The ideal names three gaps, each
+reachable without touching the controller, the IR, or the correspondence engine:
+
+1. **Within-node keep/drop.** A CSV's `region` addition and its `status` cell
+   edit are edits on one node, so the renderer cannot surface the structural
+   change while holding the cell back. The fix is a config-driven, edit-level
+   keep/drop filter in the renderer. The data path already carries
+   `EditProjection.visible`; today only writers set it. This is the smallest
+   unlock and it lives entirely in the renderer.
+
+2. **Vocabulary as a first-class change.** The `active -> decommissioned` shift
+   is reported as an ordinary `binoc.cell-change`, not as "the `status`
+   vocabulary gained a value." The fix is a plugin `EditListWriter` over
+   `tabular_v1` that diffs the distinct-value set of each categorical column and
+   emits a `binoc.vocabulary-change` edit — a plugin pack, exactly like the
+   standard library is (AGENTS rule 2).
+
+3. **Summary statistics over enumeration.** The bulk section enumerates every
+   changed cell and added row; a vintage reader wants "4 -> 6 rows, 3 cells
+   changed." The fix is the same plugin emitting an aggregate via
+   `Edit::with_summary` or a dataset-level `GlobalClaim`. The seam already
+   carries such facts — stdlib uses `with_summary` for binary string-diffs — but
+   no rule emits a tabular roll-up yet.
+
+The conclusion we are recording: the vintage-vs-same-data distinction is a
+renderer-config + plugin-pack concern, which is the architecture's whole thesis.
+The minimum to open the channel is one renderer-local filter plus one plugin
+pack. No engine surgery. The channel is provably clear, and we are choosing not
+to walk through it yet.
+
+## Alternatives Considered
+
+**Build the metadata-only filter and a sample statistics plugin now.** This is
+the natural next step and the benchmark is designed to make it cheap. We are
+deferring it for social and focus reasons, not technical ones: shipping a vintage
+surface would invite vintage feedback before the same-data experience is solid.
+The benchmark captures the design so the work is shovel-ready when we choose it.
+
+**Write the rationale as prose only, with no vector.** A document can claim the
+engine is ready; a passing benchmark proves it and keeps proving it. Without an
+executable artifact, a future change could quietly regress the vintage stance
+(e.g., bake a same-data assumption into a writer) with nothing to catch it.
+
+**Make the benchmark aspirational — hand-author the ideal as the gold file.**
+A snapshot that encodes output the engine does not produce would fail CI, forcing
+us to either disable the test (dead weight) or special-case it (harness
+complexity). Instead the harness-checked snapshot tracks reality and a separate,
+unchecked `VINTAGE-IDEAL.md` holds the target. The benchmark stays honest and
+green, and the gap is documented rather than asserted.
+
+**Promote columns (and their vocabularies) to first-class IR nodes now.** This
+would make within-node significance and vocabulary diffing fall out naturally,
+but it is a substantial IR change in service of an audience we are deliberately
+not yet serving. The benchmark shows the same outcomes are reachable with a
+plugin writer emitting tagged edits, deferring any IR commitment until the
+vintage audience is real.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -6,6 +6,7 @@ Newer entries appear first. Each entry shows its date and current status. Create
 
 | Date | Title | Status |
 |---|---|---|
+| 2026-06-22 | [The Vintage Audience: a Kept Benchmark for Metadata-Over-Data Reading](2026-06-22-vintage_audience_and_metadata_only_benchmark.md) | Accepted (benchmark landed; features deferred) |
 | 2026-06-15 | [Tiered Artifact Metadata: Column, Table, and a `parser_metadata_v1` Artifact](2026-06-15-tiered_artifact_metadata.md) | Implemented (channels + producers in CFM-80; rendering + significance in CFM-82) |
 | 2026-06-15 | [The Engine Overhaul, Told Whole: Single-Tree to Correspondence-First](2026-06-15-engine_overhaul_retrospective.md) | Retrospective |
 | 2026-06-15 | [Partition Identities: a JIT, Format-Owned Capability for N↔M Correspondence (CFM-72)](2026-06-15-partition_identities_jit_format_capability.md) | Implemented |

--- a/test-vectors/csv-vintage-benchmark/VINTAGE-IDEAL.md
+++ b/test-vectors/csv-vintage-benchmark/VINTAGE-IDEAL.md
@@ -1,0 +1,87 @@
+# Vintage benchmark — target experience
+
+This file is the north star for the *vintage* (different-edition) audience. It is
+**not** checked by the harness; it is the hand-authored target that
+`expected-output/changelog.snap` should converge toward as the vintage story
+improves. Compare the two whenever you touch tabular significance, vocabulary
+detection, or summary statistics.
+
+A vintage reader is comparing two editions of the same published dataset. They
+care about the *shape* of the data — did a column appear, did a category
+vocabulary shift — and they deliberately do **not** want to read the bulk
+cell/row churn. (This is the opposite stance from the same-data-with-edits
+reader binoc is primarily tuned for today, who wants every cell.)
+
+## What binoc renders today
+
+See `expected-output/changelog.snap`. Abbreviated:
+
+```
+## Schema & vocabulary changes
+- facilities.csv: Column added: 'region'; 1 cell changed
+  - row 2, column 'status': 'active' -> 'decommissioned'
+  - Set Headers: ...; Add Column: 'region' ...
+## Bulk data updates
+- inspections.csv: 2 rows added; 3 cells changed
+  - row 1, column 'score': '82' -> '85'
+  - ... every changed cell and added row, in full ...
+```
+
+The file-level separation is right. Three things fall short.
+
+## What great looks like
+
+```
+# Changelog: 2021 edition → 2022 edition
+
+## Schema & vocabulary changes
+- facilities.csv
+  - Column added: 'region'  (4 values: north, east, south, west)
+  - Vocabulary 'status' gained a value: 'decommissioned'
+    (now: active, inactive, decommissioned)
+
+## Bulk data updates — summarized, not enumerated
+- facilities.csv:  4 rows, 1 cell changed
+- inspections.csv: 4 → 6 rows (+2), 3 cells changed
+```
+
+## The three gaps between today and the target
+
+1. **Within-node significance / edit-level keep-drop.**
+   `facilities.csv`'s `region` addition and its `status` cell edit are edits on
+   one node, so the renderer cannot put the structural change in the top section
+   and hold the cell back. The vintage reader still sees the cell bullet.
+   *Needs:* a config-driven, edit-level drop/keep on the renderer (the data path
+   already has `EditProjection.visible`, but only writers set it). This is the
+   single smallest unlock and it lives entirely in the renderer — no engine or
+   IR change.
+
+2. **Vocabulary as a first-class change.**
+   `active → decommissioned` is reported as `binoc.cell-change`, not "the
+   `status` vocabulary gained a value." Columns are not first-class nodes and
+   distinct-value-set diffing does not exist.
+   *Needs:* a plugin `EditListWriter` over `tabular_v1` that computes the set of
+   distinct values per categorical column on each side and emits the set-delta
+   as a tagged edit (`binoc.vocabulary-change`). No engine change — a plugin
+   pack, exactly like the standard library is.
+
+3. **Summary statistics instead of enumeration.**
+   The bulk section dumps every changed cell and added row. A vintage reader
+   wants "4 → 6 rows, 3 cells changed."
+   *Needs:* the same plugin writer emitting an aggregate via `Edit::with_summary`
+   (or `GlobalClaim` for a dataset-level roll-up). The seam already carries such
+   facts — binoc-stdlib uses `with_summary` for binary string-diffs today; no
+   rule emits a tabular roll-up yet.
+
+## Why this benchmark exists
+
+It demonstrates that the *engine* does not foreclose the vintage audience: the
+target above is reachable with (1) one renderer-local keep/drop filter and (2)
+one plugin pack that emits vocabulary + statistic facts — no change to the
+type-ignorant controller, the IR, or the correspondence engine. The vintage vs.
+same-data distinction is a renderer-config + plugin-pack concern, which is the
+architecture's whole thesis (AGENTS rules 1 and 3).
+
+It is kept as a passing benchmark so the gap stays visible and measurable. We
+are deliberately **not** building the unlocks yet (we want to nail the
+same-data audience first), but the channel is provably clear.

--- a/test-vectors/csv-vintage-benchmark/expected-output/changelog.snap
+++ b/test-vectors/csv-vintage-benchmark/expected-output/changelog.snap
@@ -1,0 +1,24 @@
+---
+source: binoc-stdlib/src/test_vectors.rs
+expression: "&md"
+---
+# Changelog: snapshot-a → snapshot-b
+
+## Schema & vocabulary changes
+
+- **facilities.csv**: Column added: 'region'; 1 cell changed
+  - Changed cells
+    - row 2, column 'status': 'active' -> 'decommissioned'
+  - Set Headers: from: ["facility_id","name","status"]; to: ["facility_id","name","status","region"]
+  - Add Column: name: 'region'; values: {"total_values":4,"truncated":false,"values":["north","east","west","south"]}
+
+## Bulk data updates
+
+- **inspections.csv**: 2 rows added; 3 cells changed
+  - Changed cells
+    - row 1, column 'score': '82' -> '85'
+    - row 3, column 'score': '90' -> '91'
+    - row 4, column 'score': '68' -> '70'
+  - Rows added
+    - row 5: 'I104', 'F001', '88'
+    - row 6: 'I105', 'F002', '73'

--- a/test-vectors/csv-vintage-benchmark/expected-output/changeset.snap
+++ b/test-vectors/csv-vintage-benchmark/expected-output/changeset.snap
@@ -1,0 +1,163 @@
+---
+source: binoc-stdlib/src/test_vectors.rs
+expression: "&stable_changeset"
+---
+{
+  "from_snapshot": "snapshot-a",
+  "to_snapshot": "snapshot-b",
+  "claims": [],
+  "root": {
+    "action": "modify",
+    "item_type": "directory",
+    "path": "",
+    "children": [
+      {
+        "action": "modify",
+        "item_type": "tabular",
+        "path": "facilities.csv",
+        "sources": [
+          {
+            "path": "facilities.csv",
+            "side": "from",
+            "evidence": "binoc.pair.name",
+            "action": "modify"
+          }
+        ],
+        "summary": [
+          {
+            "text": "Column added: 'region'; 1 cell changed"
+          }
+        ],
+        "tags": [
+          "binoc.cell-change",
+          "binoc.column-addition",
+          "binoc.schema-change"
+        ],
+        "details": {
+          "edits": [
+            {
+              "params": {
+                "from": [
+                  "facility_id",
+                  "name",
+                  "status"
+                ],
+                "to": [
+                  "facility_id",
+                  "name",
+                  "status",
+                  "region"
+                ]
+              },
+              "verb": "tabular.set_headers"
+            },
+            {
+              "params": {
+                "name": "region",
+                "values": {
+                  "total_values": 4,
+                  "truncated": false,
+                  "values": [
+                    "north",
+                    "east",
+                    "west",
+                    "south"
+                  ]
+                }
+              },
+              "verb": "tabular.add_column"
+            },
+            {
+              "params": {
+                "column": "status",
+                "from": "active",
+                "row": 1,
+                "to": "decommissioned"
+              },
+              "verb": "tabular.edit_cell"
+            }
+          ]
+        }
+      },
+      {
+        "action": "modify",
+        "item_type": "tabular",
+        "path": "inspections.csv",
+        "sources": [
+          {
+            "path": "inspections.csv",
+            "side": "from",
+            "evidence": "binoc.pair.name",
+            "action": "modify"
+          }
+        ],
+        "summary": [
+          {
+            "text": "2 rows added; 3 cells changed"
+          }
+        ],
+        "tags": [
+          "binoc.cell-change",
+          "binoc.row-addition"
+        ],
+        "details": {
+          "edits": [
+            {
+              "params": {
+                "column": "score",
+                "from": "82",
+                "row": 0,
+                "to": "85"
+              },
+              "verb": "tabular.edit_cell"
+            },
+            {
+              "params": {
+                "column": "score",
+                "from": "90",
+                "row": 2,
+                "to": "91"
+              },
+              "verb": "tabular.edit_cell"
+            },
+            {
+              "params": {
+                "column": "score",
+                "from": "68",
+                "row": 3,
+                "to": "70"
+              },
+              "verb": "tabular.edit_cell"
+            },
+            {
+              "params": {
+                "rows": [
+                  {
+                    "total_values": 3,
+                    "truncated": false,
+                    "values": [
+                      "I104",
+                      "F001",
+                      "88"
+                    ]
+                  },
+                  {
+                    "total_values": 3,
+                    "truncated": false,
+                    "values": [
+                      "I105",
+                      "F002",
+                      "73"
+                    ]
+                  }
+                ],
+                "start": 4
+              },
+              "verb": "tabular.append_rows"
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/test-vectors/csv-vintage-benchmark/manifest.toml
+++ b/test-vectors/csv-vintage-benchmark/manifest.toml
@@ -1,0 +1,65 @@
+[vector]
+name = "csv-vintage-benchmark"
+description = "Two vintages of a published dataset: a vintage reader cares about schema and vocabulary, not the bulk cell/row churn. Benchmark for how well binoc can serve the vintage (different-edition) audience, distinct from the same-data-with-edits audience."
+tags = ["csv", "vintage", "metadata", "benchmark"]
+
+[docs]
+summary = "A 'vintage' reader compares two editions of the same published dataset and wants the structural story (a column appeared, a category vocabulary shifted) surfaced above the bulk data churn they intend to ignore."
+setup = """
+The dataset is a yearly facilities register published as a small directory of
+CSVs. Between the two editions:
+
+  * `facilities.csv` gains a `region` column (schema change) and one row's
+    `status` moves to a brand-new category value, `decommissioned`
+    (a *vocabulary* shift — the set of distinct values in a categorical column
+    grew).
+  * `inspections.csv` changes only in its data: several scores are edited and
+    two rows are appended. This is exactly the churn a vintage reader does not
+    want to read.
+
+The markdown config models the vintage stance as significance: schema/structural
+tags are the high-priority group, bulk cell/row tags the low-priority group.
+Because `classify_tags` promotes a node to the highest-priority group among its
+tags, `facilities.csv` (which carries both schema and cell tags) floats up to
+"Schema & vocabulary changes" while the pure-data `inspections.csv` sinks to
+"Bulk data updates". That file-granularity separation is the best vintage view
+binoc offers today.
+
+WHAT THIS BENCHMARK IS FOR — the gap between today's output (see
+`expected-output/changelog.snap`) and the target (see `VINTAGE-IDEAL.md`):
+
+  1. Within-node significance. `facilities.csv`'s `region` addition and its
+     `status` cell edit live on one node, so they cannot be separated: the
+     vintage reader still sees the cell bullet. There is no config-driven
+     edit-level drop/keep (only `EditProjection.visible`, set by writers).
+  2. Vocabulary as a first-class change. The `active -> decommissioned` shift is
+     reported as an ordinary `binoc.cell-change`, not as "the `status` vocabulary
+     gained a value". Columns are not first-class nodes and distinct-value-set
+     diffing does not exist.
+  3. Summary statistics. `inspections.csv` is rendered as full cell/row detail,
+     not as a one-line vintage statistic ("142 -> 144 rows, 3 cells changed").
+     The Summary/GlobalClaim seams exist to carry such a fact; no rule emits one.
+
+This vector is a kept benchmark, not a feature. It is expected to PASS against
+current output; as the vintage story improves, update the snapshot and watch it
+converge on VINTAGE-IDEAL.md. See docs/adr for the design rationale.
+"""
+
+# The vintage stance expressed as renderer significance (AGENTS rule 3): schema
+# and vocabulary changes outrank bulk data churn. Config order is priority, so a
+# node touching the schema is promoted above pure-data nodes.
+[config.output.markdown]
+groups = [
+    { heading = "Schema & vocabulary changes", tags = ["binoc.schema-change", "binoc.column-addition", "binoc.column-removal", "binoc.column-rename", "binoc.metadata.value-label-set"] },
+    { heading = "Bulk data updates", tags = ["binoc.cell-change", "binoc.row-addition", "binoc.row-removal"] },
+]
+
+[expected]
+root_action = "modify"
+has_tags = [
+    "binoc.column-addition",
+    "binoc.schema-change",
+    "binoc.cell-change",
+    "binoc.row-addition",
+]
+significance = "Schema & vocabulary changes"

--- a/test-vectors/csv-vintage-benchmark/snapshot-a/facilities.csv
+++ b/test-vectors/csv-vintage-benchmark/snapshot-a/facilities.csv
@@ -1,0 +1,5 @@
+facility_id,name,status
+F001,North Plant,active
+F002,East Depot,active
+F003,West Yard,inactive
+F004,South Hub,active

--- a/test-vectors/csv-vintage-benchmark/snapshot-a/inspections.csv
+++ b/test-vectors/csv-vintage-benchmark/snapshot-a/inspections.csv
@@ -1,0 +1,5 @@
+inspection_id,facility_id,score
+I100,F001,82
+I101,F002,77
+I102,F003,90
+I103,F004,68

--- a/test-vectors/csv-vintage-benchmark/snapshot-b/facilities.csv
+++ b/test-vectors/csv-vintage-benchmark/snapshot-b/facilities.csv
@@ -1,0 +1,5 @@
+facility_id,name,status,region
+F001,North Plant,active,north
+F002,East Depot,decommissioned,east
+F003,West Yard,inactive,west
+F004,South Hub,active,south

--- a/test-vectors/csv-vintage-benchmark/snapshot-b/inspections.csv
+++ b/test-vectors/csv-vintage-benchmark/snapshot-b/inspections.csv
@@ -1,0 +1,7 @@
+inspection_id,facility_id,score
+I100,F001,85
+I101,F002,77
+I102,F003,91
+I103,F004,70
+I104,F001,88
+I105,F002,73


### PR DESCRIPTION
## What

A kept, **passing** benchmark for binoc's latent *vintage* audience — readers comparing two editions of the same published dataset who care about schema and vocabulary changes, not the bulk cell/row churn. This ships no feature; it pins "what great looks like" and proves the engine is ready, while we keep our focus on the same-data audience.

- `test-vectors/csv-vintage-benchmark/` — a two-CSV "published dataset" across two editions. `facilities.csv` gains a `region` column and one row's `status` moves to a new category (`decommissioned`); `inspections.csv` changes only in its data.
- The markdown `groups` config models the vintage stance as significance. Because `classify_tags` promotes a node to its highest-priority group, the schema-touching `facilities.csv` floats up to "Schema & vocabulary changes" and the pure-data `inspections.csv` sinks to "Bulk data updates" — pure config, no controller involvement.
- `expected-output/changelog.snap` is the real, harness-checked engine output. `VINTAGE-IDEAL.md` is the hand-authored target (not harness-checked), so the gap stays visible and the test stays green.
- `docs/adr/2026-06-22-vintage_audience_and_metadata_only_benchmark.md` records the rationale.

## The gap to the ideal (all reachable without engine/IR changes)

1. **Within-node keep/drop** — surface a CSV's column-add while holding its cell edits back. Renderer-local; `EditProjection.visible` already exists but only writers set it. Smallest unlock.
2. **Vocabulary as first-class** — `active → decommissioned` is a plain `binoc.cell-change` today; a plugin `EditListWriter` could diff per-column distinct-value sets and emit `binoc.vocabulary-change`.
3. **Summary statistics** — a one-line "4 → 6 rows, 3 cells changed" via `Edit::with_summary`/`GlobalClaim` instead of enumerating the churn.

## Notes

- Full vector suite passes (`INSTA_UPDATE=no cargo test -p binoc-stdlib --test test_vectors`); no other snapshots touched.
- Deliberately **not** building the unlocks here — nail the same-data experience first. There's adjacent parallel work on branches `auto/md-groups-*` and `auto/stat-binary-metadata-only` worth coordinating with before anyone implements gap #1.

(Auto generated pull request)